### PR TITLE
feat(dependencies): bump ngx-sortablejs to 3.1.4

### DIFF
--- a/demo/src/app/app.module.ts
+++ b/demo/src/app/app.module.ts
@@ -6,7 +6,7 @@ import { OverlayModule } from '@angular/cdk/overlay';
 
 import { NgxTethysModule } from 'ngx-tethys';
 import { RouterModule } from '@angular/router';
-import { SortablejsModule } from 'angular-sortablejs';
+import { SortablejsModule } from 'ngx-sortablejs';
 
 import { AppComponent } from './app.component';
 import { COMPONENTS, ENTRY_COMPONENTS, DEMO_MODULES } from './components';

--- a/demo/src/app/components/+drop-drag/drop-drag.component.ts
+++ b/demo/src/app/components/+drop-drag/drop-drag.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { SortablejsOptions } from 'angular-sortablejs';
+import { SortablejsOptions } from 'ngx-sortablejs';
 
 @Component({
     selector: 'demo-drop-drag',

--- a/package-lock.json
+++ b/package-lock.json
@@ -19988,9 +19988,12 @@
       }
     },
     "ngx-sortablejs": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/ngx-sortablejs/-/ngx-sortablejs-2.5.2.tgz",
-      "integrity": "sha512-VpsnlDL4zl9icMi4gp3ZT+ZfmzO/jlQto7d0gW1UU6kz8ojCQq2Tooub37kV5WNhWkSkN0QwgkKA9FKhG0bUZw=="
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/ngx-sortablejs/-/ngx-sortablejs-3.1.4.tgz",
+      "integrity": "sha512-jrEC4loWf01JxBcPiOHiyHbXwNrs4acIus1c9NVv7hiK574dywoqOnL5/OVQFnluqItWC7llqCUXfDr3Kmyqfg==",
+      "requires": {
+        "tslib": "^1.9.0"
+      }
     },
     "nice-try": {
       "version": "1.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ngx-tethys",
-  "version": "7.6.26",
+  "version": "7.6.27",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -6849,11 +6849,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/amdefine/-/amdefine-1.0.1.tgz",
       "integrity": "sha1-SlKCrBZHKek2Gbz9OtFR+BfOkfU="
-    },
-    "angular-sortablejs": {
-      "version": "2.5.2",
-      "resolved": "https://registry.npmjs.org/angular-sortablejs/-/angular-sortablejs-2.5.2.tgz",
-      "integrity": "sha512-VpsnlDL4zl9icMi4gp3ZT+ZfmzO/jlQto7d0gW1UU6kz8ojCQq2Tooub37kV5WNhWkSkN0QwgkKA9FKhG0bUZw=="
     },
     "ansi-align": {
       "version": "2.0.0",
@@ -19991,6 +19986,11 @@
       "requires": {
         "tslib": "^1.9.0"
       }
+    },
+    "ngx-sortablejs": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/ngx-sortablejs/-/ngx-sortablejs-2.5.2.tgz",
+      "integrity": "sha512-VpsnlDL4zl9icMi4gp3ZT+ZfmzO/jlQto7d0gW1UU6kz8ojCQq2Tooub37kV5WNhWkSkN0QwgkKA9FKhG0bUZw=="
     },
     "nice-try": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@angular/platform-browser-dynamic": "^7.2.6",
     "@angular/router": "^7.2.6",
     "@ngx-translate/core": "^10.0.1",
-    "angular-sortablejs": "^2.5.2",
+    "ngx-sortablejs": "^2.5.2",
     "bootstrap": "^4.3.1",
     "china-division": "^2.1.1",
     "core-js": "^2.5.4",

--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "@angular/platform-browser-dynamic": "^7.2.6",
     "@angular/router": "^7.2.6",
     "@ngx-translate/core": "^10.0.1",
-    "ngx-sortablejs": "^2.5.2",
+    "ngx-sortablejs": "^3.1.4",
     "bootstrap": "^4.3.1",
     "china-division": "^2.1.1",
     "core-js": "^2.5.4",

--- a/src/grid/grid.component.ts
+++ b/src/grid/grid.component.ts
@@ -34,7 +34,7 @@ import {
     IThyGridColumnParentComponent,
     THY_GRID_COLUMN_PARENT_COMPONENT
 } from './grid-column.component';
-import { SortablejsOptions } from 'angular-sortablejs';
+import { SortablejsOptions } from 'ngx-sortablejs';
 import { helpers } from '../util';
 
 export type ThyGridTheme = 'default' | 'bordered';

--- a/src/grid/grid.module.ts
+++ b/src/grid/grid.module.ts
@@ -7,7 +7,7 @@ import { ThyPaginationModule } from '../pagination/pagination.module';
 import { ThySwitchModule } from '../switch/switch.module';
 import { ThyLoadingModule } from '../loading/loading.module';
 import { ThyEmptyModule } from '../empty/empty.module';
-import { SortablejsModule } from 'angular-sortablejs';
+import { SortablejsModule } from 'ngx-sortablejs';
 import { GridIsValidModelValuePipe } from './grid.pipe';
 import { ThyDirectiveModule } from '../directive';
 import { ThyIconModule } from '../icon/icon.module';

--- a/src/package.json
+++ b/src/package.json
@@ -13,7 +13,7 @@
     "@angular/cdk": "*",
     "lodash": "*",
     "sortablejs": "*",
-    "angular-sortablejs": "*",
+    "ngx-sortablejs": "*",
     "rxjs": "*"
   }
 }

--- a/src/transfer/transfer-list.component.ts
+++ b/src/transfer/transfer-list.component.ts
@@ -21,7 +21,7 @@ import {
     InnerTransferDragEvent
 } from './transfer.interface';
 import { ThyTransferComponent } from './transfer.component';
-import { SortablejsOptions } from 'angular-sortablejs';
+import { SortablejsOptions } from 'ngx-sortablejs';
 import { CdkDragDrop, moveItemInArray, transferArrayItem } from '@angular/cdk/drag-drop';
 
 @Component({

--- a/src/tree/tree.module.ts
+++ b/src/tree/tree.module.ts
@@ -6,7 +6,7 @@ import { ThyTreeReplaceRegionComponent } from './tree-replace-region.component';
 import { ThyInputModule } from '../input';
 import { ThyButtonModule } from '../button';
 import { ThyDirectiveModule } from '../directive';
-import { SortablejsModule } from 'angular-sortablejs';
+import { SortablejsModule } from 'ngx-sortablejs';
 import { ThyTreeService } from './tree.service';
 import { ThyListModule } from '../list';
 import { ThyOptionModule } from '../core/option';


### PR DESCRIPTION
angular-sortablejs lib name changed to ngx-sortablejs in 3.0.0

BREAKING CHANGE: rename angular-sortablejs lib to ngx-sortablejs
Closes #INF-336