### PR TITLE
feat(store): merge default options throw error idKey id empty #INFR-450

### DIFF
--- a/src/input/test/input-directive.spec.ts
+++ b/src/input/test/input-directive.spec.ts
@@ -54,7 +54,6 @@ describe('input directive', () => {
     it('thySize xs', () => {
         basicTestComponent.thySize = 'xs';
         fixture.detectChanges();
-        console.log(debugElement.nativeElement.classList.contains('form-control-xs'));
         expect(debugElement.nativeElement.classList.contains('form-control-xs')).toBe(true);
     });
 

--- a/src/store/entity-store.ts
+++ b/src/store/entity-store.ts
@@ -5,7 +5,7 @@ import { mergeReferences, buildReferencesKeyBy, ReferenceArrayExtractAllowKeys }
 import { map } from 'rxjs/operators';
 import { ReferencesIdDictionary, OnCombineRefsFn } from './references';
 
-export interface EntityStoreOptions<TEntity = undefined, TReferences = undefined> {
+export interface EntityStoreOptions<TEntity = unknown, TReferences = unknown> {
     idKey?: string;
     referencesIdKeys?: ReferenceArrayExtractAllowKeys<TReferences>;
 }
@@ -16,7 +16,7 @@ export interface EntityAddOptions {
     autoGotoLastPage?: boolean;
 }
 
-export interface EntityState<TEntity, TReferences = undefined> {
+export interface EntityState<TEntity, TReferences = unknown> {
     pagination?: PaginationInfo;
     entities: TEntity[];
     references?: TReferences;
@@ -25,7 +25,7 @@ export interface EntityState<TEntity, TReferences = undefined> {
 export class EntityStore<
     TState extends EntityState<TEntity, TReferences>,
     TEntity,
-    TReferences = undefined
+    TReferences = unknown
 > extends Store<TState> {
     protected options: EntityStoreOptions<TEntity, TReferences>;
 
@@ -96,7 +96,10 @@ export class EntityStore<
         options: EntityStoreOptions<TEntity, TReferences> = { idKey: '_id' }
     ) {
         super(initialState);
-        this.options = options;
+        this.options = { idKey: '_id', ...options };
+        if (!this.options.idKey) {
+            throw new Error(`idKey is required in EntityStore`);
+        }
         this.buildReferencesIdMap();
     }
 

--- a/src/store/spec/entity-store.spec.ts
+++ b/src/store/spec/entity-store.spec.ts
@@ -30,6 +30,7 @@ describe('Store: EntityStore', () => {
             });
         }
     }
+
     const initialUsers = [{ uid: 'user-1', name: 'user name-1' }, { uid: 'user-2', name: 'user name-2' }];
 
     it('should get store default value', () => {
@@ -353,6 +354,33 @@ describe('Store: EntityStore', () => {
             tasksEntityStore.clearPagination();
             expect(tasksEntityStore.snapshot.entities).toEqual(initialTasks);
             expect(tasksEntityStore.snapshot.pagination).toEqual(null);
+        });
+    });
+
+    describe('constructor', () => {
+        it('should merge default options', () => {
+            const store = new TasksEntityStore(
+                {
+                    entities: initialTasks
+                },
+                {}
+            );
+            expect(store['options']).toEqual({
+                idKey: '_id'
+            });
+        });
+
+        it('should throw error when idKey is undefined', () => {
+            expect(() => {
+                return new TasksEntityStore(
+                    {
+                        entities: initialTasks
+                    },
+                    {
+                        idKey: undefined
+                    }
+                );
+            }).toThrowError('idKey is required in EntityStore');
         });
     });
 });

--- a/src/store/spec/entity-store.spec.ts
+++ b/src/store/spec/entity-store.spec.ts
@@ -370,17 +370,22 @@ describe('Store: EntityStore', () => {
             });
         });
 
-        it('should throw error when idKey is undefined', () => {
-            expect(() => {
-                return new TasksEntityStore(
-                    {
-                        entities: initialTasks
-                    },
-                    {
-                        idKey: undefined
-                    }
-                );
-            }).toThrowError('idKey is required in EntityStore');
+        it('should throw error when idKey is empty', () => {
+            const assertIdKeyError = function(idKeyValue: string) {
+                expect(() => {
+                    return new TasksEntityStore(
+                        {
+                            entities: initialTasks
+                        },
+                        {
+                            idKey: idKeyValue
+                        }
+                    );
+                }).toThrowError('idKey is required in EntityStore');
+            };
+            assertIdKeyError(undefined);
+            assertIdKeyError(null);
+            assertIdKeyError('');
         });
     });
 });

--- a/src/test.ts
+++ b/src/test.ts
@@ -10,7 +10,7 @@ declare const require: any;
 getTestBed().initTestEnvironment(BrowserDynamicTestingModule, platformBrowserDynamicTesting());
 
 // Then we find all the tests.
-const context = require.context('./alert', true, /\.spec\.ts$/);
+const context = require.context('./', true, /\.spec\.ts$/);
 
 // And load the modules.
 context.keys().map(context);


### PR DESCRIPTION
when using EntityStore with references, we need to pass the parameter referencesidkeys, but the idKey value will be undefined, we need to set this idKey to _id all the time, unless it is passed in manually, in addition, we will throw an error when you pass an empty idKey parameter