### PR TITLE
fix(button): change button default border-radius to 4px #INFR-1778

### DIFF
--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -116,10 +116,10 @@ $input-btn-padding-y-lg: 0.656rem !default;
 $input-btn-focus-width: 0.0625rem !default; // 1px
 
 // Buttons
-$btn-border-radius: 1.25rem !default;
-$btn-border-radius-lg: 1.65rem !default;
-$btn-border-radius-sm: 1rem !default;
-$btn-border-radius-xs: 0.75rem !default;
+$btn-border-radius: 4px !default;
+$btn-border-radius-lg: 4px !default;
+$btn-border-radius-sm: 4px !default;
+$btn-border-radius-xs: 4px !default;
 $btn-box-shadow: null !default;
 
 $btn-line-height: $input-btn-line-height;


### PR DESCRIPTION
BREAKING CHANGE
If you want to use the previous button style, please set the following variables
```
$btn-border-radius: 1.25rem !default;
$btn-border-radius-lg: 1.65rem !default;
$btn-border-radius-sm: 1rem !default;
$btn-border-radius-xs: 0.75rem !default;
```