### PR TITLE
fix(dropdown): fix hover icon color to dropdown(#INFR-3657)

### DIFF
--- a/src/dropdown/examples/type/type.component.html
+++ b/src/dropdown/examples/type/type.component.html
@@ -2,11 +2,11 @@
 
 <thy-dropdown-menu #menu>
   <a thyDropdownMenuItem thyType="danger" href="javascript:;">
-    <thy-icon thyIconName="trash" thyDropdownMenuItemIcon></thy-icon>
+    <span thyDropdownMenuItemIcon> <thy-icon thyIconName="trash"></thy-icon></span>
     <span thyDropdownMenuItemName>Delete</span>
   </a>
   <a thyDropdownMenuItem thyType="success" href="javascript:;">
-    <thy-icon thyIconName="plus" thyDropdownMenuItemIcon></thy-icon>
+    <span thyDropdownMenuItemIcon><thy-icon thyIconName="plus"></thy-icon></span>
     <span thyDropdownMenuItemName>New</span>
   </a>
 </thy-dropdown-menu>

--- a/src/dropdown/examples/type/type.component.html
+++ b/src/dropdown/examples/type/type.component.html
@@ -2,11 +2,11 @@
 
 <thy-dropdown-menu #menu>
   <a thyDropdownMenuItem thyType="danger" href="javascript:;">
-    <span thyDropdownMenuItemIcon> <thy-icon thyIconName="trash"></thy-icon></span>
+    <thy-icon thyIconName="trash" thyDropdownMenuItemIcon></thy-icon>
     <span thyDropdownMenuItemName>Delete</span>
   </a>
   <a thyDropdownMenuItem thyType="success" href="javascript:;">
-    <span thyDropdownMenuItemIcon><thy-icon thyIconName="plus"></thy-icon></span>
+    <thy-icon thyIconName="plus" thyDropdownMenuItemIcon></thy-icon>
     <span thyDropdownMenuItemName>New</span>
   </a>
 </thy-dropdown-menu>

--- a/src/dropdown/styles/mixin.scss
+++ b/src/dropdown/styles/mixin.scss
@@ -8,7 +8,9 @@
         &:not(.dropdown-menu-sub-item) {
             color: $color;
         }
-        & > .icon {
+        & > .icon,
+        &,
+        .thy-icon {
             color: $color;
         }
     }


### PR DESCRIPTION
问题原因： 业务组件库或其他使用时会用 span 包裹一层， 这样 .icon 的样式在 span 标签上， 之前只设置了& > .icon 所以图标 hover 时颜色没有更改
