### PR TITLE
fix(dropdown): update icon spacing to child combinator and set icon-text spacing without link for breadcrumb-item

### DIFF
--- a/src/breadcrumb/examples/icon/icon.component.html
+++ b/src/breadcrumb/examples/icon/icon.component.html
@@ -3,6 +3,7 @@
   <thy-breadcrumb-item>
     <a href="javascript:;"><thy-icon thyIconName="version"></thy-icon><span>Applications</span></a>
   </thy-breadcrumb-item>
+  <thy-breadcrumb-item> <thy-icon thyIconName="version"></thy-icon><span>Sub Applications</span> </thy-breadcrumb-item>
   <thy-breadcrumb-item>
     <a href="javascript:;"><span>Application 1</span><thy-icon thyIconName="angle-down"></thy-icon></a>
   </thy-breadcrumb-item>
@@ -15,6 +16,7 @@
   <thy-breadcrumb-item>
     <a href="javascript:;"><thy-icon thyIconName="version"></thy-icon><span>Applications</span></a>
   </thy-breadcrumb-item>
+  <thy-breadcrumb-item> <thy-icon thyIconName="version"></thy-icon><span>Sub Applications</span> </thy-breadcrumb-item>
   <thy-breadcrumb-item>
     <a href="javascript:;" [thyDropdown]="menu" thyActiveClass="active"
       ><span>Application 1</span><thy-icon thyIconName="angle-down"></thy-icon

--- a/src/breadcrumb/styles/breadcrumb.scss
+++ b/src/breadcrumb/styles/breadcrumb.scss
@@ -15,6 +15,7 @@
     .thy-breadcrumb-item {
         margin-right: 8px;
         color: variables.$breadcrumb-text-color;
+        @include icon-text.icon-text-size(8px, 4px);
         a {
             @include link.link-variant(variables.$breadcrumb-text-color, none, variables.$primary, none);
             @include icon-text.icon-text-variant(variables.$breadcrumb-text-color, variables.$primary);

--- a/src/dropdown/examples/icon/icon.component.html
+++ b/src/dropdown/examples/icon/icon.component.html
@@ -2,22 +2,22 @@
 
 <thy-dropdown-menu #menu>
   <a thyDropdownMenuItem href="javascript:;">
-    <thy-icon class="icon" thyIconName="plus"></thy-icon>
+    <thy-icon thyIconName="plus"></thy-icon>
     <span thyDropdownMenuItemName>New</span>
   </a>
   <a thyDropdownMenuItem href="javascript:;">
-    <thy-icon thyDropdownMenuItemIcon thyIconName="edit"></thy-icon>
+    <thy-icon thyIconName="edit"></thy-icon>
     <span thyDropdownMenuItemName>Edit</span>
     <thy-icon thyDropdownMenuItemExtendIcon thyIconName="angle-right"></thy-icon>
   </a>
   <a thyDropdownMenuItem href="javascript:;">
-    <thy-icon thyDropdownMenuItemIcon thyIconName="copy"></thy-icon>
+    <thy-icon thyIconName="copy"></thy-icon>
     <span thyDropdownMenuItemName>Copy</span>
     <thy-icon class="text-primary" thyDropdownMenuItemExtendIcon thyIconName="check"></thy-icon>
   </a>
   <thy-divider></thy-divider>
   <a thyDropdownMenuItem href="javascript:;">
-    <thy-icon thyDropdownMenuItemIcon thyIconName="sort"></thy-icon>
+    <thy-icon thyIconName="sort"></thy-icon>
     <span thyDropdownMenuItemName>Sort</span>
     <span thyDropdownMenuItemMeta>(Default Sort)</span>
     <div thyDropdownMenuItemDesc>
@@ -26,7 +26,7 @@
   </a>
   <thy-divider></thy-divider>
   <a thyDropdownMenuItem href="javascript:;">
-    <thy-icon thyDropdownMenuItemIcon thyIconName="more-vertical"></thy-icon>
+    <thy-icon thyIconName="more-vertical"></thy-icon>
     <span thyDropdownMenuItemName>Lorem ipsum dolor sit amet, consectetur adipiscing elit</span>
   </a>
 </thy-dropdown-menu>

--- a/src/dropdown/styles/dropdown.scss
+++ b/src/dropdown/styles/dropdown.scss
@@ -54,12 +54,10 @@
             }
         }
 
-        i,
-        .thy-icon {
-            &:first-child {
-                margin-right: 8px;
-                color: variables.$dropdown-menu-item-icon-color;
-            }
+        > i:first-child,
+        > .thy-icon:first-child {
+            margin-right: 8px;
+            color: variables.$dropdown-menu-item-icon-color;
         }
         .icon {
             display: flex;

--- a/src/styles/mixins/icon-text.scss
+++ b/src/styles/mixins/icon-text.scss
@@ -17,13 +17,13 @@
 
 @mixin icon-text-size($prefix-space, $suffix-space, $icon-font-size: null) {
     @if $prefix-space {
-        .thy-icon:first-child {
+        > .thy-icon:first-child {
             margin-right: $prefix-space;
         }
     }
 
     @if $suffix-space {
-        .thy-icon:last-child {
+        > .thy-icon:last-child {
             margin-left: $suffix-space;
         }
     }


### PR DESCRIPTION
1. DropdownMenuItem 现在的图标是不用加一个 span 套一个图标了，但是之前如果设置了 span 同时 span 上加了一个 icon class 类名，这样会导致有2个间距，为了兼容之前的样式只在 Item 直接的子中设置 icon 间距，套一个 span 不会设置间距
2. 面包屑 Item 如果是非链接的场景下，图标和文字的间距没有设置，这次补上非链接的场景