### PR TITLE
补充官方文档ICON组件导入

### DIFF
--- a/src/icon/doc/zh-cn.md
+++ b/src/icon/doc/zh-cn.md
@@ -9,48 +9,44 @@ order: 30
 
 `thy-icon`使得在应用程序中更容易使用基于矢量的图标，此组件支持图标字体和SVG图标，但不支持基于位图的格式（png、jpg等）
 
-## 模块导入
-根模块注册：
+## 注册图标库
+ICON 依赖于图标库，tethys原生提供了两个标准图标库，注册方法如下：
+
 ```ts
+import {ThyIconRegistry} from 'ngx-tethys/icon';
+import {DomSanitizer} from '@angular/platform-browser';
+
 export class AppModule {
     constructor(iconRegistry: ThyIconRegistry, sanitizer: DomSanitizer) {
-        const iconSvgUrl = `assets/icons/defs/svg/sprite.defs.svg`;
-        iconRegistry.addSvgIconSet(sanitizer.bypassSecurityTrustResourceUrl(iconSvgUrl));
+        // 注册 defs SVG 雪碧图
+        iconRegistry.addSvgIconSet(sanitizer.bypassSecurityTrustResourceUrl(`assets/icons/defs/svg/sprite.defs.svg`));
+        // 注册 symbol SVG 雪碧图
+        iconRegistry.addSvgIconSet(sanitizer.bypassSecurityTrustResourceUrl(`assets/icons/symbol/svg/sprite.defs.svg`));
     }
 }
 ```
 
-模块导入：
+> 未注册图标为则将出现 `Error retrieving icon: Unable to find icon with the name ":icon-name"` 错误。
+
+## 模块导入
+
 ```ts
 import { ThyIconModule } from "ngx-tethys/icon";
-
-@NgModule({
-    declarations: [
-        ...
-    ],
-    imports: [
-        ...
-        ThyIconModule
-    ],
-    exports: [
-        ...
-    ]
-})
-export class FooModule { }
 ```
 
 ## 图标集合
 <example name="thy-icon-all-example" inline />
 
-## 注册图标
+## 注册第三方图标(库)
 图标组件支持任何第三方的矢量图标库，在使用之前需要注册，支持单个 SVG 图标和图标集合注册。
 `ThyIconRegistry`是一个可注入的服务，它允许你把图标名称和 SVG 的 URL、HTML 字符串关联起来。
+第三方图标库注册可参考标准图标库注册方法：
 
 ```ts
 // 注册一个 defs SVG 雪碧图
-iconRegistry.addSvgIconSet(domSanitizer.bypassSecurityTrustResourceUrl(`assets/icons/defs/svg/sprite.defs.svg`);
+iconRegistry.addSvgIconSet(domSanitizer.bypassSecurityTrustResourceUrl(`assets/icons/defs/svg/sprite.defs.svg`));
 // 注册一个 symbol SVG 雪碧图
-iconRegistry.addSvgIconSet(domSanitizer.bypassSecurityTrustResourceUrl(`assets/icons/symbol/svg/sprite.symbol.svg`);
+iconRegistry.addSvgIconSet(domSanitizer.bypassSecurityTrustResourceUrl(`assets/icons/symbol/svg/sprite.symbol.svg`));
 ```
 
 ## 基本使用

--- a/src/icon/doc/zh-cn.md
+++ b/src/icon/doc/zh-cn.md
@@ -10,8 +10,33 @@ order: 30
 `thy-icon`使得在应用程序中更容易使用基于矢量的图标，此组件支持图标字体和SVG图标，但不支持基于位图的格式（png、jpg等）
 
 ## 模块导入
+根模块注册：
+```ts
+export class AppModule {
+    constructor(iconRegistry: ThyIconRegistry, sanitizer: DomSanitizer) {
+        const iconSvgUrl = `assets/icons/defs/svg/sprite.defs.svg`;
+        iconRegistry.addSvgIconSet(sanitizer.bypassSecurityTrustResourceUrl(iconSvgUrl));
+    }
+}
+```
+
+模块导入：
 ```ts
 import { ThyIconModule } from "ngx-tethys/icon";
+
+@NgModule({
+    declarations: [
+        ...
+    ],
+    imports: [
+        ...
+        ThyIconModule
+    ],
+    exports: [
+        ...
+    ]
+})
+export class FooModule { }
 ```
 
 ## 图标集合

--- a/src/icon/doc/zh-cn.md
+++ b/src/icon/doc/zh-cn.md
@@ -26,7 +26,7 @@ export class AppModule {
 }
 ```
 
-> 未注册图标为则将出现 `Error retrieving icon: Unable to find icon with the name ":icon-name"` 错误。
+> 未注册图标库则将出现 `Error retrieving icon: Unable to find icon with the name ":icon-name"` 错误。
 
 ## 模块导入
 


### PR DESCRIPTION
按当前官方文档给出的icon会出现找不到icon的错误：
![image](https://user-images.githubusercontent.com/12424383/177963859-13046b26-0077-4dd3-bff0-036a2d22d49a.png)
产生该错误的原因是未在整个项目中注册iconResource。

补充在AppModule中注册iconResource后，icon正确显示。