### PR TITLE
fix(time-picker): fix use origin value when input not valid date and improve test #INFR-4316

### DIFF
--- a/src/time-picker/styles/time-picker.scss
+++ b/src/time-picker/styles/time-picker.scss
@@ -5,6 +5,9 @@
     position: relative;
     display: inline-block;
     width: 100%;
+    &-wrapper {
+        position: relative;
+    }
     &-input {
         outline: none;
         padding-right: 38px;

--- a/src/time-picker/test/time-picker-panel.component.spec.ts
+++ b/src/time-picker/test/time-picker-panel.component.spec.ts
@@ -42,6 +42,14 @@ describe('ThyTimePanelComponent', () => {
             expect(columns.find(m => m.classes[hourColumnClass])).toBeTruthy();
             expect(columns.find(m => m.classes[minuteColumnClass])).toBeTruthy();
 
+            fixtureInstance.format = null;
+            fixture.detectChanges();
+            columns = debugElementQueryAll('.thy-time-picker-panel-time-column');
+            expect(columns.length === 3).toBeTruthy();
+            expect(columns.find(m => m.classes[hourColumnClass])).toBeTruthy();
+            expect(columns.find(m => m.classes[minuteColumnClass])).toBeTruthy();
+            expect(columns.find(m => m.classes[secondColumnClass])).toBeTruthy();
+
             flush();
         }));
 
@@ -68,8 +76,11 @@ describe('ThyTimePanelComponent', () => {
             expect(debugElementQuery('.thy-time-picker-panel-time-now')).toBeTruthy();
 
             const valueChange = spyOn(fixtureInstance, 'onPickTime');
+            const closePanel = spyOn(fixtureInstance, 'closePanel');
+
             debugElementQuery('.thy-time-picker-panel-time-now').nativeElement.click();
             expect(valueChange).toHaveBeenCalled();
+            expect(closePanel).toHaveBeenCalled();
         });
 
         it('should support thyShowOperations', () => {
@@ -107,6 +118,16 @@ describe('ThyTimePanelComponent', () => {
             expect(fixtureInstance.timePanelRef.hour === 10).toBeTruthy();
             expect(fixtureInstance.timePanelRef.minute === 20).toBeTruthy();
             expect(fixtureInstance.timePanelRef.second === 3).toBeTruthy();
+
+            const value = new Date().setHours(10, 20, 30);
+            fixtureInstance.value = value;
+            fixture.detectChanges();
+            tick(500);
+
+            expect(fixtureInstance.timePanelRef.value.getTime() === value).toBeTruthy();
+            expect(fixtureInstance.timePanelRef.hour === 10).toBeTruthy();
+            expect(fixtureInstance.timePanelRef.minute === 20).toBeTruthy();
+            expect(fixtureInstance.timePanelRef.second === 30).toBeTruthy();
         }));
 
         it('should support pick hour,minute,second and emit change event', fakeAsync(() => {
@@ -215,13 +236,14 @@ describe('ThyTimePanelComponent', () => {
             [thyShowOperations]="showOperations"
             (thyPickChange)="onPickTime($event)"
             (ngModelChange)="onValueChange($event)"
+            (thyClosePanel)="closePanel()"
         ></thy-time-picker-panel>
     `
 })
 class ThyTestTimePanelComponent {
     @ViewChild('panel') timePanelRef: ThyTimePanelComponent;
 
-    value: Date;
+    value: Date | number;
 
     format: string = 'HH:mm:ss';
 
@@ -238,4 +260,6 @@ class ThyTestTimePanelComponent {
     onPickTime(value: Date) {}
 
     onValueChange(value: Date) {}
+
+    closePanel() {}
 }

--- a/src/time-picker/test/time-picker.component.spec.ts
+++ b/src/time-picker/test/time-picker.component.spec.ts
@@ -60,7 +60,7 @@ describe('ThyTimePickerComponent', () => {
 
             openOverlay();
 
-            dispatchMouseEvent(overlayQuery('.cdk-overlay-transparent-backdrop'), 'click');
+            overlayQuery('.cdk-overlay-backdrop').click();
             fixture.detectChanges();
             expect(getTimePickerPanel()).toBeNull();
 
@@ -106,6 +106,38 @@ describe('ThyTimePickerComponent', () => {
             expect(debugElementQuery(clearBtnSelector)).toBeNull();
         }));
 
+        it('should use origin value when thyAllowClear is false and input not valid value', fakeAsync(() => {
+            const value = new Date();
+            value.setHours(10, 20, 30);
+            fixtureInstance.value = value;
+            fixture.detectChanges();
+
+            fixtureInstance.allowClear = false;
+            fixture.detectChanges();
+
+            openOverlay();
+            getTimePickerInput().value = '12aw42312';
+            dispatchFakeEvent(getTimePickerInput(), 'input');
+            fixture.detectChanges();
+            tick(200);
+            dispatchMouseEvent(document.body, 'click');
+            fixture.detectChanges();
+            tick(200);
+            expect(getTimePickerInput().value === `10:20:30`).toBeTruthy();
+            expect(fixtureInstance.timePickerRef.showText === '10:20:30').toBeTruthy();
+
+            openOverlay();
+            getTimePickerInput().value = '';
+            dispatchFakeEvent(getTimePickerInput(), 'input');
+            fixture.detectChanges();
+            tick(200);
+            dispatchMouseEvent(document.body, 'click');
+            fixture.detectChanges();
+            tick(200);
+            expect(getTimePickerInput().value === `10:20:30`).toBeTruthy();
+            expect(fixtureInstance.timePickerRef.showText === '10:20:30').toBeTruthy();
+        }));
+
         it('should support thyFormat', fakeAsync(() => {
             let date = new Date();
             date.setHours(8, 20, 6);
@@ -136,6 +168,12 @@ describe('ThyTimePickerComponent', () => {
             expect(fixtureInstance.timePickerRef.showText === '8:20').toBeTruthy();
             tick(200);
             expect(getTimePickerInput().value === '8:20').toBeTruthy();
+
+            fixtureInstance.format = null;
+            fixture.detectChanges();
+            expect(fixtureInstance.timePickerRef.showText === '08:20:06').toBeTruthy();
+            tick(200);
+            expect(getTimePickerInput().value === '08:20:06').toBeTruthy();
         }));
 
         it('should support thyDisabled', fakeAsync(() => {
@@ -257,10 +295,18 @@ describe('ThyTimePickerComponent', () => {
             date.setHours(10, 20, 3);
             fixtureInstance.value = date;
             fixture.detectChanges();
-            tick(500);
+            tick(200);
 
             expect(fixtureInstance.timePickerRef.value.getTime() === date.getTime()).toBeTruthy();
             expect(fixtureInstance.timePickerRef.showText === '10:20:03').toBeTruthy();
+
+            const value = new Date().setHours(10, 20, 30);
+            fixtureInstance.value = value;
+            fixture.detectChanges();
+            tick(200);
+
+            expect(fixtureInstance.timePickerRef.value.getTime() === value).toBeTruthy();
+            expect(fixtureInstance.timePickerRef.showText === '10:20:30').toBeTruthy();
         }));
 
         it('should emit change when pick hour,minute,second and click confirm button', fakeAsync(() => {
@@ -395,7 +441,7 @@ describe('ThyTimePickerComponent', () => {
 class ThyTestTimePickerBaseComponent {
     @ViewChild('timePicker', { static: false }) timePickerRef: ThyTimePickerComponent;
 
-    value: Date;
+    value: Date | number;
 
     format: string = 'HH:mm:ss';
 

--- a/src/time-picker/time-picker-panel.component.ts
+++ b/src/time-picker/time-picker-panel.component.ts
@@ -53,7 +53,7 @@ export class ThyTimePanelComponent implements OnInit, OnDestroy, ControlValueAcc
             this.showMinuteColumn = true;
             this.showSecondColumn = true;
         }
-        this.showColumnCount = this.showSecondColumn ? 3 : 2;
+        this.showColumnCount = [this.showHourColumn, this.showMinuteColumn, this.showSecondColumn].filter(m => m).length;
         this.cdr.markForCheck();
     }
 
@@ -68,6 +68,8 @@ export class ThyTimePanelComponent implements OnInit, OnDestroy, ControlValueAcc
     @Input() @InputBoolean() thyShowOperations = true;
 
     @Output() thyPickChange = new EventEmitter<Date>();
+
+    @Output() thyClosePanel = new EventEmitter<void>();
 
     // margin-top + 1px border
     SCROLL_OFFSET_SPACING = 5;
@@ -145,11 +147,12 @@ export class ThyTimePanelComponent implements OnInit, OnDestroy, ControlValueAcc
         this.value = new Date();
         this.setHMSProperty();
         this.thyPickChange.emit(this.value);
-        this.autoScroll();
+        this.thyClosePanel.emit();
     }
 
     confirmPickTime() {
         this.onValueChangeFn(this.value || new Date());
+        this.thyClosePanel.emit();
     }
 
     scrollTo(container: HTMLElement, index: number = 0, duration: number = this.SCROLL_DEFAULT_DURATION) {
@@ -157,7 +160,7 @@ export class ThyTimePanelComponent implements OnInit, OnDestroy, ControlValueAcc
         this.runScrollAnimationFrame(container, offsetTop, duration);
     }
 
-    writeValue(value: Date): void {
+    writeValue(value: Date | number): void {
         if (value && isValid(value)) {
             this.value = new Date(value);
             this.setHMSProperty();

--- a/src/time-picker/time-picker.component.html
+++ b/src/time-picker/time-picker.component.html
@@ -1,16 +1,16 @@
-<span cdkOverlayOrigin #origin="cdkOverlayOrigin" (click)="onInputPickerClick()">
+<span cdkOverlayOrigin #origin="cdkOverlayOrigin" (click)="onInputPickerClick()" class="{{ prefixCls }}-wrapper">
   <ng-container>
     <input
       #pickerInput
       thyInput
       class="form-control {{ prefixCls }}-input"
-      [class.thy-input-disabled]="thyDisabled"
-      [class.thy-input-readonly]="thyReadonly"
+      [class.thy-input-disabled]="disabled"
+      [class.thy-input-readonly]="readonly"
       [class.thy-time-picker-panel-opened]="openState"
       [(ngModel)]="showText"
       [thySize]="thySize"
       [disabled]="disabled"
-      [readonly]="thyReadonly"
+      [readonly]="readonly"
       [placeholder]="thyPlaceholder"
       (blur)="onInputPickerBlur()"
       (keyup.enter)="onKeyupEnter()"
@@ -22,7 +22,7 @@
 </span>
 
 <ng-template #rightIcon>
-  <span class="{{ prefixCls }}-clear" *ngIf="!thyDisabled && thyAllowClear && !thyReadonly && showText">
+  <span class="{{ prefixCls }}-clear" *ngIf="!disabled && thyAllowClear && !thyReadonly && showText">
     <thy-icon thyIconName="close-circle-bold-fill" (click)="onClearTime($event)" ngClass="remove-link remove-link-{{ thySize }}"></thy-icon>
   </span>
   <span class="{{ prefixCls }}-icon">
@@ -49,13 +49,14 @@
     <thy-time-picker-panel
       [ngClass]="thyPopupClass"
       [(ngModel)]="value"
-      [thyFormat]="thyFormat"
+      [thyFormat]="format"
       [thyHourStep]="thyHourStep"
       [thyMinuteStep]="thyMinuteStep"
       [thySecondStep]="thySecondStep"
       [thyShowSelectNow]="thyShowSelectNow"
       (ngModelChange)="onPickTimeConfirm($event)"
       (thyPickChange)="onPickTime($event)"
+      (thyClosePanel)="closeOverlay()"
     ></thy-time-picker-panel>
   </div>
 </ng-template>

--- a/src/time-picker/time-picker.component.ts
+++ b/src/time-picker/time-picker.component.ts
@@ -236,7 +236,7 @@ export class ThyTimePickerComponent implements OnInit, AfterViewInit, ControlVal
     writeValue(value: Date | number): void {
         if (value && isValid(value)) {
             this.originValue = new Date(value);
-            this.setValue(new TinyDate().nativeDate);
+            this.setValue(new TinyDate(value).nativeDate);
         } else {
             this.value = new TinyDate().setHms(0, 0, 0).nativeDate;
         }

--- a/src/time-picker/time-picker.component.ts
+++ b/src/time-picker/time-picker.component.ts
@@ -8,7 +8,6 @@ import {
     EventEmitter,
     forwardRef,
     Input,
-    OnDestroy,
     OnInit,
     Output,
     ViewChild
@@ -17,7 +16,6 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { isValid } from 'date-fns';
 import { getFlexiblePositions, InputBoolean, ThyPlacement } from 'ngx-tethys/core';
 import { TinyDate } from 'ngx-tethys/util';
-import { Subject } from 'rxjs';
 
 export type TimePickerSize = 'xs' | 'sm' | 'md' | 'lg' | 'default';
 
@@ -34,8 +32,8 @@ export type TimePickerSize = 'xs' | 'sm' | 'md' | 'lg' | 'default';
     ],
     host: {
         class: 'thy-time-picker',
-        '[class.thy-time-picker-disabled]': `thyDisabled`,
-        '[class.thy-time-picker-readonly]': `thyReadonly`
+        '[class.thy-time-picker-disabled]': `disabled`,
+        '[class.thy-time-picker-readonly]': `readonly`
     }
 })
 export class ThyTimePickerComponent implements OnInit, AfterViewInit, ControlValueAccessor {
@@ -74,21 +72,15 @@ export class ThyTimePickerComponent implements OnInit, AfterViewInit, ControlVal
         this.disabled = value;
     }
 
-    @Input() @InputBoolean() thyReadonly: boolean;
+    @Input() @InputBoolean() set thyReadonly(value: boolean) {
+        this.readonly = value;
+    }
 
     @Input() @InputBoolean() thyShowSelectNow = true;
 
     @Input() @InputBoolean() thyAllowClear = true;
 
     @Output() thyOpenChange = new EventEmitter<boolean>();
-
-    get thyFormat() {
-        return this.format;
-    }
-
-    get thyDisabled() {
-        return this.disabled;
-    }
 
     prefixCls = 'thy-time-picker';
 
@@ -98,11 +90,15 @@ export class ThyTimePickerComponent implements OnInit, AfterViewInit, ControlVal
 
     disabled: boolean;
 
+    readonly: boolean;
+
     showText: string = '';
 
     openState: boolean;
 
     value: Date = new TinyDate().setHms(0, 0, 0).nativeDate;
+
+    originValue: Date;
 
     keepFocus: boolean;
 
@@ -128,20 +124,27 @@ export class ThyTimePickerComponent implements OnInit, AfterViewInit, ControlVal
     onInputPickerBlur() {
         if (this.keepFocus) {
             this.focus();
+        } else {
+            if (this.openState) {
+                this.closeOverlay();
+            }
         }
     }
 
     onPickTime(value: Date) {
+        this.originValue = new Date(value);
         this.setValue(value);
         this.emitValue();
     }
 
     onPickTimeConfirm(value: Date) {
+        this.originValue = new Date(value);
         this.confirmValue(value);
     }
 
     onClearTime(e: Event) {
         e.stopPropagation();
+        this.originValue = null;
         this.setValue(null);
         this.emitValue();
     }
@@ -199,17 +202,23 @@ export class ThyTimePickerComponent implements OnInit, AfterViewInit, ControlVal
     }
 
     closeOverlay() {
-        this.keepFocus = false;
-        this.openState = false;
-        this.blur();
-        if (this.showText?.length) {
-            if (!this.validateCustomizeInput(this.showText)) {
-                this.setValue(this.value);
+        if (this.openState) {
+            this.keepFocus = false;
+            this.openState = false;
+            this.blur();
+            if (this.showText?.length) {
+                if (!this.validateCustomizeInput(this.showText)) {
+                    this.setValue(this.originValue);
+                } else {
+                    this.showText = new TinyDate(this.value).format(this.format);
+                }
             } else {
-                this.showText = new TinyDate(this.value).format(this.thyFormat);
+                if (!this.thyAllowClear) {
+                    this.setValue(this.originValue);
+                }
             }
+            this.thyOpenChange.emit(this.openState);
         }
-        this.thyOpenChange.emit(this.openState);
     }
 
     focus() {
@@ -224,8 +233,13 @@ export class ThyTimePickerComponent implements OnInit, AfterViewInit, ControlVal
         }
     }
 
-    writeValue(value: Date): void {
-        this.setValue(value);
+    writeValue(value: Date | number): void {
+        if (value && isValid(value)) {
+            this.originValue = new Date(value);
+            this.setValue(new TinyDate().nativeDate);
+        } else {
+            this.value = new TinyDate().setHms(0, 0, 0).nativeDate;
+        }
     }
 
     registerOnChange(fn: any): void {
@@ -244,7 +258,7 @@ export class ThyTimePickerComponent implements OnInit, AfterViewInit, ControlVal
         if (value && isValid(value)) {
             this.value = new Date(value);
             if (formatText) {
-                this.showText = new TinyDate(this.value).format(this.thyFormat);
+                this.showText = new TinyDate(this.value).format(this.format);
             }
         } else {
             this.value = null;
@@ -255,7 +269,6 @@ export class ThyTimePickerComponent implements OnInit, AfterViewInit, ControlVal
 
     private confirmValue(value: Date) {
         this.setValue(value);
-        this.closeOverlay();
         this.emitValue();
         this.cdr.markForCheck();
     }
@@ -273,24 +286,35 @@ export class ThyTimePickerComponent implements OnInit, AfterViewInit, ControlVal
         if (!this.openState) {
             this.openOverlay();
         }
-        if (value?.length > 0) {
+        if (value?.length) {
             if (this.validateCustomizeInput(value)) {
                 const formatter = value.split(':');
                 const hour = formatter[0] || 0;
                 const minute = formatter[1] || 0;
                 const second = formatter[2] || 0;
                 this.setValue(new TinyDate().setHms(+hour, +minute, +second).nativeDate, false);
+                this.originValue = new Date(this.value);
                 this.emitValue();
             }
         } else {
-            this.setValue(null);
-            this.emitValue();
+            if (this.thyAllowClear) {
+                this.originValue = null;
+                this.setValue(null);
+                this.emitValue();
+            } else {
+                this.value = new Date(this.originValue);
+                this.showText = ``;
+                this.cdr.markForCheck();
+            }
         }
     }
 
     private validateCustomizeInput(value: string): boolean {
         let valid: boolean = false;
-        const formatRule = this.thyFormat.split(':');
+        if (value.length > this.format.length) {
+            return valid;
+        }
+        const formatRule = this.format.split(':');
         const formatter = value.split(':');
         valid = !formatRule
             .map((m, i) => {
@@ -301,6 +325,6 @@ export class ThyTimePickerComponent implements OnInit, AfterViewInit, ControlVal
     }
 
     private disabledUserOperation() {
-        return this.thyDisabled || this.thyReadonly;
+        return this.disabled || this.readonly;
     }
 }


### PR DESCRIPTION
1. 输入不合法值后还原为之前的值
2. 在不可清空状态下，手动清空输入框中的值还原为之前的值

**其他**

1. 修复在外部增加 padding 导致后置图标位置不正确
2. ngModel 支持 Date | number 类型
3. 选择此刻后关闭弹窗
5. 修复一些逻辑问题
6. 补充测试