### PR TITLE
fix(property): update padding-right to 16px for thy-properties-item-label

### DIFF
--- a/src/property/styles/properties.scss
+++ b/src/property/styles/properties.scss
@@ -21,7 +21,7 @@
             .thy-properties-item-label {
                 width: variables.$property-item-horizontal-label-width;
                 min-height: variables.$property-item-min-height;
-                padding-right: variables.$property-item-padding-x;
+                padding-right: 2 * variables.$property-item-padding-x;
                 span {
                     line-height: variables.$property-item-min-height;
                 }


### PR DESCRIPTION
label 内容过多的时候和鼠标移动上去显示的边框加一点间距
<img width="557" alt="image" src="https://user-images.githubusercontent.com/3959960/187672035-0cb1182f-c30c-485e-8aac-5e62c2e78d0a.png">

之前的贴一起了
<img width="393" alt="image" src="https://user-images.githubusercontent.com/3959960/187671949-2113e9ac-802f-4318-914f-49d2e9e87c7b.png">
