### PR TITLE
refactor(guider): use {x: number, y: number} instead of [number, number] #INFR-5438

### DIFF
--- a/src/guider/examples/custom-position/custom-position.component.html
+++ b/src/guider/examples/custom-position/custom-position.component.html
@@ -43,5 +43,7 @@
 <p><strong>如果需要设置新手引导的位置是相对于页面</strong>：</p>
 <p>一种方式是配置 <code>defaultPosition</code> 的值:</p>
 <button class="mb-3 custom-guider-position" thyButton="info" (click)="baseOnDefaultPosition()">基于页面位置的配置1</button>
-<p>另一种方式是配置 <code>ThyGuiderStep</code> 的 <code>target</code> 属性为 <code>[number, number]</code> 类型:</p>
+<p>
+  另一种方式是配置 <code>ThyGuiderStep</code> 的 <code>target</code> 属性为 <code>{{ '{' }}x: number, y: number {{ '}' }}</code> 类型:
+</p>
 <button class="custom-guider-position" thyButton="info" (click)="baseOnTargetPosition()">基于页面位置的配置2</button>

--- a/src/guider/examples/custom-position/custom-position.component.ts
+++ b/src/guider/examples/custom-position/custom-position.component.ts
@@ -28,7 +28,7 @@ export class ThyGuiderCustomPositionExampleComponent implements OnInit {
         this.thyGuider.close();
 
         const config = {
-            defaultPosition: [100, 100],
+            defaultPosition: { x: 100, y: 100 },
             steps: [
                 {
                     key: 'custom-guider-position',
@@ -76,7 +76,7 @@ export class ThyGuiderCustomPositionExampleComponent implements OnInit {
         this.thyGuider.close();
 
         const config = {
-            defaultPosition: [100, 100],
+            defaultPosition: { x: 100, y: 100 },
             steps: [
                 {
                     key: 'custom-guider-position',
@@ -103,11 +103,11 @@ export class ThyGuiderCustomPositionExampleComponent implements OnInit {
             steps: [
                 {
                     key: 'custom-guider-position',
-                    target: [500, 520],
+                    target: { x: 500, y: 520 },
                     data: {
                         image: 'assets/images/guider/start.png',
                         title: '基于页面的新手引导位置',
-                        description: `通过设置 target 属性类型为 [number, number] 来变更提示框位置`
+                        description: `通过设置 target 属性类型为 {x: number, y: number} 来变更提示框位置`
                     },
                     hintPlacement: this.hintPlacement
                 }

--- a/src/guider/examples/multi-step-tip/multi-step-tip.component.ts
+++ b/src/guider/examples/multi-step-tip/multi-step-tip.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ThyGuiderConfig, ThyGuiderRef, ThyGuiderStep, ThyGuider } from 'ngx-tethys/guider';
+import { ThyGuider, ThyGuiderConfig, ThyGuiderRef, ThyGuiderStep } from 'ngx-tethys/guider';
 
 @Component({
     selector: 'thy-guider-multi-step-tip-example',
@@ -64,7 +64,7 @@ export class ThyGuiderMultiStepTipExampleComponent implements OnInit {
                     }
                 }
             ] as ThyGuiderStep[],
-            defaultPosition: [100, 100]
+            defaultPosition: { x: 100, y: 100 }
         };
     }
 

--- a/src/guider/guider-step-ref.ts
+++ b/src/guider/guider-step-ref.ts
@@ -152,10 +152,7 @@ export class ThyGuiderStepRef {
         const position = this.getTipPosition(step);
         this.lastPopoverRef = this.popover.open(this.guiderRef.config.hintComponent, {
             origin: null,
-            originPosition: {
-                x: position[0],
-                y: position[1]
-            },
+            originPosition: position,
             originActiveClass: '',
             panelClass: this.guiderRef.config.hintClass || '',
             backdropClosable: false,
@@ -169,7 +166,7 @@ export class ThyGuiderStepRef {
         });
     }
 
-    private getTipPosition(step: ThyGuiderStep): [number, number] {
+    private getTipPosition(step: ThyGuiderStep): { x: number; y: number } {
         if (isPositionDataType(step.target)) {
             return step.target;
         }

--- a/src/guider/guider.class.ts
+++ b/src/guider/guider.class.ts
@@ -3,7 +3,7 @@ import { ThyPlacement } from 'ngx-tethys/core';
 
 export interface ThyGuiderStep<TData = any> {
     key: string;
-    target?: string | string[] | [number, number];
+    target?: string | string[] | { x: number; y: number };
     data: TData;
     route?: string;
     hintPlacement?: ThyPlacement;
@@ -23,7 +23,7 @@ export class ThyGuiderConfig {
     hintPlacement?: ThyPlacement;
 
     /** useful when without target */
-    defaultPosition?: [number, number];
+    defaultPosition?: { x: number; y: number };
 
     /** setting default point offset */
     pointOffset?: [number, number];
@@ -41,7 +41,7 @@ export class ThyGuiderConfig {
 export const defaultGuiderPositionConfig = {
     hintComponent: null as Type<unknown>,
     hintPlacement: 'rightBottom',
-    defaultPosition: [0, 0],
+    defaultPosition: { x: 0, y: 0 },
     pointOffset: [0, 0],
     hintOffset: 4
 };

--- a/src/guider/test/guider.spec.ts
+++ b/src/guider/test/guider.spec.ts
@@ -34,7 +34,7 @@ const guiderSteps: ThyGuiderStep[] = [
     },
     {
         key: 'multi-steps-tip-end',
-        target: [500, 500],
+        target: { x: 500, y: 500 },
         data: {
             image: '',
             title: 'step 3/3',
@@ -107,7 +107,7 @@ class GuiderBasicComponent implements OnInit {
 
     public multiStepsOption: ThyGuiderConfig = {
         steps: guiderSteps,
-        defaultPosition: [100, 50]
+        defaultPosition: { x: 100, y: 50 }
     };
 
     public innerText = templateRefInnerText;

--- a/src/guider/utils.ts
+++ b/src/guider/utils.ts
@@ -1,14 +1,11 @@
-import { isArray, isNumber } from 'ngx-tethys/util';
+import { SafeAny } from 'ngx-tethys/types';
+import { isArray, isNumber, isObject } from 'ngx-tethys/util';
 
-export function isPositionDataType(target: any): target is [number, number] {
-    if (isArray(target)) {
-        if (target.length !== 2) {
-            return false;
-        }
-        if (isNumber(target[0]) && isNumber(target[1])) {
+export function isPositionDataType(target: any): target is { x: number; y: number } {
+    if (isObject(target) && !isArray(target)) {
+        if (isNumber((target as SafeAny).x) && isNumber((target as SafeAny).y)) {
             return true;
         }
-        return false;
     }
     return false;
 }


### PR DESCRIPTION
BREAKING CHANGE:

ThyGuiderConfig.defaultPosition is {x: number, y: number} type from [number, number];
ThyGuiderStep.target now is support {x: number, y: number} and remove [number,  number] type;