### PR TITLE
fix(tree): prevent modification of selected state of disabled nodes #INFR-7372

### DIFF
--- a/src/tree/examples/checkable/checkable.component.html
+++ b/src/tree/examples/checkable/checkable.component.html
@@ -3,4 +3,4 @@
   参数自定义
 </p>
 
-<thy-tree #tree [thyNodes]="treeNodes" [thyCheckable]="true" [thyCheckStateResolve]="checkStateResolve"></thy-tree>
+<thy-tree #tree [thyNodes]="treeNodes" [thyCheckable]="true"></thy-tree>

--- a/src/tree/examples/checkable/checkable.component.html
+++ b/src/tree/examples/checkable/checkable.component.html
@@ -3,4 +3,4 @@
   参数自定义
 </p>
 
-<thy-tree #tree [thyNodes]="treeNodes" [thyCheckable]="true"></thy-tree>
+<thy-tree #tree [thyNodes]="treeNodes" [thyCheckable]="true" [thyCheckStateResolve]="checkStateResolve"></thy-tree>

--- a/src/tree/examples/mocks.ts
+++ b/src/tree/examples/mocks.ts
@@ -72,7 +72,15 @@ export const treeNodes: any[] = [
                                 _id: '0000001',
                                 name: '王五',
                                 type: 'member'
-                            }
+                            },
+                            {
+                                key: '0000004',
+                                title: '赵六',
+                                _id: '0000004',
+                                name: '赵六',
+                                type: 'member',
+                                disabled: true
+                            },
                         ]
                     },
                     {
@@ -85,7 +93,31 @@ export const treeNodes: any[] = [
                         parent_id: '5d4e5b365fadf30311c3d889',
                         position: 1048576,
                         member_count: 0,
-                        children: []
+                        children: [
+                            {
+                                key: '0000001',
+                                title: '张三',
+                                _id: '0000001',
+                                name: '张三',
+                                type: 'member',
+                                disabled: true,
+                                checked: true
+                            },
+                            {
+                                key: '0000002',
+                                title: '李四',
+                                _id: '0000003',
+                                name: '李四',
+                                type: 'member'
+                            },
+                            {
+                                key: '0000003',
+                                title: '王五',
+                                _id: '0000001',
+                                name: '王五',
+                                type: 'member'
+                            }
+                        ]
                     },
                     {
                         key: '5d51537987367c0f92fe6fa8',
@@ -93,6 +125,18 @@ export const treeNodes: any[] = [
                         expanded: false,
                         _id: '5d51537987367c0f92fe6fa8',
                         name: '产品C组',
+                        short_code: null,
+                        parent_id: '5d4e5b365fadf30311c3d889',
+                        position: 1114112,
+                        member_count: 0,
+                        children: []
+                    },
+                    {
+                        key: '5d51537987367c0f92fe6fa8',
+                        title: '产品D组',
+                        expanded: false,
+                        _id: '5d51537987367c0f92fe6fa8',
+                        name: '产品D组',
                         short_code: null,
                         parent_id: '5d4e5b365fadf30311c3d889',
                         position: 1114112,

--- a/src/tree/examples/mocks.ts
+++ b/src/tree/examples/mocks.ts
@@ -55,8 +55,7 @@ export const treeNodes: any[] = [
                                 _id: '0000001',
                                 name: '张三',
                                 type: 'member',
-                                disabled: true,
-                                checked: true
+                                disabled: true
                             },
                             {
                                 key: '0000002',
@@ -72,15 +71,7 @@ export const treeNodes: any[] = [
                                 _id: '0000001',
                                 name: '王五',
                                 type: 'member'
-                            },
-                            {
-                                key: '0000004',
-                                title: '赵六',
-                                _id: '0000004',
-                                name: '赵六',
-                                type: 'member',
-                                disabled: true
-                            },
+                            }
                         ]
                     },
                     {

--- a/src/tree/styles/tree.scss
+++ b/src/tree/styles/tree.scss
@@ -68,6 +68,9 @@
                 .thy-tree-node-check {
                     margin-top: 0;
                     margin-right: 6px;
+                    &:checked.form-check-indeterminate {
+                        background: unset;
+                    }
                 }
 
                 .thy-tree-node-title {

--- a/src/tree/styles/tree.scss
+++ b/src/tree/styles/tree.scss
@@ -68,8 +68,14 @@
                 .thy-tree-node-check {
                     margin-top: 0;
                     margin-right: 6px;
-                    &:checked.form-check-indeterminate {
+                    &:checked.form-check-indeterminate, &:checked.form-unchecked {
                         background: unset;
+                        border-color: variables.$gray-300;
+                    }
+                    &:checked.form-unchecked {
+                        &:after {
+                            opacity: 0;
+                        }
                     }
                 }
 

--- a/src/tree/test/mock.ts
+++ b/src/tree/test/mock.ts
@@ -223,6 +223,88 @@ export const treeNodes = [
                 member_count: 0,
                 children: [],
                 disabled: true
+            },
+            {
+                key: '5d4e5b365fadf30311c3d889',
+                title: '研发一部',
+                expanded: false,
+                _id: '5d4e5b365fadf30311c3d889',
+                name: '研发一部',
+                short_code: '',
+                parent_id: '111111111111111111111111',
+                position: 65536,
+                member_count: 1,
+                children: [
+                    {
+                        key: '5d51536887367c0f92fe6fa6',
+                        title: '产品A组',
+                        expanded: false,
+                        _id: '5d51536887367c0f92fe6fa6',
+                        name: '产品A组',
+                        short_code: '',
+                        parent_id: '5d4e5b365fadf30311c3d889',
+                        position: 983040,
+                        member_count: 0,
+                        children: [
+                            {
+                                key: '0000002',
+                                title: '李四',
+                                _id: '0000003',
+                                name: '李四',
+                                type: 'member',
+                                disabled: true
+                            },
+                            {
+                                key: '0000003',
+                                title: '王五',
+                                _id: '0000001',
+                                name: '王五',
+                                type: 'member'
+                            }
+                        ]
+                    },
+                    {
+                        key: '5d51537187367c0f92fe6fa7',
+                        title: '产品B组',
+                        expanded: false,
+                        _id: '5d51537187367c0f92fe6fa7',
+                        name: '产品B组',
+                        short_code: null,
+                        parent_id: '5d4e5b365fadf30311c3d889',
+                        position: 1048576,
+                        member_count: 0,
+                        children: [
+                            {
+                                key: '0000001',
+                                title: '张三',
+                                _id: '0000001',
+                                name: '张三',
+                                type: 'member',
+                                checked: true,
+                                disabled: true
+                            },
+                            {
+                                key: '0000002',
+                                title: '李四',
+                                _id: '0000002',
+                                name: '李四',
+                                type: 'member'
+                            }
+                        ]
+                    },
+                    {
+                        key: '5d51537987367c0f92fe6fa8',
+                        title: '产品C组',
+                        expanded: false,
+                        _id: '5d51537987367c0f92fe6fa8',
+                        name: '产品C组',
+                        short_code: null,
+                        parent_id: '5d4e5b365fadf30311c3d889',
+                        position: 1114112,
+                        member_count: 0,
+                        children: []
+                    }
+                ]
             }
         ]
     },

--- a/src/tree/test/tree.spec.ts
+++ b/src/tree/test/tree.spec.ts
@@ -154,7 +154,7 @@ describe('ThyTreeComponent', () => {
             checkNodes[4].click();
             checkNodes[5].click();
             fixture.detectChanges();
-            expect(treeComponent.getCheckedNodes().length).toEqual(2);
+            expect(treeComponent.getCheckedNodes().length).toEqual(3);
         });
 
         it(`test public function 'addTreeNode()`, () => {
@@ -193,12 +193,24 @@ describe('ThyTreeComponent', () => {
             const checkNodes = Array.from(treeElement.querySelectorAll('.thy-tree-node-check')) as HTMLElement[];
             checkNodes[1].click();
             fixture.detectChanges();
-            expect(treeComponent.getCheckedNodes().length).toEqual(7);
-            expect(treeElement.querySelectorAll('.form-check-indeterminate').length).toEqual(1);
+            expect(treeComponent.getCheckedNodes().length).toEqual(8);
+            expect(treeElement.querySelectorAll('.form-check-indeterminate').length).toEqual(2);
             treeComponent.treeNodes[0].children[0].children[0].children[0].setChecked(false, true);
             fixture.detectChanges();
+            expect(treeElement.querySelectorAll('.form-check-indeterminate').length).toEqual(3);
+            expect(treeComponent.getCheckedNodes().length).toEqual(5);
+        });
+
+        it(`test tree disabled checked state`, () => {
+            const checkNodes = Array.from(treeElement.querySelectorAll('.thy-tree-node-check')) as HTMLElement[];
+            checkNodes[9].click();
+            fixture.detectChanges();
+            expect(treeComponent.getCheckedNodes().length).toEqual(5);
             expect(treeElement.querySelectorAll('.form-check-indeterminate').length).toEqual(2);
-            expect(treeComponent.getCheckedNodes().length).toEqual(4);
+            checkNodes[9].click();
+            fixture.detectChanges();
+            expect(treeComponent.getCheckedNodes().length).toEqual(1);
+            expect(treeElement.querySelectorAll('.form-check-indeterminate').length).toEqual(2);
         });
 
         it(`test tree check state resolve`, () => {
@@ -210,7 +222,7 @@ describe('ThyTreeComponent', () => {
             const checkNodes = Array.from(treeElement.querySelectorAll('.thy-tree-node-check')) as HTMLInputElement[];
             checkNodes[1].click();
             fixture.detectChanges();
-            expect(treeComponent.getCheckedNodes().length).toEqual(7);
+            expect(treeComponent.getCheckedNodes().length).toEqual(8);
             expect(checkStateResolveSpy).toHaveBeenCalled();
             expect(checkNodes[0].checked).toEqual(false);
         });
@@ -322,7 +334,7 @@ describe('ThyTreeComponent', () => {
 
         it(`test public function onDragDrop not has parent`, () => {
             expect(treeComponent.getTreeNode(treeNodes[0].key).title).toEqual('易成时代（不可拖拽）');
-            const item = treeElement.querySelectorAll(treeNodeSelector)[9];
+            const item = treeElement.querySelectorAll(treeNodeSelector)[10];
 
             const dragstartEvent = createDragEvent('dragstart');
             item.dispatchEvent(dragstartEvent);
@@ -364,7 +376,7 @@ describe('ThyTreeComponent', () => {
             const treeServiceSpy = spyOn(treeComponent.thyTreeService, 'resetSortedTreeNodes');
             // const thyOnDragDropSpy = spyOn(treeComponent, 'thyOnDragDrop');
 
-            const secondItem = treeElement.querySelectorAll(treeNodeSelector)[9];
+            const secondItem = treeElement.querySelectorAll(treeNodeSelector)[10];
             const dataTransfer = new DataTransfer();
             dataTransfer.dropEffect = 'move';
             const dropEvent = createDragEvent('drop', dataTransfer, true, true);
@@ -378,7 +390,7 @@ describe('ThyTreeComponent', () => {
                 afterNode: treeComponent.flattenTreeNodes[0],
                 currentIndex: 1,
                 event: jasmine.any(Object),
-                dragNode: treeComponent.flattenTreeNodes[8],
+                dragNode: treeComponent.flattenTreeNodes[9],
                 targetNode: null
             });
             expect(treeComponent.getRootNodes()[1].title).toEqual('设计部(禁用)');
@@ -386,7 +398,7 @@ describe('ThyTreeComponent', () => {
 
         it(`test public function onDragDrop child item after parent item when item is checked`, fakeAsync(() => {
             expect(treeComponent.getTreeNode(treeNodes[0].key).title).toEqual('易成时代（不可拖拽）');
-            treeComponent.flattenTreeNodes[8].setChecked(true);
+            treeComponent.flattenTreeNodes[7].setChecked(true);
             expect(treeComponent.flattenTreeNodes[0].isChecked).toEqual(2);
 
             const item = treeElement.querySelectorAll(treeNodeSelector)[8];
@@ -403,7 +415,7 @@ describe('ThyTreeComponent', () => {
             const treeServiceSpy = spyOn(treeComponent.thyTreeService, 'resetSortedTreeNodes');
             // const thyOnDragDropSpy = spyOn(treeComponent, 'thyOnDragDrop');
 
-            const secondItem = treeElement.querySelectorAll(treeNodeSelector)[9];
+            const secondItem = treeElement.querySelectorAll(treeNodeSelector)[10];
             const dataTransfer = new DataTransfer();
             dataTransfer.dropEffect = 'move';
             const dropEvent = createDragEvent('drop', dataTransfer, true, true);
@@ -417,12 +429,12 @@ describe('ThyTreeComponent', () => {
                 afterNode: treeComponent.flattenTreeNodes[0],
                 currentIndex: 1,
                 event: jasmine.any(Object),
-                dragNode: treeComponent.flattenTreeNodes[8],
+                dragNode: treeComponent.flattenTreeNodes[9],
                 targetNode: null
             });
             expect(treeComponent.getRootNodes()[1].title).toEqual('设计部(禁用)');
-            expect(treeComponent.flattenTreeNodes[0].isChecked).toEqual(0);
-            expect(treeComponent.flattenTreeNodes[8].isChecked).toEqual(1);
+            expect(treeComponent.flattenTreeNodes[0].isChecked).toEqual(2);
+            expect(treeComponent.flattenTreeNodes[7].isChecked).toEqual(1);
         }));
 
         it(`test public function onDragDrop`, () => {
@@ -497,7 +509,7 @@ describe('ThyTreeComponent', () => {
 
         it('test should successful add tree node ', () => {
             const treeCount = treeElement.querySelectorAll(treeNodeSelector).length;
-            expect(treeCount).toEqual(10);
+            expect(treeCount).toEqual(11);
             const tmpTreeNode = {
                 key: '111000000000000',
                 title: '新增测试',
@@ -509,12 +521,12 @@ describe('ThyTreeComponent', () => {
             treeComponent.addTreeNode(tmpTreeNode);
             fixture.detectChanges();
             const updateTreeNodesCount = treeElement.querySelectorAll(treeNodeSelector).length;
-            expect(updateTreeNodesCount).toEqual(11);
+            expect(updateTreeNodesCount).toEqual(12);
         });
 
         it('test should successful delete tree node ', () => {
             const treeCount = treeElement.querySelectorAll(treeNodeSelector).length;
-            expect(treeCount).toEqual(10);
+            expect(treeCount).toEqual(11);
             const node = treeComponent.treeNodes[0];
             treeComponent.deleteTreeNode(node);
             fixture.detectChanges();
@@ -578,7 +590,7 @@ describe('ThyTreeComponent', () => {
             tick(100);
             fixture.detectChanges();
             expect(nodeElement.querySelector(loadingSelector)).toBeNull();
-            expect(treeElement.querySelectorAll(treeNodeSelector).length).toEqual(10);
+            expect(treeElement.querySelectorAll(treeNodeSelector).length).toEqual(11);
         }));
     });
 

--- a/src/tree/tree-node.component.html
+++ b/src/tree/tree-node.component.html
@@ -32,6 +32,7 @@
       type="checkbox"
       class="thy-tree-node-check"
       [class.form-check-indeterminate]="node.isChecked === checkState.indeterminate"
+      [class.form-unchecked]="node.isChecked === checkState.unchecked"
       [checked]="node.isChecked === checkState.checked"
       [disabled]="node.isDisabled"
       (click)="clickNodeCheck($event)"

--- a/src/tree/tree-node.component.ts
+++ b/src/tree/tree-node.component.ts
@@ -176,10 +176,18 @@ export class ThyTreeNodeComponent implements OnDestroy, OnInit, OnChanges {
 
     public clickNodeCheck(event: Event) {
         event.stopPropagation();
-        if (this.node.isChecked === ThyTreeNodeCheckState.unchecked || this.node.isChecked === ThyTreeNodeCheckState.indeterminate) {
+        if (this.node.isChecked === ThyTreeNodeCheckState.unchecked) {
             this.node.setChecked(true);
-        } else {
+        } else if (this.node.isChecked === ThyTreeNodeCheckState.checked) {
             this.node.setChecked(false);
+        } else if (this.node.isChecked === ThyTreeNodeCheckState.indeterminate) {
+            if (this.node.children?.length) {
+                const activeChildren = this.node.children.filter(item => !item.isDisabled);
+                const isAllActiveChildrenChecked = activeChildren.every(item => item.isChecked);
+                this.node.setChecked(!isAllActiveChildrenChecked);
+            } else {
+                this.node.setChecked(true);
+            }
         }
         this.thyOnCheckboxChange.emit({
             eventName: 'checkboxChange',

--- a/src/tree/tree.service.ts
+++ b/src/tree/tree.service.ts
@@ -136,12 +136,26 @@ export class ThyTreeService implements OnDestroy {
     }
 
     private _setNodeChecked(node: ThyTreeNode, checked: boolean, propagateUp = true, propagateDown = true) {
-        node.isChecked = checked ? ThyTreeNodeCheckState.checked : ThyTreeNodeCheckState.unchecked;
-        node.origin.checked = checked;
         if (propagateDown && node.children) {
             node.children.forEach(subNode => {
                 this._setNodeChecked(subNode, checked, false, true);
             });
+        }
+        if (!node.isDisabled) {
+            if (node.children.length) {
+                if (checked) {
+                    const isAllChildrenChecked = node.children.every(item => item.isChecked === ThyTreeNodeCheckState.checked);
+                    node.isChecked = isAllChildrenChecked ? ThyTreeNodeCheckState.checked : ThyTreeNodeCheckState.indeterminate;
+                    node.origin.checked = isAllChildrenChecked && checked;
+                } else {
+                    const isAllChildrenUnChecked = node.children.every(item => item.isChecked === ThyTreeNodeCheckState.unchecked);
+                    node.isChecked = isAllChildrenUnChecked ? ThyTreeNodeCheckState.unchecked : ThyTreeNodeCheckState.indeterminate;
+                    node.origin.checked = isAllChildrenUnChecked && checked;
+                }
+            } else {
+                node.isChecked = checked ? ThyTreeNodeCheckState.checked : ThyTreeNodeCheckState.unchecked;
+                node.origin.checked = checked;
+            }
         }
         if (propagateUp) {
             this._syncNodeCheckState(node.parentNode);


### PR DESCRIPTION
BREAKING CHANGES
1. cannot modify selected state if node is disabled
2. If there is an unselected disabled node in the child node,  when the parent is selected, the selected state of the parent is **indeterminate**
3. If there is a selected disabled node in the child node, when the parent node is unchecked, the state of the parent node is **indeterminate**