### PR TITLE
fix(table): thyTheme值为bordered且可拖拽时，拖拽图标和文字之间的间距过大 #INFR-8217

### DIFF
--- a/src/styles/modules/tables.scss
+++ b/src/styles/modules/tables.scss
@@ -1,9 +1,9 @@
-@use "sass:map";
-@use "../bootstrap/mixins/breakpoints.scss";
-@use "../mixins/hover.scss";
-@use "../bootstrap/variables.scss" as bootstrap-variables;
-@use "../mixins/tables.scss";
-@use "../variables.scss";
+@use 'sass:map';
+@use '../bootstrap/mixins/breakpoints.scss';
+@use '../mixins/hover.scss';
+@use '../bootstrap/variables.scss' as bootstrap-variables;
+@use '../mixins/tables.scss';
+@use '../variables.scss';
 
 .table {
     width: 100%;
@@ -155,7 +155,6 @@
 }
 
 .table-hover {
-
     tbody tr {
         @include hover.hover {
             cursor: pointer;
@@ -210,14 +209,6 @@
                         display: none;
                     }
                 }
-            }
-        }
-    }
-
-    &.table-bordered {
-        tbody tr td {
-            &:first-child {
-                padding-left: variables.$table-draggable-bordered-icon-padding-left;
             }
         }
     }

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -362,7 +362,6 @@ $table-draggable-first-th-padding-left: 16px !default;
 $table-draggable-first-td-padding-left: 16px !default;
 $table-draggable-icon-color: $gray-600 !default;
 $table-draggable-icon-left: 0px !default;
-$table-draggable-bordered-icon-padding-left: 30px !default;
 $table-default-header-cell-padding: 0 16px !default;
 $table-default-header-padding: 12px 16px !default;
 $table-default-sm-header-padding: 8px 16px !default;


### PR DESCRIPTION
![image](https://github.com/atinc/ngx-tethys/assets/13193164/0e586dd0-5acc-4afb-8780-77015e37e137)
