### PR TITLE
feat(table): replace loading with skeleton and make skeleton stronger #INFR-9201

### DIFF
--- a/src/table/enums/column-skeleton-type.ts
+++ b/src/table/enums/column-skeleton-type.ts
@@ -1,0 +1,5 @@
+export enum ThyTableColumnSkeletonType {
+    title = 'title',
+    member = 'member',
+    default = 'default'
+}

--- a/src/table/enums/index.ts
+++ b/src/table/enums/index.ts
@@ -1,0 +1,1 @@
+export * from './column-skeleton-type';

--- a/src/table/examples/pagination/pagination.component.html
+++ b/src/table/examples/pagination/pagination.component.html
@@ -9,16 +9,16 @@
   [thyShowTotal]="true"
   [thyShowSizeChanger]="true"
   [thyLoadingDone]="loadingDone"
+  [thyColumnSkeletonTypes]="skeletonTypes"
   (thyOnPageChange)="onPageChange($event)"
-  (thyOnPageSizeChange)="onPageSizeChange($event)"
->
-  <thy-table-column thyTitle="#" thyType="index"> </thy-table-column>
-  <thy-table-column thyTitle="Id" thyModelKey="id"></thy-table-column>
-  <thy-table-column thyTitle="Name" thyModelKey="name"></thy-table-column>
-  <thy-table-column thyTitle="Age" thyModelKey="age"></thy-table-column>
-  <thy-table-column thyTitle="Job" thyModelKey="job"> </thy-table-column>
-  <thy-table-column thyTitle="Address" thyModelKey="address"></thy-table-column>
-  <thy-table-column thyTitle="" thyClassName="thy-operation-links">
+  (thyOnPageSizeChange)="onPageSizeChange($event)">
+  <thy-table-column thyTitle="#" thyType="index" thyWidth="80"> </thy-table-column>
+  <thy-table-column thyTitle="Id" thyModelKey="id" thyWidth="80"></thy-table-column>
+  <thy-table-column thyTitle="Name" thyModelKey="name" thyWidth="150"></thy-table-column>
+  <thy-table-column thyTitle="Age" thyModelKey="age" thyWidth="100"></thy-table-column>
+  <thy-table-column thyTitle="Job" thyModelKey="job" thyWidth="150"> </thy-table-column>
+  <thy-table-column thyTitle="Address" thyModelKey="address" thyWidth="auto"></thy-table-column>
+  <thy-table-column thyTitle="" thyClassName="thy-operation-links" thyWidth="150">
     <ng-template #cell let-row>
       <a class="link-secondary" href="javascript:;">
         <thy-icon thyIconName="user-add"></thy-icon>

--- a/src/table/examples/pagination/pagination.component.ts
+++ b/src/table/examples/pagination/pagination.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { ThyMultiSelectEvent, ThyTableRowEvent, ThyTableSize, ThyPageChangedEvent } from 'ngx-tethys/table';
+import { ThyTableRowEvent, ThyPageChangedEvent, ThyTableColumnSkeletonType } from 'ngx-tethys/table';
 import { of } from 'rxjs';
 import { delay, finalize } from 'rxjs/operators';
 
@@ -19,6 +19,12 @@ export class ThyTablePaginationExampleComponent implements OnInit {
 
     loadingDone = false;
 
+    skeletonTypes: ThyTableColumnSkeletonType[] = [
+        ThyTableColumnSkeletonType.default,
+        ThyTableColumnSkeletonType.default,
+        ThyTableColumnSkeletonType.member
+    ];
+
     private getRandomIndex(max: number) {
         return Math.floor(Math.random() * max);
     }
@@ -37,7 +43,7 @@ export class ThyTablePaginationExampleComponent implements OnInit {
                     const originalData = [
                         { id: 1, name: 'Peter', age: 25, job: 'Engineer', address: 'Beijing Dong Sheng Technology' },
                         { id: 2, name: 'James', age: 26, job: 'Designer', address: 'Xian Economic Development Zone' },
-                        { id: 3, name: 'Tom', age: 30, job: 'Engineer', address: 'New Industrial Park, Shushan, Hefei, Anhui' },
+                        { id: 3, name: 'Tom', age: 30, job: 'Engineer', address: 'New Industrial Park' },
                         { id: 4, name: 'Elyse', age: 31, job: 'Engineer', address: 'Yichuan Ningxia' },
                         { id: 5, name: 'Jill', age: 22, job: 'DevOps', address: 'Hangzhou' }
                     ];

--- a/src/table/examples/skeleton/skeleton.component.html
+++ b/src/table/examples/skeleton/skeleton.component.html
@@ -1,1 +1,17 @@
-<thy-table-skeleton [thyRowCount]="5"> </thy-table-skeleton>
+<span>默认：</span>
+<div class="mt-2">
+  <thy-radio-group [(ngModel)]="theme">
+    <label thyRadio thyLabelText="Default" thyInline thyValue="default"></label>
+    <label thyRadio thyLabelText="Bordered" thyInline thyValue="bordered"></label>
+    <label thyRadio thyLabelText="Boxed" thyInline thyValue="boxed"></label>
+  </thy-radio-group>
+</div>
+<thy-button-group thySize="sm" thyType="outline-default" class="mb-2">
+  <button thyButton *ngFor="let item of sizes" (click)="size = item.value" [ngClass]="{ active: item.value === size }">
+    {{ item.value }}({{ item.height }})
+  </button>
+</thy-button-group>
+<thy-table-skeleton [thyRowCount]="5" [thyTheme]="theme" [thySize]="size"> </thy-table-skeleton>
+
+<span class="d-inline-block mt-8">支持配置骨架列的宽度和类型：</span>
+<thy-table-skeleton [thyRowCount]="5" [thyColumns]="columns"> </thy-table-skeleton>

--- a/src/table/examples/skeleton/skeleton.component.ts
+++ b/src/table/examples/skeleton/skeleton.component.ts
@@ -1,5 +1,5 @@
 import { Component } from '@angular/core';
-import { ThyTableColumnSkeletonType, ThyTableSize, ThyTableTheme } from 'ngx-tethys/table';
+import { ThyTableColumnSkeletonType, ThyTableSize, ThyTableSkeletonColumn, ThyTableTheme } from 'ngx-tethys/table';
 
 @Component({
     selector: 'thy-table-skeleton-example',
@@ -14,7 +14,7 @@ export class ThyTableSkeletonExampleComponent {
 
     theme: ThyTableTheme = 'default';
 
-    sizes = [
+    sizes: { value: ThyTableSize; height: number }[] = [
         {
             value: 'xs',
             height: 44
@@ -39,7 +39,7 @@ export class ThyTableSkeletonExampleComponent {
 
     size: ThyTableSize = 'md';
 
-    columns = [
+    columns: ThyTableSkeletonColumn[] = [
         { width: '40%', type: ThyTableColumnSkeletonType.title },
         { width: 'auto', type: ThyTableColumnSkeletonType.default },
         { width: 'auto', type: ThyTableColumnSkeletonType.default },

--- a/src/table/examples/skeleton/skeleton.component.ts
+++ b/src/table/examples/skeleton/skeleton.component.ts
@@ -1,16 +1,49 @@
-import { Component, OnInit } from '@angular/core';
+import { Component } from '@angular/core';
+import { ThyTableColumnSkeletonType, ThyTableSize, ThyTableTheme } from 'ngx-tethys/table';
 
 @Component({
     selector: 'thy-table-skeleton-example',
     templateUrl: './skeleton.component.html'
 })
-export class ThyTableSkeletonExampleComponent implements OnInit {
+export class ThyTableSkeletonExampleComponent {
     data = [
         { id: 1, name: 'Peter', age: 25, job: 'Engineer', address: 'Beijing Dong Sheng Technology' },
         { id: 2, name: 'James', age: 26, job: 'Designer', address: 'Xian Economic Development Zone' },
         { id: 3, name: 'Tom', age: 30, job: 'Engineer', address: 'New Industrial Park, Shushan, Hefei, Anhui' }
     ];
-    constructor() {}
 
-    ngOnInit() {}
+    theme: ThyTableTheme = 'default';
+
+    sizes = [
+        {
+            value: 'xs',
+            height: 44
+        },
+        {
+            value: 'sm',
+            height: 48
+        },
+        {
+            value: 'md',
+            height: 52
+        },
+        {
+            value: 'lg',
+            height: 56
+        },
+        {
+            value: 'xlg',
+            height: 60
+        }
+    ];
+
+    size: ThyTableSize = 'md';
+
+    columns = [
+        { width: '40%', type: ThyTableColumnSkeletonType.title },
+        { width: 'auto', type: ThyTableColumnSkeletonType.default },
+        { width: 'auto', type: ThyTableColumnSkeletonType.default },
+        { width: 'auto', type: ThyTableColumnSkeletonType.default },
+        { width: '17%', type: ThyTableColumnSkeletonType.member }
+    ];
 }

--- a/src/table/index.ts
+++ b/src/table/index.ts
@@ -5,3 +5,4 @@ export * from './pipes/drag.pipe';
 export * from './table.module';
 export * from './table-column.component';
 export * from './table-skeleton.component';
+export * from './enums';

--- a/src/table/styles/skeleton.scss
+++ b/src/table/styles/skeleton.scss
@@ -1,4 +1,4 @@
-@use "../../styles/variables";
+@use '../../styles/variables';
 
 .thy-table-skeleton {
     table {
@@ -8,11 +8,7 @@
 
         td,
         th {
-            border-bottom: variables.$table-border-width solid variables.$gray-200;
             text-align: left;
-            padding: 8px 28px;
-            height: 52px;
         }
     }
-
 }

--- a/src/table/table-skeleton.component.html
+++ b/src/table/table-skeleton.component.html
@@ -1,79 +1,87 @@
-<table>
-  <thead>
-    <tr>
-      <th [width]="i === 0 ? '40%' : i === 1 ? '20%' : 'auto'" *ngFor="let key of columnCount; index as i">
-        <thy-skeleton-rectangle
-          [thyRowWidth]="titleWidth"
-          [thyRowHeight]="titleHeight"
-          [thyBorderRadius]="thyBorderRadius"
-          [thyAnimated]="thyAnimated"
-          [thyAnimatedInterval]="thyAnimatedInterval"
-          [thyPrimaryColor]="thyPrimaryColor"
-          [thySecondaryColor]="thySecondaryColor"
-        ></thy-skeleton-rectangle>
-      </th>
-    </tr>
-  </thead>
-  <tbody>
-    <ng-template ngFor let-item [ngForOf]="rowCount" let-i="index + 1">
+<table [ngClass]="tableClassMap" [style.min-width]="thyMinWidth">
+  <colgroup>
+    <col *ngFor="let column of columns; trackBy: trackByFn" [width]="column.width" />
+  </colgroup>
+  <ng-container *ngIf="!thyHeadless">
+    <thead>
       <tr>
-        <td>
-          <div class="d-flex" style="align-items:center">
-            <thy-skeleton-rectangle
-              class="mr-2"
-              [thyRowWidth]="checkBoxWidth"
-              [thyRowHeight]="thyRowHeight"
-              [thyBorderRadius]="thyBorderRadius"
-              [thyAnimated]="thyAnimated"
-              [thyAnimatedInterval]="thyAnimatedInterval"
-              [thyPrimaryColor]="thyPrimaryColor"
-              [thySecondaryColor]="thySecondaryColor"
-            ></thy-skeleton-rectangle>
-            <thy-skeleton-rectangle
-              [thyRowWidth]="i % 3 === 1 ? '70%' : i % 3 === 2 ? '85%' : '60%'"
-              [thyRowHeight]="thyRowHeight"
-              [thyBorderRadius]="thyBorderRadius"
-              [thyAnimated]="thyAnimated"
-              [thyAnimatedInterval]="thyAnimatedInterval"
-              [thyPrimaryColor]="thyPrimaryColor"
-              [thySecondaryColor]="thySecondaryColor"
-            ></thy-skeleton-rectangle>
-          </div>
-        </td>
-        <td>
-          <div class="d-flex" style="align-items:center">
-            <thy-skeleton-circle
-              class="mr-2"
-              [thySize]="avatarSize"
-              [thyAnimated]="thyAnimated"
-              [thyAnimatedInterval]="thyAnimatedInterval"
-              [thyPrimaryColor]="thyPrimaryColor"
-              [thySecondaryColor]="thySecondaryColor"
-            ></thy-skeleton-circle>
-
-            <thy-skeleton-rectangle
-              [thyRowWidth]="i % 3 === 1 ? '50%' : i % 3 === 2 ? '60%' : '40%'"
-              [thyRowHeight]="thyRowHeight"
-              [thyBorderRadius]="thyBorderRadius"
-              [thyAnimated]="thyAnimated"
-              [thyAnimatedInterval]="thyAnimatedInterval"
-              [thyPrimaryColor]="thyPrimaryColor"
-              [thySecondaryColor]="thySecondaryColor"
-            ></thy-skeleton-rectangle>
-          </div>
-        </td>
-        <td *ngFor="let item of columnCount.slice(2)">
+        <th *ngFor="let column of columns; trackBy: trackByFn">
           <thy-skeleton-rectangle
-            [thyRowWidth]="'70%'"
-            [thyRowHeight]="thyRowHeight"
+            [thyRowWidth]="titleWidth"
+            [thyRowHeight]="titleHeight"
             [thyBorderRadius]="thyBorderRadius"
             [thyAnimated]="thyAnimated"
             [thyAnimatedInterval]="thyAnimatedInterval"
-            [thyPrimaryColor]="thyPrimaryColor"
-            [thySecondaryColor]="thySecondaryColor"
-          ></thy-skeleton-rectangle>
-        </td>
+            [thyPrimaryColor]="thyTheme === 'bordered' || thyTheme === 'boxed' ? '#eee' : thyPrimaryColor"
+            [thySecondaryColor]="thySecondaryColor"></thy-skeleton-rectangle>
+        </th>
       </tr>
-    </ng-template>
+    </thead>
+  </ng-container>
+  <tbody>
+    <ng-container *ngFor="let item of rowCount; let i = index">
+      <tr>
+        <ng-container *ngFor="let column of columns; trackBy: trackByFn">
+          <td>
+            <ng-container
+              *thyViewOutlet="
+                column.type === columnType.title
+                  ? titleTemplate
+                  : column.type === columnType.member
+                  ? memberTemplate
+                  : defaultTemplate;
+                  context:{
+                    trIndex: i,
+                  }
+              "></ng-container>
+          </td>
+        </ng-container>
+      </tr>
+    </ng-container>
   </tbody>
 </table>
+
+<ng-template #titleTemplate let-trIndex="trIndex">
+  <div class="d-flex align-items-center">
+    <thy-skeleton-rectangle
+      class="mr-2 flex-shrink-0"
+      [thyRowWidth]="checkBoxWidth"
+      [thyRowHeight]="thyRowHeight"
+      [thyBorderRadius]="thyBorderRadius"
+      [thyAnimated]="thyAnimated"
+      [thyAnimatedInterval]="thyAnimatedInterval"
+      [thyPrimaryColor]="thyPrimaryColor"
+      [thySecondaryColor]="thySecondaryColor"></thy-skeleton-rectangle>
+
+    <ng-container
+      *thyViewOutlet="defaultTemplate;
+      context:{
+        rowWidth: trIndex % 3 === 0 ? '75%' : trIndex % 3 === 1 ? '100%' : trIndex % 3 === 2 ? '65%' : '',
+      }"></ng-container>
+  </div>
+</ng-template>
+
+<ng-template #memberTemplate>
+  <div class="d-flex align-items-center">
+    <thy-skeleton-circle
+      class="mr-2 flex-shrink-0"
+      [thySize]="avatarSize"
+      [thyAnimated]="thyAnimated"
+      [thyAnimatedInterval]="thyAnimatedInterval"
+      [thyPrimaryColor]="thyPrimaryColor"
+      [thySecondaryColor]="thySecondaryColor"></thy-skeleton-circle>
+
+    <ng-container *thyViewOutlet="defaultTemplate"></ng-container>
+  </div>
+</ng-template>
+
+<ng-template #defaultTemplate let-rowWidth="rowWidth">
+  <thy-skeleton-rectangle
+    [thyRowWidth]="rowWidth"
+    [thyRowHeight]="thyRowHeight"
+    [thyBorderRadius]="thyBorderRadius"
+    [thyAnimated]="thyAnimated"
+    [thyAnimatedInterval]="thyAnimatedInterval"
+    [thyPrimaryColor]="thyPrimaryColor"
+    [thySecondaryColor]="thySecondaryColor"></thy-skeleton-rectangle>
+</ng-template>

--- a/src/table/table-skeleton.component.ts
+++ b/src/table/table-skeleton.component.ts
@@ -1,7 +1,11 @@
-import { NgFor } from '@angular/common';
+import { NgClass, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { InputBoolean, InputCssPixel } from 'ngx-tethys/core';
 import { ThySkeletonCircleComponent, ThySkeletonRectangleComponent } from 'ngx-tethys/skeleton';
+import { ThyTableSkeletonColumn } from './table.interface';
+import { ThyViewOutletDirective } from 'ngx-tethys/shared';
+import { ThyTableColumnSkeletonType } from './enums';
+import { ThyTableSize, ThyTableTheme } from './table.component';
 
 const COLUMN_COUNT = 5;
 
@@ -18,7 +22,7 @@ const COLUMN_COUNT = 5;
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     standalone: true,
-    imports: [NgFor, ThySkeletonRectangleComponent, ThySkeletonCircleComponent]
+    imports: [NgFor, NgClass, NgIf, NgTemplateOutlet, ThyViewOutletDirective, ThySkeletonRectangleComponent, ThySkeletonCircleComponent]
 })
 export class ThyTableSkeletonComponent {
     /**
@@ -33,15 +37,15 @@ export class ThyTableSkeletonComponent {
      */
     @Input()
     @InputCssPixel()
-    thyRowHeight: string | number = '18px';
+    thyRowHeight: string | number = '20px';
 
     /**
      * 是否开启动画
-     * @default false
+     * @default true
      */
     @Input()
     @InputBoolean()
-    thyAnimated: boolean;
+    thyAnimated: boolean = true;
 
     /**
      * 动画速度
@@ -68,13 +72,85 @@ export class ThyTableSkeletonComponent {
         this.rowCount = Array.from({ length: +value });
     }
 
-    public titleHeight = '12px';
+    /**
+     * 是否展示骨架头
+     * @default false
+     */
+    @Input() @InputBoolean() thyHeadless = false;
+
+    /**
+     * 骨架屏的风格
+     * @type default | bordered | boxed
+     */
+    @Input() thyTheme: ThyTableTheme = 'default';
+
+    /**
+     * 骨架屏的大小
+     * @type xs | sm | md | lg | xlg | default
+     * @default md
+     */
+    @Input() thySize: ThyTableSize = 'md';
+
+    /**
+     * 设置表格最小宽度
+     */
+    @Input()
+    @InputCssPixel()
+    thyMinWidth: string | number;
+
+    /**
+     * 表格列骨架的配置项，支持配置列宽、骨架类型
+     * @type ThyTableSkeletonColumn[]
+     */
+    @Input() set thyColumns(columns: ThyTableSkeletonColumn[]) {
+        if (columns && columns.length) {
+            this.columns = columns;
+        } else {
+            this.columns = [...this.defaultColumns];
+        }
+    }
+
+    public titleHeight = '16px';
 
     public titleWidth = '50px';
 
-    public checkBoxWidth = '18px';
+    public checkBoxWidth = '20px';
 
-    public avatarSize = '28px';
+    public avatarSize = '24px';
 
-    columnCount = Array.from({ length: COLUMN_COUNT });
+    public columnType = ThyTableColumnSkeletonType;
+
+    get tableClassMap() {
+        return {
+            table: true,
+            'table-bordered': this.thyTheme === 'bordered',
+            'table-boxed': this.thyTheme === 'boxed',
+            [`table-${this.thySize}`]: !!this.thySize
+        };
+    }
+
+    private defaultColumns = Array.from({ length: COLUMN_COUNT }).map((item, index: number) => {
+        if (index === 0) {
+            return {
+                width: '40%',
+                type: ThyTableColumnSkeletonType.title
+            };
+        } else if (index === 1) {
+            return {
+                width: '17%',
+                type: ThyTableColumnSkeletonType.member
+            };
+        } else {
+            return {
+                width: 'auto',
+                type: ThyTableColumnSkeletonType.default
+            };
+        }
+    });
+
+    public columns: ThyTableSkeletonColumn[] = [...this.defaultColumns];
+
+    public trackByFn(index: number) {
+        return index;
+    }
 }

--- a/src/table/table.component.html
+++ b/src/table/table.component.html
@@ -1,8 +1,7 @@
 <div
   class="thy-table-body"
   cdkScrollable
-  [ngClass]="{ 'thy-table-fixed': hasFixed, 'thy-table-bordered-theme': theme === 'bordered' && hasFixed }"
->
+  [ngClass]="{ 'thy-table-fixed': hasFixed, 'thy-table-bordered-theme': theme === 'bordered' && hasFixed }">
   <table
     #table
     class="table"
@@ -10,13 +9,12 @@
     [class.table-fixed]="thyLayoutFixed"
     [class.table-draggable]="draggable"
     [class.table-group]="mode === 'group'"
-    [style.min-width]="thyMinWidth"
-  >
+    [style.min-width]="thyMinWidth">
     <colgroup>
       <col *ngFor="let column of columns" [width]="column.width" [style.minWidth]="hasFixed ? column.width : column.minWidth" />
     </colgroup>
 
-    <thead *ngIf="thyShowHeader">
+    <thead *ngIf="!thyHeadless">
       <tr>
         <th
           *ngFor="let column of columns"
@@ -26,8 +24,7 @@
           [class.thy-table-fixed-column-right]="column.fixed === fixedDirection.right"
           [style.left.px]="column.left"
           [style.right.px]="column.right"
-          (click)="onColumnHeaderClick($event, column)"
-        >
+          (click)="onColumnHeaderClick($event, column)">
           <ng-container *ngIf="!column.headerTemplateRef">
             <span>{{ column.title }}</span>
           </ng-container>
@@ -48,8 +45,7 @@
       cdkDropList
       [cdkDropListDisabled]="!draggable"
       [cdkDropListSortPredicate]="dropListEnterPredicate"
-      (cdkDropListDropped)="onDragDropped($event)"
-    >
+      (cdkDropListDropped)="onDragDropped($event)">
       <!-- group -->
       <ng-container *ngIf="mode === 'group'">
         <ng-container *ngFor="let group of groups">
@@ -59,21 +55,19 @@
             cdkDrag
             [cdkDragPreviewClass]="dragPreviewClass"
             [cdkDragData]="group"
-            [cdkDragDisabled]="group | tableRowDragDisabled: thyDragDisabledPredicate"
+            [cdkDragDisabled]="group | tableRowDragDisabled : thyDragDisabledPredicate"
             (cdkDragStarted)="onDragGroupStarted($event)"
-            (cdkDragEnded)="onDragGroupEnd($event)"
-          >
+            (cdkDragEnded)="onDragGroupEnd($event)">
             <td [attr.colspan]="columns.length">
               <div class="thy-table-group-container">
-                <ng-container *ngIf="draggable && !(group | tableRowDragDisabled: thyDragDisabledPredicate)">
+                <ng-container *ngIf="draggable && !(group | tableRowDragDisabled : thyDragDisabledPredicate)">
                   <thy-icon class="table-draggable-icon" thyIconName="drag"></thy-icon>
                 </ng-container>
                 <thy-icon class="expand-icon" [thyIconName]="group.expand ? 'angle-down' : 'angle-right'"></thy-icon>
                 <ng-container *ngIf="groupTemplate">
                   <ng-template
                     [ngTemplateOutlet]="groupTemplate"
-                    [ngTemplateOutletContext]="{ $implicit: group.origin, group: group.origin }"
-                  ></ng-template>
+                    [ngTemplateOutletContext]="{ $implicit: group.origin, group: group.origin }"></ng-template>
                 </ng-container>
               </div>
             </td>
@@ -86,8 +80,7 @@
                   row: row,
                   index: i,
                   level: 0
-                }"
-              ></ng-template>
+                }"></ng-template>
             </ng-container>
           </ng-container>
         </ng-container>
@@ -102,20 +95,18 @@
           cdkDrag
           [cdkDragPreviewClass]="dragPreviewClass"
           [cdkDragData]="row"
-          [cdkDragDisabled]="row | tableRowDragDisabled: thyDragDisabledPredicate"
+          [cdkDragDisabled]="row | tableRowDragDisabled : thyDragDisabledPredicate"
           (cdkDragStarted)="onDragStarted($event)"
           [ngClass]="renderRowClassName(row, i)"
           (click)="onRowClick($event, row)"
-          (thyContextMenu)="onRowContextMenu($event, row)"
-        >
+          (thyContextMenu)="onRowContextMenu($event, row)">
           <ng-template
             [ngTemplateOutlet]="tdsTemplate"
             [ngTemplateOutletContext]="{
               row: row,
               index: i,
               level: 0
-            }"
-          ></ng-template>
+            }"></ng-template>
         </tr>
       </ng-container>
 
@@ -133,27 +124,24 @@
           [cdkDragPreviewClass]="dragPreviewClass"
           [cdkDragData]="row"
           (cdkDragStarted)="onDragStarted($event)"
-          [cdkDragDisabled]="row | tableRowDragDisabled: thyDragDisabledPredicate"
+          [cdkDragDisabled]="row | tableRowDragDisabled : thyDragDisabledPredicate"
           [ngClass]="renderRowClassName(row, i)"
           (click)="onRowClick($event, row)"
-          (thyContextMenu)="onRowContextMenu($event, row)"
-        >
+          (thyContextMenu)="onRowContextMenu($event, row)">
           <ng-template
             [ngTemplateOutlet]="tdsTemplate"
             [ngTemplateOutletContext]="{
               row: row,
               index: i,
               level: level + 1
-            }"
-          ></ng-template>
+            }"></ng-template>
         </tr>
 
         <ng-container *ngIf="mode === 'tree' && isExpanded(row)">
           <ng-template
             *ngFor="let child of row[thyChildrenKey]; trackBy: trackByFn; let j = index"
             [ngTemplateOutlet]="trTemplate"
-            [ngTemplateOutletContext]="{ row: child, index: j, level: level + 1 }"
-          ></ng-template>
+            [ngTemplateOutletContext]="{ row: child, index: j, level: level + 1 }"></ng-template>
         </ng-container>
       </ng-template>
 
@@ -168,9 +156,8 @@
           [class.thy-table-fixed-column-right]="column.fixed === fixedDirection.right"
           [style.left.px]="column.left"
           [style.right.px]="column.right"
-          [ngStyle]="mode === 'tree' && column.expand ? tdIndentComputed(level) : null"
-        >
-          <ng-container *ngIf="j === 0 && draggable && !(row | tableRowDragDisabled: thyDragDisabledPredicate)">
+          [ngStyle]="mode === 'tree' && column.expand ? tdIndentComputed(level) : null">
+          <ng-container *ngIf="j === 0 && draggable && !(row | tableRowDragDisabled : thyDragDisabledPredicate)">
             <thy-icon class="table-draggable-icon" thyIconName="drag"></thy-icon>
           </ng-container>
 
@@ -181,8 +168,7 @@
               *ngIf="mode === 'tree' && column.expand"
               [thyIconName]="isExpanded(row) ? 'angle-down' : 'angle-right'"
               [style.visibility]="showExpand(row) ? 'visible' : 'hidden'"
-              [style.left.px]="iconIndentComputed(level)"
-            ></thy-icon>
+              [style.left.px]="iconIndentComputed(level)"></thy-icon>
             <ng-template [ngTemplateOutlet]="column.cellTemplateRef" [ngTemplateOutletContext]="{ $implicit: row }"></ng-template>
           </ng-container>
 
@@ -195,8 +181,7 @@
                 *ngIf="mode === 'tree' && column.expand"
                 [thyIconName]="isExpanded(row) ? 'angle-down' : 'angle-right'"
                 [style.visibility]="showExpand(row) ? 'visible' : 'hidden'"
-                [style.marginLeft.px]="iconIndentComputed(level)"
-              ></thy-icon>
+                [style.marginLeft.px]="iconIndentComputed(level)"></thy-icon>
               <ng-container *ngIf="getModelValue(row, column.model) | isValidModelValue; else default">
                 {{ getModelValue(row, column.model) }}
               </ng-container>
@@ -219,8 +204,7 @@
                 [(ngModel)]="row[column.key]"
                 (ngModelChange)="onCheckboxChange(row, column)"
                 (click)="onStopPropagation($event)"
-                [disabled]="column.disabled"
-              />
+                [disabled]="column.disabled" />
             </ng-container>
 
             <!-- radio -->
@@ -231,8 +215,7 @@
                 [value]="row"
                 [disabled]="column.disabled"
                 (click)="onStopPropagation($event)"
-                (change)="onRadioSelectChange($event, row)"
-              />
+                (change)="onRadioSelectChange($event, row)" />
             </ng-container>
 
             <!-- switch -->
@@ -241,8 +224,7 @@
                 [(ngModel)]="row[column.key]"
                 (ngModelChange)="onModelChange(row, column)"
                 [disabled]="column.disabled"
-                (thyChange)="onSwitchChange($event, row, column)"
-              ></thy-switch>
+                (thyChange)="onSwitchChange($event, row, column)"></thy-switch>
             </ng-container>
           </ng-container>
         </td>
@@ -265,12 +247,19 @@
         [thySize]="emptyOptions.size"
         [thyMarginTop]="emptyOptions.marginTop"
         [thyTopAuto]="emptyOptions.topAuto"
-        [thyContainer]="emptyOptions.container"
-      ></thy-empty>
+        [thyContainer]="emptyOptions.container"></thy-empty>
     </ng-template>
   </div>
 
-  <thy-loading [thyDone]="loadingDone" [thyTip]="loadingText"></thy-loading>
+  <thy-table-skeleton
+    *ngIf="!loadingDone"
+    [thyRowCount]="5"
+    [thyHeadless]="true"
+    [thyTheme]="theme"
+    [thySize]="size"
+    [thyMinWidth]="thyMinWidth"
+    [thyColumns]="skeletonColumns">
+  </thy-table-skeleton>
 
   <div class="thy-table-footer" *ngIf="pagination.total > pagination.size" [class.thy-table-footer-has-padding]="theme === 'default'">
     <thy-pagination
@@ -282,8 +271,7 @@
       [thyShowTotal]="showTotal"
       (thyPageChanged)="onPageChange($event)"
       (thyPageIndexChange)="onPageIndexChange($event)"
-      (thyPageSizeChanged)="onPageSizeChange($event)"
-    ></thy-pagination>
+      (thyPageSizeChanged)="onPageSizeChange($event)"></thy-pagination>
   </div>
 </div>
 

--- a/src/table/table.interface.ts
+++ b/src/table/table.interface.ts
@@ -1,4 +1,5 @@
 import { EventEmitter, TemplateRef } from '@angular/core';
+import { ThyTableColumnSkeletonType } from './enums';
 
 export enum ThyTableSortDirection {
     default = '',
@@ -92,4 +93,9 @@ export interface ThyTableSortEvent {
 export interface ThyTableRowEvent {
     event: Event;
     row: any;
+}
+
+export interface ThyTableSkeletonColumn {
+    width: number | string;
+    type: ThyTableColumnSkeletonType;
 }

--- a/src/table/test/table-skeleton.spec.ts
+++ b/src/table/test/table-skeleton.spec.ts
@@ -1,0 +1,165 @@
+import { Component, DebugElement } from '@angular/core';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import {
+    ThyTableColumnSkeletonType,
+    ThyTableModule,
+    ThyTableSize,
+    ThyTableSkeletonColumn,
+    ThyTableSkeletonComponent,
+    ThyTableTheme
+} from 'ngx-tethys/table';
+import { SafeAny } from 'ngx-tethys/types';
+
+const defaultColumns = [
+    {
+        width: '40%',
+        type: ThyTableColumnSkeletonType.title
+    },
+    {
+        width: '17%',
+        type: ThyTableColumnSkeletonType.member
+    },
+    {
+        width: 'auto',
+        type: ThyTableColumnSkeletonType.default
+    },
+    {
+        width: 'auto',
+        type: ThyTableColumnSkeletonType.default
+    },
+    {
+        width: 'auto',
+        type: ThyTableColumnSkeletonType.default
+    }
+];
+
+@Component({
+    selector: 'test-table-skeleton-basic',
+    template: `<thy-table-skeleton
+        [thyRowCount]="rowCount"
+        [thyTheme]="theme"
+        [thySize]="size"
+        [thyColumns]="columns"
+        [thyHeadless]="headless"
+        [thyMinWidth]="minWidth">
+    </thy-table-skeleton>`
+})
+class TestTableSkeletonBasicComponent {
+    rowCount: number;
+
+    headless: boolean;
+
+    theme: ThyTableTheme;
+
+    size: ThyTableSize;
+
+    minWidth: string | number;
+
+    columns: ThyTableSkeletonColumn[];
+}
+
+describe('thy-table-skeleton', () => {
+    let fixture: ComponentFixture<TestTableSkeletonBasicComponent>;
+    let tableSkeletonElement: SafeAny;
+    let tableSkeletonInstance: ThyTableSkeletonComponent;
+    let tableDebugElement: DebugElement;
+    let tableElement: SafeAny;
+    let testComponent: TestTableSkeletonBasicComponent;
+
+    beforeEach(() => {
+        TestBed.configureTestingModule({
+            declarations: [TestTableSkeletonBasicComponent],
+            imports: [ThyTableModule, BrowserAnimationsModule]
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(TestTableSkeletonBasicComponent);
+
+        const tableSkeletonDebugElement = fixture.debugElement.query(By.directive(ThyTableSkeletonComponent));
+        tableSkeletonElement = tableSkeletonDebugElement.nativeElement;
+        tableSkeletonInstance = tableSkeletonDebugElement.componentInstance;
+
+        tableDebugElement = fixture.debugElement.query(By.css('table'));
+        tableElement = tableDebugElement.nativeElement;
+        testComponent = fixture.debugElement.componentInstance;
+
+        fixture.detectChanges();
+    });
+
+    it('should create table skeleton', () => {
+        expect(fixture).toBeTruthy();
+        expect(tableSkeletonElement).toBeTruthy();
+        expect(tableSkeletonElement.classList).toContain('thy-table-skeleton');
+        expect(tableElement.classList).toContain('table');
+    });
+
+    it('should support thyTheme', () => {
+        testComponent.theme = 'bordered';
+        fixture.detectChanges();
+        expect(tableSkeletonInstance.thyTheme).toBe('bordered');
+        expect(tableElement.classList).toContain('table-bordered');
+
+        testComponent.theme = 'boxed';
+        fixture.detectChanges();
+        expect(tableSkeletonInstance.thyTheme).toBe('boxed');
+        expect(tableElement.classList).toContain('table-boxed');
+    });
+
+    it('should support thySize', () => {
+        ['xs', 'sm', 'md', 'lg', 'xlg', 'default'].forEach((size: ThyTableSize) => {
+            testComponent.size = size;
+            fixture.detectChanges();
+            expect(tableSkeletonInstance.thySize).toBe(size);
+            expect(tableElement.classList).toContain(`table-${size}`);
+        });
+    });
+
+    it('should has correct default columns', () => {
+        expect(tableSkeletonInstance.columns).toEqual(defaultColumns);
+    });
+
+    it('should support thyRowCount', () => {
+        testComponent.rowCount = 3;
+        fixture.detectChanges();
+
+        const trLen = tableElement.querySelectorAll('tbody tr').length;
+        expect(trLen).toBe(3);
+    });
+
+    it('should support thyColumns', () => {
+        testComponent.columns = [
+            { width: 'auto', type: ThyTableColumnSkeletonType.title },
+            { width: 'auto', type: ThyTableColumnSkeletonType.default },
+            { width: 100, type: ThyTableColumnSkeletonType.default },
+            { width: '200px', type: ThyTableColumnSkeletonType.default },
+            { width: '17%', type: ThyTableColumnSkeletonType.member }
+        ];
+
+        fixture.detectChanges();
+        expect(tableSkeletonInstance.columns).toEqual(testComponent.columns);
+    });
+
+    it('should support thyHeadless', fakeAsync(() => {
+        expect(tableSkeletonInstance.thyHeadless).toBe(false);
+        const theadElement = fixture.debugElement.query(By.css('thead'));
+        expect(theadElement).toBeTruthy();
+
+        testComponent.headless = true;
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        expect(tableSkeletonInstance.thyHeadless).toBe(true);
+        const theadElement2 = fixture.debugElement.query(By.css('thead'));
+        expect(theadElement2).toBeFalsy();
+    }));
+
+    it('should support thyMinWidth', () => {
+        expect(tableSkeletonInstance.thyMinWidth).toBe('');
+        expect(tableElement.style.minWidth).toBeFalsy();
+
+        testComponent.minWidth = 700;
+        fixture.detectChanges();
+        expect(tableSkeletonInstance.thyMinWidth).toBe('700px');
+    });
+});

--- a/src/table/test/table.spec.ts
+++ b/src/table/test/table.spec.ts
@@ -30,7 +30,7 @@ import { ThyTableModule } from '../table.module';
             [thyRowClassName]="tableRowClassName"
             [thyLoadingDone]="isLoadingDone"
             [thyLoadingText]="loadingText"
-            [thyShowHeader]="isShowHeader"
+            [thyHeadless]="headless"
             (thyOnRowClick)="onRowClick($event)"
             (thyOnMultiSelectChange)="onMultiSelectChange($event)"
             (thyOnRadioSelectChange)="onRadioSelectChange($event)"
@@ -146,6 +146,7 @@ class ThyDemoDefaultTableComponent {
         sizeOptions: [3, 5, 10]
     };
     isShowHeader = true;
+    headless = false;
     isDraggable = false;
     isRowSelect = false;
     tableClassName = 'class-name';
@@ -407,12 +408,11 @@ describe('ThyTable: basic', () => {
         expect(defaultEmptyComponent).toBeTruthy();
     });
 
-    it('should have thy-loading component when isLoadingDone is false', () => {
+    it('should have thy-table-skeleton component when isLoadingDone is false', () => {
         testComponent.isLoadingDone = false;
         fixture.detectChanges();
-        const loadingComponent = tableComponent.nativeElement.querySelector('thy-loading');
-        const loadingText = loadingComponent.querySelector('span');
-        expect(loadingText.innerText).toEqual(testComponent.loadingText);
+        const skeletonElement = tableComponent.nativeElement.querySelector('thy-table-skeleton');
+        expect(skeletonElement).toBeTruthy();
     });
 
     it('should not have thy-pagination component when size is bigger than total', () => {
@@ -463,17 +463,14 @@ describe('ThyTable: basic', () => {
         expect(paginationComponent).toBeTruthy();
     });
 
-    it('have <thead> when set thyShowHeader true', () => {
+    it('should show <thead> when thyHeadless is false, and hidden <thead> when thyHeadless is true', () => {
+        testComponent.headless = false;
         fixture.detectChanges();
-        const thead = table.querySelector('thead');
-        expect(thead).toBeTruthy();
-    });
+        expect(table.querySelector('thead')).toBeTruthy();
 
-    it('do not have <thead> when set thyShowHeader false', () => {
-        testComponent.isShowHeader = false;
+        testComponent.headless = true;
         fixture.detectChanges();
-        const thead = table.querySelector('thead');
-        expect(thead).toBeNull();
+        expect(table.querySelector('thead')).toBeFalsy();
     });
 
     it('should has correct class and when mode is group', () => {


### PR DESCRIPTION
1. thy-table-skeleton 支持设置 thyHeadless、thySize、thyTheme、thyMinWidth、thyColumns 参数。默认开启动画。
2. thy-table 新增参数：thyColumnSkeletonTypes，支持设置内置骨架屏的列类型，骨架列宽和column列宽一致。
3. thy-table 新增参数：thyHeadless，并兼容 thyShowHeader，标记 thyShowHeader 为废弃。
4. thy-table 内置的 thy-loading 改成 thy-table-skeleton，标记 thyLoadingText 为废弃。
5. 单元测试