### PR TITLE
docs(layout): support thyDragMinWidth for sidebar #INFR-3948

### DIFF
--- a/src/layout/examples/sidebar/sidebar.component.html
+++ b/src/layout/examples/sidebar/sidebar.component.html
@@ -64,11 +64,11 @@
 <thy-layout style="height: 100px">
   <thy-sidebar
     [thyDraggable]="true"
-    [thyCollapsedWidth]="collapsedWidth"
+    [thyCollapsedWidth]="100"
     [thyDragMaxWidth]="700"
     class="p-2"
     (thyDragWidthChange)="dragWidthChange($event)">
-    Sidebar can drag to change width
+    Sidebar can drag to change width, with min width 100px and max width 700px
   </thy-sidebar>
   <thy-content> Content </thy-content>
 </thy-layout>

--- a/src/layout/sidebar.component.ts
+++ b/src/layout/sidebar.component.ts
@@ -235,7 +235,7 @@ export class ThySidebarComponent implements OnInit, OnDestroy {
     }
 
     /**
-     * 收起后的宽度
+     * 收起后的宽度、拖拽的最小宽度
      */
     @Input() @InputNumber() thyCollapsedWidth = 20;
 


### PR DESCRIPTION
thy-sidebar 已经支持了拖拽时限制最小宽度的功能 thyCollapsedWidth。不考虑新增 thyDragMinWidth 参数，因为，在支持用户设置 thyCollapsible 为true 的同时，也支持用户设置 thyDraggable 为true，此时，thyCollapsedWidth 和 thyDragMinWidth 都是限制最小宽度，参数意义重复。 
<img width="875" alt="image" src="https://github.com/atinc/ngx-tethys/assets/28333707/56678b03-7224-4764-9246-bee5c80cf302">

