### PR TITLE
feat(dialog): add cdkScrollable for scrollable element dialog-body #INFR-8826

### DIFF
--- a/src/dialog/body/dialog-body.component.ts
+++ b/src/dialog/body/dialog-body.component.ts
@@ -1,6 +1,6 @@
 import { Component, Input, OnInit, HostBinding, ElementRef, NgZone } from '@angular/core';
 import { coerceBooleanProperty } from 'ngx-tethys/util';
-import { CdkScrollable, ScrollDispatcher } from '@angular/cdk/scrolling';
+import { CdkScrollable, ScrollDispatcher, ScrollingModule } from '@angular/cdk/scrolling';
 
 /**
  * 模态框的主体组件
@@ -13,7 +13,7 @@ import { CdkScrollable, ScrollDispatcher } from '@angular/cdk/scrolling';
     // changeDetection: ChangeDetectionStrategy.OnPush,
     exportAs: 'thyDialogBody',
     standalone: true,
-    imports: [CdkScrollable],
+    imports: [CdkScrollable, ScrollingModule],
     providers: [
         {
             provide: CdkScrollable,

--- a/src/dialog/body/dialog-body.component.ts
+++ b/src/dialog/body/dialog-body.component.ts
@@ -1,6 +1,6 @@
-import { Component, Input, OnInit, HostBinding } from '@angular/core';
-import { ThyDialog } from '../dialog.service';
+import { Component, Input, OnInit, HostBinding, ElementRef, NgZone } from '@angular/core';
 import { coerceBooleanProperty } from 'ngx-tethys/util';
+import { CdkScrollable, ScrollDispatcher } from '@angular/cdk/scrolling';
 
 /**
  * 模态框的主体组件
@@ -12,9 +12,16 @@ import { coerceBooleanProperty } from 'ngx-tethys/util';
     template: '<ng-content></ng-content>',
     // changeDetection: ChangeDetectionStrategy.OnPush,
     exportAs: 'thyDialogBody',
-    standalone: true
+    standalone: true,
+    imports: [CdkScrollable],
+    providers: [
+        {
+            provide: CdkScrollable,
+            useExisting: DialogBodyComponent
+        }
+    ]
 })
-export class DialogBodyComponent implements OnInit {
+export class DialogBodyComponent extends CdkScrollable implements OnInit {
     @HostBinding(`class.dialog-body`) _isDialogBody = true;
 
     @HostBinding(`class.dialog-body-clear-padding`)
@@ -29,7 +36,11 @@ export class DialogBodyComponent implements OnInit {
         this.thyClearPaddingClassName = coerceBooleanProperty(value);
     }
 
-    constructor(private dialog: ThyDialog) {}
+    constructor(public elementRef: ElementRef, public scrollDispatcher: ScrollDispatcher, public ngZone: NgZone) {
+        super(elementRef, scrollDispatcher, ngZone);
+    }
 
-    ngOnInit() {}
+    ngOnInit() {
+        super.ngOnInit();
+    }
 }

--- a/src/dialog/dialog.module.ts
+++ b/src/dialog/dialog.module.ts
@@ -22,7 +22,6 @@ import { ScrollingModule } from '@angular/cdk/scrolling';
 @NgModule({
     imports: [
         CommonModule,
-        ScrollingModule,
         ThySharedModule,
         PortalModule,
         OverlayModule,

--- a/src/dialog/dialog.module.ts
+++ b/src/dialog/dialog.module.ts
@@ -17,7 +17,6 @@ import { THY_DIALOG_DEFAULT_OPTIONS_PROVIDER, THY_DIALOG_LAYOUT_CONFIG_PROVIDER 
 import { ThyDialog } from './dialog.service';
 import { DialogFooterComponent } from './footer/dialog-footer.component';
 import { DialogHeaderComponent } from './header/dialog-header.component';
-import { ScrollingModule } from '@angular/cdk/scrolling';
 
 @NgModule({
     imports: [

--- a/src/dialog/dialog.module.ts
+++ b/src/dialog/dialog.module.ts
@@ -17,10 +17,12 @@ import { THY_DIALOG_DEFAULT_OPTIONS_PROVIDER, THY_DIALOG_LAYOUT_CONFIG_PROVIDER 
 import { ThyDialog } from './dialog.service';
 import { DialogFooterComponent } from './footer/dialog-footer.component';
 import { DialogHeaderComponent } from './header/dialog-header.component';
+import { ScrollingModule } from '@angular/cdk/scrolling';
 
 @NgModule({
     imports: [
         CommonModule,
+        ScrollingModule,
         ThySharedModule,
         PortalModule,
         OverlayModule,


### PR DESCRIPTION
统一解决：以 thy-dialog-body 为滚动容器时，打开内容区的 overlay，滚动内容区，overlay 的滚动策略不生效的问题。