### PR TITLE
fix(switch): the switch thyDisabled does not take effect when using ngModel #INFR-10583

### DIFF
--- a/src/switch/examples/disabled/disabled.component.html
+++ b/src/switch/examples/disabled/disabled.component.html
@@ -1,1 +1,3 @@
 <thy-switch [thyDisabled]="true" [(ngModel)]="isChecked"></thy-switch>
+
+<thy-switch disabled [(ngModel)]="isChecked" class="ml-4"></thy-switch>

--- a/src/switch/switch.component.ts
+++ b/src/switch/switch.component.ts
@@ -57,6 +57,8 @@ export class ThySwitchComponent extends TabIndexDisabledControlValueAccessorMixi
 
     private initialized = false;
 
+    private isDisabledFirstChange = true;
+
     @ViewChild('switch', { static: true }) switchElementRef: ElementRef;
 
     /**
@@ -135,8 +137,9 @@ export class ThySwitchComponent extends TabIndexDisabledControlValueAccessorMixi
         this.onModelTouched = fn;
     }
 
-    setDisabledState(isDisabled: boolean) {
-        this.disabled = isDisabled;
+    setDisabledState(isDisabled: boolean): void {
+        this.disabled = (this.isDisabledFirstChange && this.thyDisabled) || isDisabled;
+        this.isDisabledFirstChange = false;
         this.setClassNames();
     }
 

--- a/src/switch/test/switch.component.spec.ts
+++ b/src/switch/test/switch.component.spec.ts
@@ -115,7 +115,6 @@ describe('switch component', () => {
         fixture.detectChanges();
         const disabledSwitch = fixture.debugElement.queryAll(By.directive(ThySwitchComponent))[1];
         const disabledSwitchElement = disabledSwitch.nativeElement;
-        console.log('disabledSwitchElement:', disabledSwitchElement);
         labelNode = disabledSwitchElement.children[0];
         expect(labelNode.classList.contains('thy-switch-disabled')).toBeTruthy();
     }));

--- a/src/switch/test/switch.component.spec.ts
+++ b/src/switch/test/switch.component.spec.ts
@@ -1,18 +1,20 @@
 import { Component, DebugElement } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ThySwitchComponent } from '../switch.component';
 import { ThySwitchModule } from '../switch.module';
 
 @Component({
     selector: 'thy-switch-test',
-    template: ` <thy-switch [thySize]="size" [thyType]="type" [thyDisabled]="isDisabled"></thy-switch> `
+    template: `<thy-switch [thySize]="size" [thyType]="type" [thyDisabled]="isDisabled" [(ngModel)]="isChecked"></thy-switch>
+        <thy-switch disabled [(ngModel)]="isChecked"></thy-switch>`
 })
 class SwitchTestComponent {
     size = ``;
     type = ``;
     isDisabled: boolean;
+    isChecked: boolean;
 }
 
 describe('switch component', () => {
@@ -106,4 +108,15 @@ describe('switch component', () => {
         fixture.detectChanges();
         expect(label.getAttribute('tabindex')).toBe('0');
     });
+
+    it('should have correct class when set disabled attribute', fakeAsync(() => {
+        fixture.detectChanges();
+        tick();
+        fixture.detectChanges();
+        const disabledSwitch = fixture.debugElement.queryAll(By.directive(ThySwitchComponent))[1];
+        const disabledSwitchElement = disabledSwitch.nativeElement;
+        console.log('disabledSwitchElement:', disabledSwitchElement);
+        labelNode = disabledSwitchElement.children[0];
+        expect(labelNode.classList.contains('thy-switch-disabled')).toBeTruthy();
+    }));
 });


### PR DESCRIPTION
<thy-switch [thyDisabled]="true"></thy-switch>
这种方式禁用有效。

<thy-switch [thyDisabled]="true" [(ngModel)]="isChecked"></thy-switch>
这种方式禁用无效。原因：ControlValueAccessor.setDisabledState 的调用覆盖了原先设置的 thyDisabled 值。


修复后以下两种方式均禁用有效：
<thy-switch [thyDisabled]="true" [(ngModel)]="isChecked"></thy-switch>
<thy-switch disabled [(ngModel)]="isChecked"></thy-switch>