### PR TITLE
refactor(testing): use the MouseEvent constructor to replace the deprecated initMouseEvent and set default value for detail and buttons INFR-11454

### DIFF
--- a/src/testing/dispatcher-events.ts
+++ b/src/testing/dispatcher-events.ts
@@ -37,10 +37,11 @@ export function dispatchMouseEvent(
     clientX = 0,
     clientY = 0,
     button?: number,
+    buttons?: number,
     modifiers?: ModifierKeys,
     relatedTarget?: Element
 ): MouseEvent {
-    return dispatchEvent(node, createMouseEvent(type, clientX, clientY, button, modifiers, relatedTarget));
+    return dispatchEvent(node, createMouseEvent(type, clientX, clientY, button, buttons, modifiers, relatedTarget));
 }
 
 /**

--- a/src/testing/dispatcher-events.ts
+++ b/src/testing/dispatcher-events.ts
@@ -38,10 +38,11 @@ export function dispatchMouseEvent(
     clientY = 0,
     button?: number,
     buttons?: number,
+    detail?: number,
     modifiers?: ModifierKeys,
     relatedTarget?: Element
 ): MouseEvent {
-    return dispatchEvent(node, createMouseEvent(type, clientX, clientY, button, buttons, modifiers, relatedTarget));
+    return dispatchEvent(node, createMouseEvent(type, clientX, clientY, button, buttons, detail, modifiers, relatedTarget));
 }
 
 /**

--- a/src/testing/events.ts
+++ b/src/testing/events.ts
@@ -10,6 +10,7 @@ export function createMouseEvent(
     clientY = 0,
     button = 0,
     buttons = 1,
+    detail = 1,
     modifiers: ModifierKeys = {},
     relatedTarget?: Element
 ) {
@@ -24,13 +25,13 @@ export function createMouseEvent(
         bubbles: true,
         cancelable: true,
         view: window,
-        detail: 1,
         screenX,
         screenY,
         clientX,
         clientY,
         button,
         buttons,
+        detail,
         relatedTarget,
         ctrlKey: !!modifiers.control,
         altKey: !!modifiers.alt,

--- a/src/testing/events.ts
+++ b/src/testing/events.ts
@@ -9,12 +9,10 @@ export function createMouseEvent(
     clientX = 0,
     clientY = 0,
     button = 0,
+    buttons = 1,
     modifiers: ModifierKeys = {},
     relatedTarget?: Element
 ) {
-    const event = document.createEvent('MouseEvent');
-    const originalPreventDefault = event.preventDefault.bind(event);
-
     // Note: We cannot determine the position of the mouse event based on the screen
     // because the dimensions and position of the browser window are not available
     // To provide reasonable `screenX` and `screenY` coordinates, we simply use the
@@ -22,29 +20,26 @@ export function createMouseEvent(
     const screenX = clientX;
     const screenY = clientY;
 
-    event.initMouseEvent(
-        type,
-        /* canBubble */ true,
-        /* cancelable */ true,
-        /* view */ window,
-        /* detail */ 0,
-        /* screenX */ screenX,
-        /* screenY */ screenY,
-        /* clientX */ clientX,
-        /* clientY */ clientY,
-        /* ctrlKey */ !!modifiers.control,
-        /* altKey */ !!modifiers.alt,
-        /* shiftKey */ !!modifiers.shift,
-        /* metaKey */ !!modifiers.meta,
-        /* button */ button,
-        /* relatedTarget */ relatedTarget
-    );
-
-    // `initMouseEvent` doesn't allow us to pass the `buttons` and
-    // defaults it to 0 which looks like a fake event.
-    defineReadonlyEventProperty(event, 'buttons', 1);
+    const event = new MouseEvent(type, {
+        bubbles: true,
+        cancelable: true,
+        view: window,
+        detail: 1,
+        screenX,
+        screenY,
+        clientX,
+        clientY,
+        button,
+        buttons,
+        relatedTarget,
+        ctrlKey: !!modifiers.control,
+        altKey: !!modifiers.alt,
+        shiftKey: !!modifiers.shift,
+        metaKey: !!modifiers.meta
+    });
 
     // IE won't set `defaultPrevented` on synthetic events so we need to do it manually.
+    const originalPreventDefault = event.preventDefault.bind(event);
     event.preventDefault = function () {
         defineReadonlyEventProperty(event, 'defaultPrevented', true);
         return originalPreventDefault();

--- a/src/tree/test/tree.spec.ts
+++ b/src/tree/test/tree.spec.ts
@@ -1,9 +1,7 @@
-import { createDragEvent, dispatchFakeEvent, dispatchMouseEvent, dispatchTouchEvent } from 'ngx-tethys/testing';
-import { animationFrameScheduler } from 'rxjs';
+import { dispatchMouseEvent } from 'ngx-tethys/testing';
 
-import { CdkVirtualScrollViewport, ExtendedScrollToOptions } from '@angular/cdk/scrolling';
-import { ApplicationRef, Component, OnInit, ViewChild } from '@angular/core';
-import { ComponentFixture, fakeAsync, flush, TestBed, tick, waitForAsync } from '@angular/core/testing';
+import { Component, OnInit, ViewChild } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
@@ -25,13 +23,12 @@ import { bigTreeNodes, treeNodes, hasCheckTreeNodes } from './mock';
 import { ThyTreeNodeComponent } from '../tree-node.component';
 import { CDK_DRAG_CONFIG, DragDropConfig } from '@angular/cdk/drag-drop';
 import { DOCUMENT } from '@angular/common';
-import { dargNode, scrollToViewport, scrollToViewportOffset } from './utils';
+import { scrollToViewport, scrollToViewportOffset } from './utils';
 
 const expandSelector = '.thy-tree-expand';
 const expandIconSelector = '.thy-tree-expand-icon';
 const treeNodeSelector = '.thy-tree-node';
 const loadingSelector = '.thy-loading';
-const treeNodeScrollViewport = '.cdk-virtual-scroll-viewport';
 const treeNodeContentSelector = '.thy-tree-node-content';
 
 describe('ThyTreeComponent', () => {
@@ -1094,4 +1091,26 @@ function startDragging(fixture: ComponentFixture<any>, element: Element, x?: num
 
     dispatchMouseEvent(document, 'mousemove', x, y);
     fixture.detectChanges();
+}
+
+function dargNode(fixture: ComponentFixture<any>, startNode: HTMLElement, targetNode: HTMLElement, dropPosition: ThyTreeDropPosition) {
+    startDragging(fixture, startNode, 10, 10);
+
+    const targetClientRect = targetNode.getBoundingClientRect();
+    let targetClientY = 0;
+    if (dropPosition === ThyTreeDropPosition.before) {
+        targetClientY = targetClientRect.top;
+    } else if (dropPosition === ThyTreeDropPosition.in) {
+        targetClientY = targetClientRect.top + targetClientRect.height / 2 - 1;
+    } else {
+        targetClientY = targetClientRect.top + targetClientRect.height - 1;
+    }
+
+    dispatchMouseEvent(targetNode, 'mousemove', targetClientRect.left, targetClientY);
+    fixture.detectChanges();
+
+    dispatchMouseEvent(targetNode, 'mouseup', targetClientRect.left, targetClientY);
+    fixture.detectChanges();
+
+    tick();
 }

--- a/src/tree/test/utils.ts
+++ b/src/tree/test/utils.ts
@@ -1,43 +1,8 @@
 import { ComponentFixture, tick } from '@angular/core/testing';
-import { ThyTreeDropPosition } from '../tree.class';
-import { dispatchFakeEvent, dispatchMouseEvent } from '../../../cdk/testing';
+
+import { dispatchFakeEvent } from '../../../cdk/testing';
 import { animationFrameScheduler } from 'rxjs';
 import { ExtendedScrollToOptions } from '@angular/cdk/scrolling';
-
-export function dargNode(
-    fixture: ComponentFixture<any>,
-    startNode: HTMLElement,
-    targetNode: HTMLElement,
-    dropPosition: ThyTreeDropPosition
-) {
-    startDragging(fixture, startNode, 10, 10);
-
-    const targetClientRect = targetNode.getBoundingClientRect();
-    let targetClientY = 0;
-    if (dropPosition === ThyTreeDropPosition.before) {
-        targetClientY = targetClientRect.top;
-    } else if (dropPosition === ThyTreeDropPosition.in) {
-        targetClientY = targetClientRect.top + targetClientRect.height / 2 - 1;
-    } else {
-        targetClientY = targetClientRect.top + targetClientRect.height - 1;
-    }
-
-    dispatchMouseEvent(targetNode, 'mousemove', targetClientRect.left, targetClientY);
-    fixture.detectChanges();
-
-    dispatchMouseEvent(targetNode, 'mouseup', targetClientRect.left, targetClientY);
-    fixture.detectChanges();
-
-    tick();
-}
-
-export function startDragging(fixture: ComponentFixture<any>, element: Element, x?: number, y?: number) {
-    dispatchMouseEvent(element, 'mousedown', x, y);
-    fixture.detectChanges();
-
-    dispatchMouseEvent(document, 'mousemove', x, y);
-    fixture.detectChanges();
-}
 
 export function scrollToViewportOffset(fixture: ComponentFixture<any>, offset?: number) {
     if (offset !== undefined) {


### PR DESCRIPTION
问题：目前master分支有 10个 拖拽相关的单元测试都报错了。
原因：MouseEvent.initMouseEvent() 方法已废弃，而且它不支持 detail、buttons 参数。 
解决：使用 new MouseEvent()  替换  MouseEvent.initMouseEvent()，并设置上detail、buttons配置。