### PR TITLE
refactor: remove the component suffix for standalone components and provide schematics #INFR-10654

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -26,6 +26,7 @@
         "@angular-eslint/no-input-rename": "off",
         "@angular-eslint/no-output-native": "off",
         "@angular-eslint/no-output-rename": "off",
+        "@angular-eslint/component-class-suffix": "off",
         "@angular-eslint/component-selector": [
           "error",
           {

--- a/schematics/ng-update/data/class-names.ts
+++ b/schematics/ng-update/data/class-names.ts
@@ -15,7 +15,7 @@ export const classNames: VersionChanges<ClassNameUpgradeData> = {
                 },
                 {
                     replace: 'ThyLabelComponent',
-                    replaceWith: 'ThyTagComponent'
+                    replaceWith: 'ThyTag'
                 },
                 {
                     replace: 'ThyLabelModule',
@@ -35,15 +35,15 @@ export const classNames: VersionChanges<ClassNameUpgradeData> = {
                 },
                 {
                     replace: 'ThyActionMenuComponent',
-                    replaceWith: 'ThyDropdownMenuComponent'
+                    replaceWith: 'ThyDropdownMenu'
                 },
                 {
                     replace: 'ThyActionMenuGroupComponent',
-                    replaceWith: 'ThyDropdownMenuGroupComponent'
+                    replaceWith: 'ThyDropdownMenuGroup'
                 },
                 {
                     replace: 'ThyActionMenuDividerComponent',
-                    replaceWith: 'ThyDropdownMenuDividerComponent'
+                    replaceWith: 'ThyDropdownMenuDivider'
                 },
                 {
                     replace: 'ThyActionMenuDividerTitleDirective',
@@ -92,6 +92,742 @@ export const classNames: VersionChanges<ClassNameUpgradeData> = {
                 {
                     replace: 'ThyActionMenuItemActiveDirective',
                     replaceWith: 'ThyDropdownMenuItemActiveDirective'
+                },
+                {
+                    replace: 'ThyActionComponent',
+                    replaceWith: 'ThyAction'
+                },
+                {
+                    replace: 'ThyActionsComponent',
+                    replaceWith: 'ThyActions'
+                },
+                {
+                    replace: 'ThyAffixComponent',
+                    replaceWith: 'ThyAffix'
+                },
+                {
+                    replace: 'ThyAlertComponent',
+                    replaceWith: 'ThyAlert'
+                },
+                {
+                    replace: 'ThyAnchorLinkComponent',
+                    replaceWith: 'ThyAnchorLink'
+                },
+                {
+                    replace: 'ThyAnchorComponent',
+                    replaceWith: 'ThyAnchor'
+                },
+                {
+                    replace: 'ThyArrowSwitcherComponent',
+                    replaceWith: 'ThyArrowSwitcher'
+                },
+                {
+                    replace: 'ThyAutocompleteComponent',
+                    replaceWith: 'ThyAutocomplete'
+                },
+                {
+                    replace: 'ThyAvatarComponent',
+                    replaceWith: 'ThyAvatar'
+                },
+                {
+                    replace: 'ThyBackTopComponent',
+                    replaceWith: 'ThyBackTop'
+                },
+                {
+                    replace: 'ThyBadgeComponent',
+                    replaceWith: 'ThyBadge'
+                },
+                {
+                    replace: 'ThyBreadcrumbItemComponent',
+                    replaceWith: 'ThyBreadcrumbItem'
+                },
+                {
+                    replace: 'ThyBreadcrumbComponent',
+                    replaceWith: 'ThyBreadcrumb'
+                },
+                {
+                    replace: 'ThyButtonGroupComponent',
+                    replaceWith: 'ThyButtonGroup'
+                },
+                {
+                    replace: 'ThyButtonIconComponent',
+                    replaceWith: 'ThyButtonIcon'
+                },
+                {
+                    replace: 'ThyButtonComponent',
+                    replaceWith: 'ThyButton'
+                },
+                {
+                    replace: 'ThyCalendarHeaderComponent',
+                    replaceWith: 'ThyCalendarHeader'
+                },
+                {
+                    replace: 'ThyCalendarComponent',
+                    replaceWith: 'ThyCalendar'
+                },
+                {
+                    replace: 'ThyCardComponent',
+                    replaceWith: 'ThyCard'
+                },
+                {
+                    replace: 'ThyCardContentComponent',
+                    replaceWith: 'ThyCardContent'
+                },
+                {
+                    replace: 'ThyCardHeaderComponent',
+                    replaceWith: 'ThyCardHeader'
+                },
+                {
+                    replace: 'ThyCarouselComponent',
+                    replaceWith: 'ThyCarousel'
+                },
+                {
+                    replace: 'ThyCascaderComponent',
+                    replaceWith: 'ThyCascader'
+                },
+                {
+                    replace: 'ThyCheckboxComponent',
+                    replaceWith: 'ThyCheckbox'
+                },
+                {
+                    replace: 'ThyCollapseItemComponent',
+                    replaceWith: 'ThyCollapseItem'
+                },
+                {
+                    replace: 'ThyCollapseComponent',
+                    replaceWith: 'ThyCollapse'
+                },
+                {
+                    replace: 'ThyColorPickerCustomPanelComponent',
+                    replaceWith: 'ThyColorPickerCustomPanel'
+                },
+                {
+                    replace: 'ThyColorPickerPanelComponent',
+                    replaceWith: 'ThyColorPickerPanel'
+                },
+                {
+                    replace: 'ThyCommentComponent',
+                    replaceWith: 'ThyComment'
+                },
+                {
+                    replace: 'BasePickerComponent',
+                    replaceWith: 'BasePicker'
+                },
+                {
+                    replace: 'ThyDatePickerComponent',
+                    replaceWith: 'ThyDatePicker'
+                },
+                {
+                    replace: 'ThyMonthPickerComponent',
+                    replaceWith: 'ThyMonthPicker'
+                },
+                {
+                    replace: 'ThyPickerComponent',
+                    replaceWith: 'ThyPicker'
+                },
+                {
+                    replace: 'ThyQuarterPickerComponent',
+                    replaceWith: 'ThyQuarterPicker'
+                },
+                {
+                    replace: 'ThyRangePickerComponent',
+                    replaceWith: 'ThyRangePicker'
+                },
+                {
+                    replace: 'ThyWeekPickerComponent',
+                    replaceWith: 'ThyWeekPicker'
+                },
+                {
+                    replace: 'ThyYearPickerComponent',
+                    replaceWith: 'ThyYearPicker'
+                },
+                {
+                    replace: 'ThyDateRangeComponent',
+                    replaceWith: 'ThyDateRange'
+                },
+                {
+                    replace: 'ThyDialogContainerComponent',
+                    replaceWith: 'ThyDialogContainer'
+                },
+                {
+                    replace: 'ThyDividerComponent',
+                    replaceWith: 'ThyDivider'
+                },
+                {
+                    replace: 'ThyDotComponent',
+                    replaceWith: 'ThyDot'
+                },
+                {
+                    replace: 'ThyDropdownMenuGroupComponent',
+                    replaceWith: 'ThyDropdownMenuGroup'
+                },
+                {
+                    replace: 'ThyDropdownMenuDividerComponent',
+                    replaceWith: 'ThyDropdownMenuDivider'
+                },
+                {
+                    replace: 'ThyDropdownSubmenuComponent',
+                    replaceWith: 'ThyDropdownSubmenu'
+                },
+                {
+                    replace: 'ThyEmptyComponent',
+                    replaceWith: 'ThyEmpty'
+                },
+                {
+                    replace: 'ThyFlexibleTextComponent',
+                    replaceWith: 'ThyFlexibleText'
+                },
+                {
+                    replace: 'ThyFormGroupComponent',
+                    replaceWith: 'ThyFormGroup'
+                },
+                {
+                    replace: 'ThyGridItemComponent',
+                    replaceWith: 'ThyGridItem'
+                },
+                {
+                    replace: 'ThyIconComponent',
+                    replaceWith: 'ThyIcon'
+                },
+                {
+                    replace: 'ThyImageGroupComponent',
+                    replaceWith: 'ThyImageGroup'
+                },
+                {
+                    replace: 'ThyInputCountComponent',
+                    replaceWith: 'ThyInputCount'
+                },
+                {
+                    replace: 'ThyInputGroupComponent',
+                    replaceWith: 'ThyInputGroup'
+                },
+                {
+                    replace: 'ThyInputSearchComponent',
+                    replaceWith: 'ThyInputSearch'
+                },
+                {
+                    replace: 'ThyInputComponent',
+                    replaceWith: 'ThyInput'
+                },
+                {
+                    replace: 'ThyInputNumberComponent',
+                    replaceWith: 'ThyInputNumber'
+                },
+                {
+                    replace: 'ThyContentMainComponent',
+                    replaceWith: 'ThyContentMain'
+                },
+                {
+                    replace: 'ThyContentSectionComponent',
+                    replaceWith: 'ThyContentSection'
+                },
+                {
+                    replace: 'ThyContentComponent',
+                    replaceWith: 'ThyContent'
+                },
+                {
+                    replace: 'ThyHeaderComponent',
+                    replaceWith: 'ThyHeader'
+                },
+                {
+                    replace: 'ThyLayoutComponent',
+                    replaceWith: 'ThyLayout'
+                },
+                {
+                    replace: 'ThySidebarContentComponent',
+                    replaceWith: 'ThySidebarContent'
+                },
+                {
+                    replace: 'ThySidebarFooterComponent',
+                    replaceWith: 'ThySidebarFooter'
+                },
+                {
+                    replace: 'ThySidebarHeaderComponent',
+                    replaceWith: 'ThySidebarHeader'
+                },
+                {
+                    replace: 'ThySidebarComponent',
+                    replaceWith: 'ThySidebar'
+                },
+                {
+                    replace: 'ThyListItemMetaComponent',
+                    replaceWith: 'ThyListItemMeta'
+                },
+                {
+                    replace: 'ThyListItemComponent',
+                    replaceWith: 'ThyListItem'
+                },
+                {
+                    replace: 'ThyListComponent',
+                    replaceWith: 'ThyList'
+                },
+                {
+                    replace: 'ThyLoadingComponent',
+                    replaceWith: 'ThyLoading'
+                },
+                {
+                    replace: 'ThyMenuComponent',
+                    replaceWith: 'ThyMenu'
+                },
+                {
+                    replace: 'ThyMessageContainerComponent',
+                    replaceWith: 'ThyMessageContainer'
+                },
+                {
+                    replace: 'ThyMessageComponent',
+                    replaceWith: 'ThyMessage'
+                },
+                {
+                    replace: 'ThyNavComponent',
+                    replaceWith: 'ThyNav'
+                },
+                {
+                    replace: 'ThyNotifyContainerComponent',
+                    replaceWith: 'ThyNotifyContainer'
+                },
+                {
+                    replace: 'ThyNotifyComponent',
+                    replaceWith: 'ThyNotify'
+                },
+                {
+                    replace: 'ThyPaginationComponent',
+                    replaceWith: 'ThyPagination'
+                },
+                {
+                    replace: 'ThyPopoverContainerComponent',
+                    replaceWith: 'ThyPopoverContainer'
+                },
+                {
+                    replace: 'ThyProgressCircleComponent',
+                    replaceWith: 'ThyProgressCircle'
+                },
+                {
+                    replace: 'ThyProgressStripComponent',
+                    replaceWith: 'ThyProgressStrip'
+                },
+                {
+                    replace: 'ThyProgressComponent',
+                    replaceWith: 'ThyProgress'
+                },
+                {
+                    replace: 'ThyPropertiesComponent',
+                    replaceWith: 'ThyProperties'
+                },
+                {
+                    replace: 'ThyPropertyItemComponent',
+                    replaceWith: 'ThyPropertyItem'
+                },
+                {
+                    replace: 'ThyPropertyOperationComponent',
+                    replaceWith: 'ThyPropertyOperation'
+                },
+                {
+                    replace: 'ThyRadioComponent',
+                    replaceWith: 'ThyRadio'
+                },
+                {
+                    replace: 'ThyRateItemComponent',
+                    replaceWith: 'ThyRateItem'
+                },
+                {
+                    replace: 'ThyRateComponent',
+                    replaceWith: 'ThyRate'
+                },
+                {
+                    replace: 'ThyResizeHandleComponent',
+                    replaceWith: 'ThyResizeHandle'
+                },
+                {
+                    replace: 'ThyResizeHandlesComponent',
+                    replaceWith: 'ThyResizeHandles'
+                },
+                {
+                    replace: 'ThyResultComponent',
+                    replaceWith: 'ThyResult'
+                },
+                {
+                    replace: 'ThySegmentItemComponent',
+                    replaceWith: 'ThySegmentItem'
+                },
+                {
+                    replace: 'ThySegmentComponent',
+                    replaceWith: 'ThySegment'
+                },
+                {
+                    replace: 'ThySelectComponent',
+                    replaceWith: 'ThySelect'
+                },
+                {
+                    replace: 'ThySkeletonCircleComponent',
+                    replaceWith: 'ThySkeletonCircle'
+                },
+                {
+                    replace: 'ThySkeletonRectangleComponent',
+                    replaceWith: 'ThySkeletonRectangle'
+                },
+                {
+                    replace: 'ThySkeletonComponent',
+                    replaceWith: 'ThySkeleton'
+                },
+                {
+                    replace: 'ThySlideContainerComponent',
+                    replaceWith: 'ThySlideContainer'
+                },
+                {
+                    replace: 'ThySliderComponent',
+                    replaceWith: 'ThySlider'
+                },
+                {
+                    replace: 'ThySpaceComponent',
+                    replaceWith: 'ThySpace'
+                },
+                {
+                    replace: 'ThyStatisticComponent',
+                    replaceWith: 'ThyStatistic'
+                },
+                {
+                    replace: 'ThyStepHeaderComponent',
+                    replaceWith: 'ThyStepHeader'
+                },
+                {
+                    replace: 'ThyStepComponent',
+                    replaceWith: 'ThyStep'
+                },
+                {
+                    replace: 'ThyStepperComponent',
+                    replaceWith: 'ThyStepper'
+                },
+                {
+                    replace: 'ThyStrengthComponent',
+                    replaceWith: 'ThyStrength'
+                },
+                {
+                    replace: 'ThySwitchComponent',
+                    replaceWith: 'ThySwitch'
+                },
+                {
+                    replace: 'ThyTableSkeletonComponent',
+                    replaceWith: 'ThyTableSkeleton'
+                },
+                {
+                    replace: 'ThyTableComponent',
+                    replaceWith: 'ThyTable'
+                },
+                {
+                    replace: 'ThyTabContentComponent',
+                    replaceWith: 'ThyTabContent'
+                },
+                {
+                    replace: 'ThyTabComponent',
+                    replaceWith: 'ThyTab'
+                },
+                {
+                    replace: 'ThyTabsComponent',
+                    replaceWith: 'ThyTabs'
+                },
+                {
+                    replace: 'ThyTagComponent',
+                    replaceWith: 'ThyTag'
+                },
+                {
+                    replace: 'ThyTagsComponent',
+                    replaceWith: 'ThyTags'
+                },
+                {
+                    replace: 'ThyTimePanelComponent',
+                    replaceWith: 'ThyTimePanel'
+                },
+                {
+                    replace: 'ThyTimePickerComponent',
+                    replaceWith: 'ThyTimePicker'
+                },
+                {
+                    replace: 'ThyTimelineItemComponent',
+                    replaceWith: 'ThyTimelineItem'
+                },
+                {
+                    replace: 'ThyTimelineComponent',
+                    replaceWith: 'ThyTimeline'
+                },
+                {
+                    replace: 'ThyTooltipComponent',
+                    replaceWith: 'ThyTooltip'
+                },
+                {
+                    replace: 'ThyTransferListComponent',
+                    replaceWith: 'ThyTransferList'
+                },
+                {
+                    replace: 'ThyTransferComponent',
+                    replaceWith: 'ThyTransfer'
+                },
+                {
+                    replace: 'ThyTreeComponent',
+                    replaceWith: 'ThyTree'
+                },
+                {
+                    replace: 'ThyTreeSelectComponent',
+                    replaceWith: 'ThyTreeSelect'
+                },
+                {
+                    replace: 'ThyTreeSelectNodesComponent',
+                    replaceWith: 'ThyTreeSelectNodes'
+                },
+                {
+                    replace: 'ThyFileSelectComponent',
+                    replaceWith: 'ThyFileSelect'
+                },
+                {
+                    replace: 'ThyVoteComponent',
+                    replaceWith: 'ThyVote'
+                },
+                {
+                    replace: 'ThyAutocompleteContainerComponent',
+                    replaceWith: 'ThyAutocompleteContainer'
+                },
+                {
+                    replace: 'ThyAvatarListComponent',
+                    replaceWith: 'ThyAvatarList'
+                },
+                {
+                    replace: 'OptionalDateRangesComponent',
+                    replaceWith: 'OptionalDateRanges'
+                },
+                {
+                    replace: 'DialogBodyComponent',
+                    replaceWith: 'DialogBody'
+                },
+                {
+                    replace: 'ThyConfirmComponent',
+                    replaceWith: 'ThyConfirm'
+                },
+                {
+                    replace: 'DialogFooterComponent',
+                    replaceWith: 'DialogFooter'
+                },
+                {
+                    replace: 'DialogHeaderComponent',
+                    replaceWith: 'DialogHeader'
+                },
+                {
+                    replace: 'ThyFormGroupErrorComponent',
+                    replaceWith: 'ThyFormGroupError'
+                },
+                {
+                    replace: 'ThyFormGroupFooterComponent',
+                    replaceWith: 'ThyFormGroupFooter'
+                },
+                {
+                    replace: 'ThyGuiderHintComponent',
+                    replaceWith: 'ThyGuiderHint'
+                },
+                {
+                    replace: 'ThyImagePreviewComponent',
+                    replaceWith: 'ThyImagePreview'
+                },
+                {
+                    replace: 'ThySelectionListComponent',
+                    replaceWith: 'ThySelectionList'
+                },
+                {
+                    replace: 'ThyMentionSuggestionsComponent',
+                    replaceWith: 'ThyMentionSuggestions'
+                },
+                {
+                    replace: 'ThyMenuDividerComponent',
+                    replaceWith: 'ThyMenuDivider'
+                },
+                {
+                    replace: 'ThyMenuGroupComponent',
+                    replaceWith: 'ThyMenuGroup'
+                },
+                {
+                    replace: 'ThyMenuItemComponent',
+                    replaceWith: 'ThyMenuItem'
+                },
+                {
+                    replace: 'ThyIconNavLinkComponent',
+                    replaceWith: 'ThyIconNavLink'
+                },
+                {
+                    replace: 'ThyIconNavComponent',
+                    replaceWith: 'ThyIconNav'
+                },
+                {
+                    replace: 'ThyPopoverBodyComponent',
+                    replaceWith: 'ThyPopoverBody'
+                },
+                {
+                    replace: 'ThyPopoverHeaderComponent',
+                    replaceWith: 'ThyPopoverHeader'
+                },
+                {
+                    replace: 'ThyPropertyOperationGroupComponent',
+                    replaceWith: 'ThyPropertyOperationGroup'
+                },
+                {
+                    replace: 'ThyRadioButtonComponent',
+                    replaceWith: 'ThyRadioButton'
+                },
+                {
+                    replace: 'ThyRadioGroupComponent',
+                    replaceWith: 'ThyRadioGroup'
+                },
+                {
+                    replace: 'ThySelectCustomComponent',
+                    replaceWith: 'ThySelectCustom'
+                },
+                {
+                    replace: 'ThyOptionGroupComponent',
+                    replaceWith: 'ThyOptionGroup'
+                },
+                {
+                    replace: 'ThyOptionComponent',
+                    replaceWith: 'ThyOption'
+                },
+                {
+                    replace: 'ThyOptionsContainerComponent',
+                    replaceWith: 'ThyOptionsContainer'
+                },
+                {
+                    replace: 'ThySkeletonBulletListComponent',
+                    replaceWith: 'ThySkeletonBulletList'
+                },
+                {
+                    replace: 'ThySkeletonListComponent',
+                    replaceWith: 'ThySkeletonList'
+                },
+                {
+                    replace: 'ThySkeletonParagraphComponent',
+                    replaceWith: 'ThySkeletonParagraph'
+                },
+                {
+                    replace: 'ThySlideBodySectionComponent',
+                    replaceWith: 'ThySlideBodySection'
+                },
+                {
+                    replace: 'ThySlideBodyComponent',
+                    replaceWith: 'ThySlideBody'
+                },
+                {
+                    replace: 'ThySlideFooterComponent',
+                    replaceWith: 'ThySlideFooter'
+                },
+                {
+                    replace: 'ThySlideHeaderComponent',
+                    replaceWith: 'ThySlideHeader'
+                },
+                {
+                    replace: 'ThySlideLayoutComponent',
+                    replaceWith: 'ThySlideLayout'
+                },
+                {
+                    replace: 'ThyInnerTimePickerComponent',
+                    replaceWith: 'ThyInnerTimePicker'
+                },
+                {
+                    replace: 'ThyTextComponent',
+                    replaceWith: 'ThyText'
+                },
+                {
+                    replace: 'ThyAlphaComponent',
+                    replaceWith: 'ThyAlpha'
+                },
+                {
+                    replace: 'ThyHueComponent',
+                    replaceWith: 'ThyHue'
+                },
+                {
+                    replace: 'ThyIndicatorComponent',
+                    replaceWith: 'ThyIndicator'
+                },
+                {
+                    replace: 'ThyColorInputsComponent',
+                    replaceWith: 'ThyColorInputs'
+                },
+                {
+                    replace: 'ThySaturationComponent',
+                    replaceWith: 'ThySaturation'
+                },
+                {
+                    replace: 'CalendarFooterComponent',
+                    replaceWith: 'CalendarFooter'
+                },
+                {
+                    replace: 'DateHeaderComponent',
+                    replaceWith: 'DateHeader'
+                },
+                {
+                    replace: 'DateTableCellComponent',
+                    replaceWith: 'DateTableCell'
+                },
+                {
+                    replace: 'DateTableComponent',
+                    replaceWith: 'DateTable'
+                },
+                {
+                    replace: 'DateCarouselComponent',
+                    replaceWith: 'DateCarousel'
+                },
+                {
+                    replace: 'DecadeHeaderComponent',
+                    replaceWith: 'DecadeHeader'
+                },
+                {
+                    replace: 'DecadeTableComponent',
+                    replaceWith: 'DecadeTable'
+                },
+                {
+                    replace: 'MonthHeaderComponent',
+                    replaceWith: 'MonthHeader'
+                },
+                {
+                    replace: 'MonthTableComponent',
+                    replaceWith: 'MonthTable'
+                },
+                {
+                    replace: 'DatePopupComponent',
+                    replaceWith: 'DatePopup'
+                },
+                {
+                    replace: 'InnerPopupComponent',
+                    replaceWith: 'InnerPopup'
+                },
+                {
+                    replace: 'QuarterTableComponent',
+                    replaceWith: 'QuarterTable'
+                },
+                {
+                    replace: 'YearHeaderComponent',
+                    replaceWith: 'YearHeader'
+                },
+                {
+                    replace: 'YearTableComponent',
+                    replaceWith: 'YearTable'
+                },
+                {
+                    replace: 'ThyMenuItemActionComponent',
+                    replaceWith: 'ThyMenuItemAction'
+                },
+                {
+                    replace: 'ThyMenuItemIconComponent',
+                    replaceWith: 'ThyMenuItemIcon'
+                },
+                {
+                    replace: 'ThyMenuItemNameComponent',
+                    replaceWith: 'ThyMenuItemName'
+                },
+                {
+                    replace: 'ThySelectOptionGroupComponent',
+                    replaceWith: 'ThySelectOptionGroup'
+                },
+                {
+                    replace: 'ThyListOptionComponent',
+                    replaceWith: 'ThyListOption'
+                },
+                {
+                    replace: 'ThySelectControlComponent',
+                    replaceWith: 'ThySelectControl'
                 }
             ]
         }

--- a/src/action/action.component.ts
+++ b/src/action/action.component.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/core';
 import { InputBoolean } from 'ngx-tethys/core';
 import { useHostRenderer } from '@tethys/cdk/dom';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf } from '@angular/common';
 import { Subscription, timer } from 'rxjs';
 
@@ -55,9 +55,9 @@ const defaultFeedbackOptions: Record<ThyActionFeedback, ThyActionFeedbackOptions
         '[class.disabled]': 'thyDisabled'
     },
     standalone: true,
-    imports: [NgIf, ThyIconComponent]
+    imports: [NgIf, ThyIcon]
 })
-export class ThyActionComponent implements OnInit, AfterViewInit, OnChanges, OnDestroy {
+export class ThyAction implements OnInit, AfterViewInit, OnChanges, OnDestroy {
     icon: string;
 
     feedback: ThyActionFeedback = null;

--- a/src/action/action.module.ts
+++ b/src/action/action.module.ts
@@ -2,11 +2,11 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { ThyIconModule } from 'ngx-tethys/icon';
-import { ThyActionComponent } from './action.component';
-import { ThyActionsComponent } from './actions.component';
+import { ThyAction } from './action.component';
+import { ThyActions } from './actions.component';
 
 @NgModule({
-    imports: [CommonModule, ThyIconModule, ThyActionComponent, ThyActionsComponent],
-    exports: [ThyActionComponent, ThyActionsComponent]
+    imports: [CommonModule, ThyIconModule, ThyAction, ThyActions],
+    exports: [ThyAction, ThyActions]
 })
 export class ThyActionModule {}

--- a/src/action/actions.component.ts
+++ b/src/action/actions.component.ts
@@ -10,7 +10,7 @@ import {
     SimpleChanges
 } from '@angular/core';
 import { ThySpacingSize, getNumericSize } from 'ngx-tethys/core';
-import { ThyActionComponent } from './action.component';
+import { ThyAction } from './action.component';
 
 /**
  * Actions 组件
@@ -25,8 +25,8 @@ import { ThyActionComponent } from './action.component';
     },
     standalone: true
 })
-export class ThyActionsComponent implements OnInit, AfterContentInit, OnChanges {
-    @ContentChildren(ThyActionComponent) actions: QueryList<ThyActionComponent>;
+export class ThyActions implements OnInit, AfterContentInit, OnChanges {
+    @ContentChildren(ThyAction) actions: QueryList<ThyAction>;
 
     /**
      * 大小，支持 `zero` | `xxs` | `xs` | `sm` | `md` | `lg` | `xlg` 和自定义数字大小
@@ -45,14 +45,14 @@ export class ThyActionsComponent implements OnInit, AfterContentInit, OnChanges 
     }
 
     ngAfterContentInit(): void {
-        this.actions.changes.subscribe((actions: ThyActionComponent[]) => {
+        this.actions.changes.subscribe((actions: ThyAction[]) => {
             this.setActionsSize(actions);
         });
         this.setActionsSize(this.actions.toArray());
     }
 
-    private setActionsSize(actions: ThyActionComponent[]) {
-        actions.forEach((action: ThyActionComponent, index) => {
+    private setActionsSize(actions: ThyAction[]) {
+        actions.forEach((action: ThyAction, index) => {
             // can't set marginRight value for last item
             if (index !== actions.length - 1) {
                 action.setMarginRight(getNumericSize(this.thySize, 'md') + 'px');

--- a/src/action/test/actions.spec.ts
+++ b/src/action/test/actions.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { ThyActionModule } from '../action.module';
 import { injectDefaultSvgIconSet } from 'ngx-tethys/testing';
 import { By } from '@angular/platform-browser';
-import { ThyActionsComponent } from '../actions.component';
+import { ThyActions } from '../actions.component';
 
 @Component({
     selector: 'thy-test-actions-basic',
@@ -37,7 +37,7 @@ describe('thy-actions', () => {
         injectDefaultSvgIconSet();
         fixture = TestBed.createComponent(ThyActionsTestBasicComponent);
         fixture.detectChanges();
-        actionsDebugElement = fixture.debugElement.query(By.directive(ThyActionsComponent));
+        actionsDebugElement = fixture.debugElement.query(By.directive(ThyActions));
     });
 
     function assertActionsExpected(actions: NodeListOf<HTMLElement>, marginRight: string, message: string) {

--- a/src/affix/affix.component.ts
+++ b/src/affix/affix.component.ts
@@ -45,7 +45,7 @@ const THY_AFFIX_DEFAULT_SCROLL_TIME = 20;
     encapsulation: ViewEncapsulation.None,
     standalone: true
 })
-export class ThyAffixComponent implements AfterViewInit, OnChanges, OnDestroy {
+export class ThyAffix implements AfterViewInit, OnChanges, OnDestroy {
     @ViewChild('fixedElement', { static: true }) private fixedElement!: ElementRef<HTMLDivElement>;
 
     /**

--- a/src/affix/affix.module.ts
+++ b/src/affix/affix.module.ts
@@ -2,10 +2,10 @@ import { PlatformModule } from '@angular/cdk/platform';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ThyAffixComponent } from './affix.component';
+import { ThyAffix } from './affix.component';
 
 @NgModule({
-    exports: [ThyAffixComponent],
-    imports: [CommonModule, PlatformModule, ThyAffixComponent]
+    exports: [ThyAffix],
+    imports: [CommonModule, PlatformModule, ThyAffix]
 })
 export class ThyAffixModule {}

--- a/src/alert/alert.component.ts
+++ b/src/alert/alert.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, OnInit, ContentChild, TemplateRef, OnChanges, ChangeDetectionStrategy, SimpleChanges } from '@angular/core';
 import { isString } from 'ngx-tethys/util';
 import { useHostRenderer } from '@tethys/cdk/dom';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgTemplateOutlet } from '@angular/common';
 import { InputBoolean } from 'ngx-tethys/core';
 
@@ -46,9 +46,9 @@ const typeIconsMap: Record<string, string> = {
         '[class.thy-alert-hidden]': 'hidden'
     },
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgTemplateOutlet]
+    imports: [NgIf, ThyIcon, NgTemplateOutlet]
 })
-export class ThyAlertComponent implements OnInit, OnChanges {
+export class ThyAlert implements OnInit, OnChanges {
     private hidden = false;
 
     private showIcon = true;

--- a/src/alert/alert.module.ts
+++ b/src/alert/alert.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyAlertComponent } from './alert.component';
+import { ThyAlert } from './alert.component';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyAlertActionItemDirective } from './alert.directive';
 
 @NgModule({
-    imports: [CommonModule, ThyIconModule, ThyAlertComponent, ThyAlertActionItemDirective],
-    exports: [ThyAlertComponent, ThyAlertActionItemDirective]
+    imports: [CommonModule, ThyIconModule, ThyAlert, ThyAlertActionItemDirective],
+    exports: [ThyAlert, ThyAlertActionItemDirective]
 })
 export class ThyAlertModule {}

--- a/src/alert/test/alert.spec.ts
+++ b/src/alert/test/alert.spec.ts
@@ -2,7 +2,7 @@ import { fakeAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ThyAlertModule } from '../alert.module';
 import { NgModule, Component, ViewChild, TemplateRef, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { ThyAlertComponent } from '../alert.component';
+import { ThyAlert } from '../alert.component';
 import { bypassSanitizeProvider, injectDefaultSvgIconSet } from 'ngx-tethys/testing';
 
 describe('ThyAlert', () => {
@@ -25,7 +25,7 @@ describe('ThyAlert', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(ThyDemoAlertComponent);
             testComponent = fixture.debugElement.componentInstance;
-            alertComponent = fixture.debugElement.query(By.directive(ThyAlertComponent));
+            alertComponent = fixture.debugElement.query(By.directive(ThyAlert));
             alertElement = alertComponent.nativeElement;
             alertContentElement = alertComponent.nativeElement.children[0];
         });

--- a/src/anchor/anchor-link.component.ts
+++ b/src/anchor/anchor-link.component.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/core';
 import { useHostRenderer } from '@tethys/cdk/dom';
 
-import { ThyAnchorComponent } from './anchor.component';
+import { ThyAnchor } from './anchor.component';
 import { NgIf } from '@angular/common';
 
 /**
@@ -35,7 +35,7 @@ import { NgIf } from '@angular/common';
     standalone: true,
     imports: [NgIf]
 })
-export class ThyAnchorLinkComponent implements OnInit, OnDestroy {
+export class ThyAnchorLink implements OnInit, OnDestroy {
     title: string | null = '';
 
     titleTemplate?: TemplateRef<any>;
@@ -64,7 +64,7 @@ export class ThyAnchorLinkComponent implements OnInit, OnDestroy {
 
     @ViewChild('linkTitle', { static: true }) linkTitle!: ElementRef<HTMLAnchorElement>;
 
-    constructor(public elementRef: ElementRef, private anchorComponent: ThyAnchorComponent, private platform: Platform) {
+    constructor(public elementRef: ElementRef, private anchorComponent: ThyAnchor, private platform: Platform) {
         this.hostRenderer.addClass('thy-anchor-link');
         if (elementRef.nativeElement.tagName.toLowerCase() === 'thy-link') {
             console.warn(`'thy-link' and 'thyLink' are deprecated, please use 'thy-anchor-link' and 'thyAnchorLink' instead.`);

--- a/src/anchor/anchor.component.ts
+++ b/src/anchor/anchor.component.ts
@@ -21,13 +21,13 @@ import { Subject, fromEvent } from 'rxjs';
 import { takeUntil, throttleTime } from 'rxjs/operators';
 
 import { DOCUMENT, NgClass, NgIf, NgStyle, NgTemplateOutlet } from '@angular/common';
-import { ThyAffixComponent } from 'ngx-tethys/affix';
+import { ThyAffix } from 'ngx-tethys/affix';
 import { InputBoolean, InputNumber, ThyScrollService } from 'ngx-tethys/core';
 import { getOffset } from 'ngx-tethys/util';
-import { ThyAnchorLinkComponent } from './anchor-link.component';
+import { ThyAnchorLink } from './anchor-link.component';
 
 interface Section {
-    linkComponent: ThyAnchorLinkComponent;
+    linkComponent: ThyAnchorLink;
     top: number;
 }
 
@@ -62,9 +62,9 @@ const sharpMatcherRegx = /#([^#]+)$/;
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgIf, ThyAffixComponent, NgTemplateOutlet, NgStyle, NgClass]
+    imports: [NgIf, ThyAffix, NgTemplateOutlet, NgStyle, NgClass]
 })
-export class ThyAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
+export class ThyAnchor implements OnDestroy, AfterViewInit, OnChanges {
     @ViewChild('ink') private ink!: ElementRef;
 
     /**
@@ -101,12 +101,12 @@ export class ThyAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
     /**
      * 点击项触发
      */
-    @Output() readonly thyClick = new EventEmitter<ThyAnchorLinkComponent>();
+    @Output() readonly thyClick = new EventEmitter<ThyAnchorLink>();
 
     /**
      * 滚动到某锚点时触发
      */
-    @Output() readonly thyScroll = new EventEmitter<ThyAnchorLinkComponent>();
+    @Output() readonly thyScroll = new EventEmitter<ThyAnchorLink>();
 
     visible = false;
 
@@ -114,7 +114,7 @@ export class ThyAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
 
     container?: HTMLElement | Window;
 
-    private links: ThyAnchorLinkComponent[] = [];
+    private links: ThyAnchorLink[] = [];
 
     private animating = false;
 
@@ -132,11 +132,11 @@ export class ThyAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
         private elementRef: ElementRef
     ) {}
 
-    registerLink(link: ThyAnchorLinkComponent): void {
+    registerLink(link: ThyAnchorLink): void {
         this.links.push(link);
     }
 
-    unregisterLink(link: ThyAnchorLinkComponent): void {
+    unregisterLink(link: ThyAnchorLink): void {
         this.links.splice(this.links.indexOf(link), 1);
     }
 
@@ -225,7 +225,7 @@ export class ThyAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
         });
     }
 
-    private handleActive(linkComponent: ThyAnchorLinkComponent): void {
+    private handleActive(linkComponent: ThyAnchorLink): void {
         this.clearActive();
         linkComponent.setActive();
         const linkNode = linkComponent.getLinkTitleElement();
@@ -252,7 +252,7 @@ export class ThyAnchorComponent implements OnDestroy, AfterViewInit, OnChanges {
         }
     }
 
-    handleScrollTo(linkComponent: ThyAnchorLinkComponent): void {
+    handleScrollTo(linkComponent: ThyAnchorLink): void {
         const container: HTMLElement = this.container instanceof HTMLElement ? this.container : this.document;
         const linkElement: HTMLElement = container.querySelector(linkComponent.thyHref);
         if (!linkElement) {

--- a/src/anchor/anchor.module.ts
+++ b/src/anchor/anchor.module.ts
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { PlatformModule } from '@angular/cdk/platform';
-import { ThyAnchorComponent } from './anchor.component';
-import { ThyAnchorLinkComponent } from './anchor-link.component';
+import { ThyAnchor } from './anchor.component';
+import { ThyAnchorLink } from './anchor-link.component';
 import { ThyAffixModule } from 'ngx-tethys/affix';
 
 @NgModule({
-    exports: [ThyAnchorComponent, ThyAnchorLinkComponent],
-    imports: [CommonModule, PlatformModule, ThyAffixModule, ThyAnchorComponent, ThyAnchorLinkComponent]
+    exports: [ThyAnchor, ThyAnchorLink],
+    imports: [CommonModule, PlatformModule, ThyAffixModule, ThyAnchor, ThyAnchorLink]
 })
 export class ThyAnchorModule {}

--- a/src/anchor/test/anchor.component.spec.ts
+++ b/src/anchor/test/anchor.component.spec.ts
@@ -5,15 +5,15 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { dispatchFakeEvent } from 'ngx-tethys/testing';
 import { ThyScrollService } from '../../core/scroll';
 import { getOffset } from '../../util/dom';
-import { ThyAnchorLinkComponent } from '../anchor-link.component';
-import { ThyAnchorComponent } from '../anchor.component';
+import { ThyAnchorLink } from '../anchor-link.component';
+import { ThyAnchor } from '../anchor.component';
 import { ThyAnchorModule } from '../anchor.module';
 
 describe('thy-anchor', () => {
     describe('default', () => {
         let fixture: ComponentFixture<TestAnchorComponent>;
         let debugElement: DebugElement;
-        let component: ThyAnchorComponent;
+        let component: ThyAnchor;
         let scrollService: ThyScrollService;
         const id = 'components-anchor-demo-basic';
         beforeEach(() => {
@@ -75,7 +75,7 @@ describe('thy-anchor', () => {
     describe('thyContainer', () => {
         let fixture: ComponentFixture<TestContainerAnchorComponent>;
         let debugElement: DebugElement;
-        let component: ThyAnchorComponent;
+        let component: ThyAnchor;
         let scrollService: ThyScrollService;
         const id = 'components-anchor-demo-basic';
         const containerClass = '.demo-card';
@@ -107,7 +107,7 @@ describe('thy-anchor', () => {
     describe('thyAnchorLink', () => {
         let fixture: ComponentFixture<TestThyAnchorLinkComponent>;
         let debugElement: DebugElement;
-        let component: ThyAnchorComponent;
+        let component: ThyAnchor;
 
         beforeEach(() => {
             TestBed.configureTestingModule({
@@ -124,7 +124,7 @@ describe('thy-anchor', () => {
 
         it('should set link title', () => {
             const comp = fixture.componentInstance;
-            const anchorLinkComponent = fixture.debugElement.query(By.directive(ThyAnchorLinkComponent)).componentInstance;
+            const anchorLinkComponent = fixture.debugElement.query(By.directive(ThyAnchorLink)).componentInstance;
             comp.title = 'Basic demo title';
             fixture.detectChanges();
             expect(anchorLinkComponent.title).toEqual(comp.title);
@@ -134,7 +134,7 @@ describe('thy-anchor', () => {
     describe('horizontal anchor', () => {
         let fixture: ComponentFixture<TestAnchorComponent>;
         let debugElement: DebugElement;
-        let component: ThyAnchorComponent;
+        let component: ThyAnchor;
         let scrollService: ThyScrollService;
         const id = 'components-anchor-demo-basic';
 
@@ -237,8 +237,8 @@ describe('thy-anchor', () => {
 class TestAnchorComponent implements OnInit {
     demos: number[] = [];
 
-    @ViewChild(ThyAnchorComponent, { static: true })
-    thyAnchorComponent: ThyAnchorComponent;
+    @ViewChild(ThyAnchor, { static: true })
+    thyAnchorComponent: ThyAnchor;
 
     thyOffsetTop = 60;
 
@@ -270,8 +270,8 @@ class TestAnchorComponent implements OnInit {
 class TestContainerAnchorComponent implements OnInit {
     demos: number[] = [];
 
-    @ViewChild(ThyAnchorComponent, { static: true })
-    thyAnchorComponent: ThyAnchorComponent;
+    @ViewChild(ThyAnchor, { static: true })
+    thyAnchorComponent: ThyAnchor;
 
     thyOffsetTop = 60;
 
@@ -303,8 +303,8 @@ class TestContainerAnchorComponent implements OnInit {
     `
 })
 class TestThyAnchorLinkComponent implements OnInit {
-    @ViewChild(ThyAnchorComponent, { static: true })
-    thyAnchorComponent: ThyAnchorComponent;
+    @ViewChild(ThyAnchor, { static: true })
+    thyAnchorComponent: ThyAnchor;
 
     @ViewChild('titleTemplate', { static: true })
     titleTemplate: TemplateRef<void>;

--- a/src/arrow-switcher/arrow-switcher.component.ts
+++ b/src/arrow-switcher/arrow-switcher.component.ts
@@ -10,10 +10,10 @@ import {
     forwardRef
 } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { ThyButtonIconComponent } from 'ngx-tethys/button';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyButtonIcon } from 'ngx-tethys/button';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { ThyTooltipDirective } from 'ngx-tethys/tooltip';
-import { ThyActionComponent } from 'ngx-tethys/action';
+import { ThyAction } from 'ngx-tethys/action';
 import { NgIf } from '@angular/common';
 import { InputNumber } from 'ngx-tethys/core';
 
@@ -35,14 +35,14 @@ export interface ThyArrowSwitcherEvent {
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThyArrowSwitcherComponent),
+            useExisting: forwardRef(() => ThyArrowSwitcher),
             multi: true
         }
     ],
     standalone: true,
-    imports: [NgIf, ThyActionComponent, ThyTooltipDirective, ThyIconComponent, ThyButtonIconComponent]
+    imports: [NgIf, ThyAction, ThyTooltipDirective, ThyIcon, ThyButtonIcon]
 })
-export class ThyArrowSwitcherComponent implements OnInit, ControlValueAccessor {
+export class ThyArrowSwitcher implements OnInit, ControlValueAccessor {
     @HostBinding('class.thy-arrow-switcher') _isArrowSwitcher = true;
 
     @HostBinding('class.thy-arrow-switcher-small') _isSmallSize = false;

--- a/src/arrow-switcher/module.ts
+++ b/src/arrow-switcher/module.ts
@@ -2,12 +2,12 @@ import { ThyTooltipModule } from 'ngx-tethys/tooltip';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ThyButtonModule } from 'ngx-tethys/button';
-import { ThyArrowSwitcherComponent } from './arrow-switcher.component';
+import { ThyArrowSwitcher } from './arrow-switcher.component';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyActionModule } from 'ngx-tethys/action';
 
 @NgModule({
-    imports: [CommonModule, ThyButtonModule, ThyIconModule, ThyActionModule, ThyTooltipModule, ThyArrowSwitcherComponent],
-    exports: [ThyArrowSwitcherComponent]
+    imports: [CommonModule, ThyButtonModule, ThyIconModule, ThyActionModule, ThyTooltipModule, ThyArrowSwitcher],
+    exports: [ThyArrowSwitcher]
 })
 export class ThyArrowSwitcherModule {}

--- a/src/arrow-switcher/test/arrow-switcher.spec.ts
+++ b/src/arrow-switcher/test/arrow-switcher.spec.ts
@@ -2,7 +2,7 @@ import { fakeAsync, ComponentFixture, TestBed, flush } from '@angular/core/testi
 import { ThyArrowSwitcherModule } from '../module';
 import { NgModule, Component, DebugElement, ViewChild } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { ThyArrowSwitcherComponent } from '../arrow-switcher.component';
+import { ThyArrowSwitcher } from '../arrow-switcher.component';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ThyTooltipDirective } from 'ngx-tethys/tooltip';
@@ -24,7 +24,7 @@ describe('ThyArrowSwitcher', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyDemoArrowSwitcherComponent);
         testComponent = fixture.debugElement.componentInstance;
-        arrowSwitcherComponent = fixture.debugElement.query(By.directive(ThyArrowSwitcherComponent));
+        arrowSwitcherComponent = fixture.debugElement.query(By.directive(ThyArrowSwitcher));
     });
 
     it('should create', () => {
@@ -136,7 +136,7 @@ class ThyDemoArrowSwitcherComponent {
     previousTooltip: string;
     nextTooltip: string;
 
-    @ViewChild('switcher', { static: true }) switcherComponent: ThyArrowSwitcherComponent;
+    @ViewChild('switcher', { static: true }) switcherComponent: ThyArrowSwitcher;
 
     previousClick() {}
 

--- a/src/autocomplete/autocomplete.component.ts
+++ b/src/autocomplete/autocomplete.component.ts
@@ -23,22 +23,22 @@ import { SelectionModel } from '@angular/cdk/collections';
 import {
     THY_OPTION_PARENT_COMPONENT,
     IThyOptionParentComponent,
-    ThyOptionComponent,
+    ThyOption,
     ThyOptionSelectionChangeEvent,
     ThyStopPropagationDirective
 } from 'ngx-tethys/shared';
 import { ActiveDescendantKeyManager } from '@angular/cdk/a11y';
 import { coerceBooleanProperty } from '@angular/cdk/coercion';
-import { ThyEmptyComponent } from 'ngx-tethys/empty';
+import { ThyEmpty } from 'ngx-tethys/empty';
 import { NgClass, NgIf } from '@angular/common';
 
 /** Event object that is emitted when an autocomplete option is activated. */
 export interface ThyAutocompleteActivatedEvent {
     /** Reference to the autocomplete panel that emitted the event. */
-    source: ThyAutocompleteComponent;
+    source: ThyAutocomplete;
 
     /** Option that was selected. */
-    option: ThyOptionComponent | null;
+    option: ThyOption | null;
 }
 
 const _MixinBase: Constructor<ThyUnsubscribe> & typeof MixinBase = mixinUnsubscribe(MixinBase);
@@ -54,13 +54,13 @@ const _MixinBase: Constructor<ThyUnsubscribe> & typeof MixinBase = mixinUnsubscr
     providers: [
         {
             provide: THY_OPTION_PARENT_COMPONENT,
-            useExisting: ThyAutocompleteComponent
+            useExisting: ThyAutocomplete
         }
     ],
     standalone: true,
-    imports: [ThyStopPropagationDirective, NgClass, NgIf, ThyEmptyComponent]
+    imports: [ThyStopPropagationDirective, NgClass, NgIf, ThyEmpty]
 })
-export class ThyAutocompleteComponent extends _MixinBase implements IThyOptionParentComponent, OnInit, AfterContentInit, OnDestroy {
+export class ThyAutocomplete extends _MixinBase implements IThyOptionParentComponent, OnInit, AfterContentInit, OnDestroy {
     dropDownClass: { [key: string]: boolean };
 
     isMultiple = false;
@@ -69,12 +69,12 @@ export class ThyAutocompleteComponent extends _MixinBase implements IThyOptionPa
 
     isEmptyOptions = false;
 
-    selectionModel: SelectionModel<ThyOptionComponent>;
+    selectionModel: SelectionModel<ThyOption>;
 
     isOpened = false;
 
     /** Manages active item in option list based on key events. */
-    keyManager: ActiveDescendantKeyManager<ThyOptionComponent>;
+    keyManager: ActiveDescendantKeyManager<ThyOption>;
 
     @ViewChild('contentTemplate', { static: true })
     contentTemplateRef: TemplateRef<any>;
@@ -86,7 +86,7 @@ export class ThyAutocompleteComponent extends _MixinBase implements IThyOptionPa
     /**
      * @private
      */
-    @ContentChildren(ThyOptionComponent, { descendants: true }) options: QueryList<ThyOptionComponent>;
+    @ContentChildren(ThyOption, { descendants: true }) options: QueryList<ThyOption>;
 
     readonly optionSelectionChanges: Observable<ThyOptionSelectionChangeEvent> = defer(() => {
         if (this.options) {
@@ -168,7 +168,7 @@ export class ThyAutocompleteComponent extends _MixinBase implements IThyOptionPa
 
     initKeyManager() {
         const changedOrDestroyed$ = merge(this.options.changes, this.ngUnsubscribe$);
-        this.keyManager = new ActiveDescendantKeyManager<ThyOptionComponent>(this.options).withWrap();
+        this.keyManager = new ActiveDescendantKeyManager<ThyOption>(this.options).withWrap();
         this.keyManager.change.pipe(takeUntil(changedOrDestroyed$)).subscribe(index => {
             this.thyOptionActivated.emit({ source: this, option: this.options.toArray()[index] || null });
         });
@@ -197,14 +197,14 @@ export class ThyAutocompleteComponent extends _MixinBase implements IThyOptionPa
         if (this.selectionModel) {
             this.selectionModel.clear();
         }
-        this.selectionModel = new SelectionModel<ThyOptionComponent>(this.isMultiple);
+        this.selectionModel = new SelectionModel<ThyOption>(this.isMultiple);
         this.selectionModel.changed.pipe(takeUntil(this.ngUnsubscribe$)).subscribe(event => {
             event.added.forEach(option => option.select());
             event.removed.forEach(option => option.deselect());
         });
     }
 
-    private onSelect(option: ThyOptionComponent, isUserInput: boolean) {
+    private onSelect(option: ThyOption, isUserInput: boolean) {
         const wasSelected = this.selectionModel.isSelected(option);
 
         if (option.thyValue == null && !this.isMultiple) {

--- a/src/autocomplete/autocomplete.trigger.directive.ts
+++ b/src/autocomplete/autocomplete.trigger.directive.ts
@@ -16,8 +16,8 @@ import { OverlayRef, Overlay } from '@angular/cdk/overlay';
 import { InputBoolean, InputNumber, ThyPlacement } from 'ngx-tethys/core';
 import { ThyAutocompleteService } from './overlay/autocomplete.service';
 import { ThyAutocompleteRef } from './overlay/autocomplete-ref';
-import { ThyAutocompleteComponent } from './autocomplete.component';
-import { ThyOptionComponent, ThyOptionSelectionChangeEvent } from 'ngx-tethys/shared';
+import { ThyAutocomplete } from './autocomplete.component';
+import { ThyOption, ThyOptionSelectionChangeEvent } from 'ngx-tethys/shared';
 import { DOCUMENT } from '@angular/common';
 import { Subject, Observable, merge, fromEvent, of, Subscription } from 'rxjs';
 import { ESCAPE, UP_ARROW, ENTER, DOWN_ARROW, TAB } from 'ngx-tethys/util';
@@ -43,13 +43,13 @@ import { warnDeprecation } from 'ngx-tethys/util';
 export class ThyAutocompleteTriggerDirective implements OnInit, OnDestroy {
     protected overlayRef: OverlayRef;
 
-    private autocompleteRef: ThyAutocompleteRef<ThyAutocompleteComponent>;
+    private autocompleteRef: ThyAutocompleteRef<ThyAutocomplete>;
 
     private readonly closeKeyEventStream = new Subject<void>();
 
     private closingActionsSubscription: Subscription;
 
-    private _autocompleteComponent: ThyAutocompleteComponent;
+    private _autocompleteComponent: ThyAutocomplete;
 
     @HostBinding(`class.thy-autocomplete-opened`) panelOpened = false;
 
@@ -59,7 +59,7 @@ export class ThyAutocompleteTriggerDirective implements OnInit, OnDestroy {
      * @deprecated
      */
     @Input('thyAutocompleteComponent')
-    set autocompleteComponent(data: ThyAutocompleteComponent) {
+    set autocompleteComponent(data: ThyAutocomplete) {
         if (typeof ngDevMode === 'undefined' || ngDevMode) {
             warnDeprecation(`The property thyAutocompleteComponent will be deprecated, please use thyAutocomplete instead.`);
         }
@@ -71,7 +71,7 @@ export class ThyAutocompleteTriggerDirective implements OnInit, OnDestroy {
      * @type thyAutocompleteComponent
      */
     @Input('thyAutocomplete')
-    set autocomplete(data: ThyAutocompleteComponent) {
+    set autocomplete(data: ThyAutocomplete) {
         this._autocompleteComponent = data;
     }
 
@@ -103,7 +103,7 @@ export class ThyAutocompleteTriggerDirective implements OnInit, OnDestroy {
      */
     @Input() @InputBoolean() thyIsFocusOpen = true;
 
-    get activeOption(): ThyOptionComponent | null {
+    get activeOption(): ThyOption | null {
         if (this.autocompleteComponent && this.autocompleteComponent.keyManager) {
             return this.autocompleteComponent.keyManager.activeItem;
         }

--- a/src/autocomplete/module.ts
+++ b/src/autocomplete/module.ts
@@ -8,9 +8,9 @@ import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyInputModule } from 'ngx-tethys/input';
 import { ThyLoadingModule } from 'ngx-tethys/loading';
 import { ThyOptionModule, ThySharedModule } from 'ngx-tethys/shared';
-import { ThyAutocompleteComponent } from './autocomplete.component';
+import { ThyAutocomplete } from './autocomplete.component';
 import { ThyAutocompleteTriggerDirective } from './autocomplete.trigger.directive';
-import { ThyAutocompleteContainerComponent } from './overlay/autocomplete-container.component';
+import { ThyAutocompleteContainer } from './overlay/autocomplete-container.component';
 import { THY_AUTOCOMPLETE_DEFAULT_CONFIG_PROVIDER } from './overlay/autocomplete.config';
 import { ThyAutocompleteService } from './overlay/autocomplete.service';
 
@@ -27,10 +27,10 @@ import { ThyAutocompleteService } from './overlay/autocomplete.service';
         ThyEmptyModule,
         ThyOptionModule,
         ThyAutocompleteTriggerDirective,
-        ThyAutocompleteComponent,
-        ThyAutocompleteContainerComponent
+        ThyAutocomplete,
+        ThyAutocompleteContainer
     ],
-    exports: [ThyAutocompleteTriggerDirective, ThyAutocompleteComponent, ThyAutocompleteContainerComponent, ThyOptionModule],
+    exports: [ThyAutocompleteTriggerDirective, ThyAutocomplete, ThyAutocompleteContainer, ThyOptionModule],
     providers: [THY_AUTOCOMPLETE_DEFAULT_CONFIG_PROVIDER, ThyAutocompleteService]
 })
 export class ThyAutocompleteModule {}

--- a/src/autocomplete/overlay/autocomplete-container.component.ts
+++ b/src/autocomplete/overlay/autocomplete-container.component.ts
@@ -29,7 +29,7 @@ import { autocompleteAbstractOverlayOptions } from './autocomplete.options';
     standalone: true,
     imports: [PortalModule, ThyPortalOutlet]
 })
-export class ThyAutocompleteContainerComponent extends ThyAbstractOverlayContainer implements AfterViewInit {
+export class ThyAutocompleteContainer extends ThyAbstractOverlayContainer implements AfterViewInit {
     @ViewChild(ThyPortalOutlet, { static: true })
     portalOutlet: ThyPortalOutlet;
 

--- a/src/autocomplete/overlay/autocomplete-ref.ts
+++ b/src/autocomplete/overlay/autocomplete-ref.ts
@@ -2,17 +2,17 @@ import { ThyAbstractInternalOverlayRef, ThyAbstractOverlayRef } from 'ngx-tethys
 
 import { OverlayRef } from '@angular/cdk/overlay';
 
-import { ThyAutocompleteContainerComponent } from './autocomplete-container.component';
+import { ThyAutocompleteContainer } from './autocomplete-container.component';
 import { ThyAutocompleteConfig } from './autocomplete.config';
 import { autocompleteAbstractOverlayOptions } from './autocomplete.options';
 
-export abstract class ThyAutocompleteRef<T, TResult = any> extends ThyAbstractOverlayRef<T, ThyAutocompleteContainerComponent, TResult> {}
+export abstract class ThyAutocompleteRef<T, TResult = any> extends ThyAbstractOverlayRef<T, ThyAutocompleteContainer, TResult> {}
 
 export class ThyInternalAutocompleteRef<T, TResult = any>
-    extends ThyAbstractInternalOverlayRef<T, ThyAutocompleteContainerComponent, TResult>
+    extends ThyAbstractInternalOverlayRef<T, ThyAutocompleteContainer, TResult>
     implements ThyAutocompleteRef<T, TResult>
 {
-    constructor(overlayRef: OverlayRef, containerInstance: ThyAutocompleteContainerComponent, config: ThyAutocompleteConfig) {
+    constructor(overlayRef: OverlayRef, containerInstance: ThyAutocompleteContainer, config: ThyAutocompleteConfig) {
         super(autocompleteAbstractOverlayOptions, overlayRef, containerInstance, config);
     }
 

--- a/src/autocomplete/overlay/autocomplete.service.ts
+++ b/src/autocomplete/overlay/autocomplete.service.ts
@@ -20,7 +20,7 @@ import { ViewportRuler } from '@angular/cdk/scrolling';
 import { DOCUMENT } from '@angular/common';
 import { ElementRef, Inject, Injectable, Injector, NgZone, OnDestroy, StaticProvider, TemplateRef } from '@angular/core';
 
-import { ThyAutocompleteContainerComponent } from './autocomplete-container.component';
+import { ThyAutocompleteContainer } from './autocomplete-container.component';
 import { ThyAutocompleteRef, ThyInternalAutocompleteRef } from './autocomplete-ref';
 import { THY_AUTOCOMPLETE_DEFAULT_CONFIG, ThyAutocompleteConfig } from './autocomplete.config';
 import { autocompleteAbstractOverlayOptions } from './autocomplete.options';
@@ -30,7 +30,7 @@ import { autocompleteAbstractOverlayOptions } from './autocomplete.options';
  */
 @Injectable()
 export class ThyAutocompleteService
-    extends ThyAbstractOverlayService<ThyAutocompleteConfig, ThyAutocompleteContainerComponent>
+    extends ThyAbstractOverlayService<ThyAutocompleteConfig, ThyAutocompleteContainer>
     implements OnDestroy
 {
     private readonly ngUnsubscribe$ = new Subject();
@@ -73,20 +73,20 @@ export class ThyAutocompleteService
         return overlayConfig;
     }
 
-    protected attachOverlayContainer(overlay: OverlayRef, config: ThyAutocompleteConfig<any>): ThyAutocompleteContainerComponent {
+    protected attachOverlayContainer(overlay: OverlayRef, config: ThyAutocompleteConfig<any>): ThyAutocompleteContainer {
         const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
         const injector = Injector.create({
             parent: userInjector || this.injector,
             providers: [{ provide: ThyAutocompleteConfig, useValue: config }]
         });
-        const containerPortal = new ComponentPortal(ThyAutocompleteContainerComponent, config.viewContainerRef, injector);
-        const containerRef = overlay.attach<ThyAutocompleteContainerComponent>(containerPortal);
+        const containerPortal = new ComponentPortal(ThyAutocompleteContainer, config.viewContainerRef, injector);
+        const containerRef = overlay.attach<ThyAutocompleteContainer>(containerPortal);
         return containerRef.instance;
     }
 
     protected createAbstractOverlayRef<T>(
         overlayRef: OverlayRef,
-        containerInstance: ThyAutocompleteContainerComponent,
+        containerInstance: ThyAutocompleteContainer,
         config: ThyAutocompleteConfig<any>
     ): ThyInternalAutocompleteRef<T> {
         return new ThyInternalAutocompleteRef<T>(overlayRef, containerInstance, config);
@@ -95,12 +95,12 @@ export class ThyAutocompleteService
     protected createInjector<T>(
         config: ThyAutocompleteConfig,
         autocompleteRef: ThyAutocompleteRef<T>,
-        autocompleteContainer: ThyAutocompleteContainerComponent
+        autocompleteContainer: ThyAutocompleteContainer
     ): Injector {
         const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
         const injectionTokens: StaticProvider[] = [
             {
-                provide: ThyAutocompleteContainerComponent,
+                provide: ThyAutocompleteContainer,
                 useValue: autocompleteContainer
             },
             {

--- a/src/autocomplete/test/autocomplete.component.spec.ts
+++ b/src/autocomplete/test/autocomplete.component.spec.ts
@@ -1,4 +1,4 @@
-import { ThyInputSearchComponent } from 'ngx-tethys/input';
+import { ThyInputSearch } from 'ngx-tethys/input';
 import {
     bypassSanitizeProvider,
     dispatchFakeEvent,
@@ -20,8 +20,8 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ThyFormModule } from '../../form';
 import { ThyInputModule } from '../../input/module';
 import { ThyOptionModule, ThySharedModule } from '../../shared';
-import { ThyOptionComponent } from '../../shared/option/option.component';
-import { ThyAutocompleteComponent } from '../autocomplete.component';
+import { ThyOption } from '../../shared/option/option.component';
+import { ThyAutocomplete } from '../autocomplete.component';
 import { ThyAutocompleteTriggerDirective } from '../autocomplete.trigger.directive';
 import { ThyAutocompleteModule } from '../module';
 
@@ -57,9 +57,9 @@ class BasicSelectComponent {
         { value: 'pasta-6', viewValue: 'Pasta' },
         { value: null, viewValue: 'Sushi' }
     ];
-    @ViewChild(ThyAutocompleteComponent, { static: true }) autocomplete: ThyAutocompleteComponent;
+    @ViewChild(ThyAutocomplete, { static: true }) autocomplete: ThyAutocomplete;
     @ViewChild(ThyAutocompleteTriggerDirective, { static: true }) autocompleteDirective: ThyAutocompleteTriggerDirective;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
 
     opened() {
         this.openedSpy();
@@ -93,8 +93,8 @@ class InputSearchSelectComponent {
         { value: 'pizza-1', viewValue: 'Pizza' }
     ];
 
-    @ViewChild(ThyAutocompleteComponent, { static: true }) autocomplete: ThyAutocompleteComponent;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChild(ThyAutocomplete, { static: true }) autocomplete: ThyAutocomplete;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
 }
 
 describe('ThyAutocomplete', () => {
@@ -322,7 +322,7 @@ describe('ThyAutocomplete', () => {
 
             beforeEach(fakeAsync(() => {
                 fixture = TestBed.createComponent(InputSearchSelectComponent);
-                debugSearchElement = fixture.debugElement.query(By.directive(ThyInputSearchComponent));
+                debugSearchElement = fixture.debugElement.query(By.directive(ThyInputSearch));
                 fixture.componentInstance.autocomplete.isMultiple = true;
                 fixture.detectChanges();
                 tick(100);

--- a/src/avatar/avatar-list/avatar-list.component.ts
+++ b/src/avatar/avatar-list/avatar-list.component.ts
@@ -15,7 +15,7 @@ import {
 import { UpdateHostClassService } from 'ngx-tethys/core';
 import { SafeAny } from 'ngx-tethys/types';
 import { Subject } from 'rxjs';
-import { DEFAULT_SIZE, ThyAvatarComponent } from '../avatar.component';
+import { DEFAULT_SIZE, ThyAvatar } from '../avatar.component';
 import { takeUntil, startWith } from 'rxjs/operators';
 
 export const THY_AVATAR_ITEM_SPACE = 4;
@@ -40,12 +40,12 @@ export const enum ThyAvatarListMode {
     },
     providers: [UpdateHostClassService],
     standalone: true,
-    imports: [NgFor, NgStyle, ThyAvatarComponent, NgIf, NgClass, NgTemplateOutlet]
+    imports: [NgFor, NgStyle, ThyAvatar, NgIf, NgClass, NgTemplateOutlet]
 })
-export class ThyAvatarListComponent implements OnChanges, OnDestroy, AfterContentInit {
+export class ThyAvatarList implements OnChanges, OnDestroy, AfterContentInit {
     @HostBinding('class.thy-avatar-list-overlap') overlapMode = false;
 
-    public avatarItems: ThyAvatarComponent[] = [];
+    public avatarItems: ThyAvatar[] = [];
 
     private ngUnsubscribe$ = new Subject<void>();
 
@@ -71,7 +71,7 @@ export class ThyAvatarListComponent implements OnChanges, OnDestroy, AfterConten
     /**
      * @private
      */
-    @ContentChildren(ThyAvatarComponent) avatarComponents: QueryList<ThyAvatarComponent>;
+    @ContentChildren(ThyAvatar) avatarComponents: QueryList<ThyAvatar>;
 
     constructor() {}
 

--- a/src/avatar/avatar.component.ts
+++ b/src/avatar/avatar.component.ts
@@ -4,7 +4,7 @@ import { coerceBooleanProperty, isString } from 'ngx-tethys/util';
 import { useHostRenderer } from '@tethys/cdk/dom';
 import { ThyAvatarService } from './avatar.service';
 import { AvatarShortNamePipe, AvatarBgColorPipe, AvatarSrcPipe } from './avatar.pipe';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgClass, NgStyle } from '@angular/common';
 import { InputBoolean } from 'ngx-tethys/core';
 
@@ -36,9 +36,9 @@ export type ThyAvatarFetchPriority = 'high' | 'low' | 'auto';
     templateUrl: './avatar.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgIf, NgClass, NgStyle, ThyIconComponent, AvatarShortNamePipe, AvatarBgColorPipe, AvatarSrcPipe]
+    imports: [NgIf, NgClass, NgStyle, ThyIcon, AvatarShortNamePipe, AvatarBgColorPipe, AvatarSrcPipe]
 })
-export class ThyAvatarComponent implements OnInit {
+export class ThyAvatar implements OnInit {
     _src: string;
     _name: string;
     _size: number;

--- a/src/avatar/avatar.module.ts
+++ b/src/avatar/avatar.module.ts
@@ -1,19 +1,19 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyAvatarComponent } from './avatar.component';
+import { ThyAvatar } from './avatar.component';
 import { AvatarPipes } from './avatar.pipe';
 import { ThyAvatarService, ThyDefaultAvatarService } from './avatar.service';
 import { ThyIconModule } from 'ngx-tethys/icon';
-import { ThyAvatarListComponent } from './avatar-list/avatar-list.component';
+import { ThyAvatarList } from './avatar-list/avatar-list.component';
 
 @NgModule({
-    imports: [CommonModule, ThyIconModule, ThyAvatarComponent, ThyAvatarListComponent, AvatarPipes],
+    imports: [CommonModule, ThyIconModule, ThyAvatar, ThyAvatarList, AvatarPipes],
     providers: [
         {
             provide: ThyAvatarService,
             useClass: ThyDefaultAvatarService
         }
     ],
-    exports: [ThyAvatarComponent, ThyAvatarListComponent, AvatarPipes]
+    exports: [ThyAvatar, ThyAvatarList, AvatarPipes]
 })
 export class ThyAvatarModule {}

--- a/src/avatar/test/avatar-list.spec.ts
+++ b/src/avatar/test/avatar-list.spec.ts
@@ -1,8 +1,8 @@
 import { Component, DebugElement, OnInit } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ThyAvatarListComponent, ThyAvatarListMode } from '../avatar-list/avatar-list.component';
-import { ThyAvatarComponent } from '../avatar.component';
+import { ThyAvatarList, ThyAvatarListMode } from '../avatar-list/avatar-list.component';
+import { ThyAvatar } from '../avatar.component';
 import { ThyAvatarModule } from '../avatar.module';
 
 const userNameList = [{ name: 'Abigail' }, { name: 'Belle' }, { name: 'Camilla' }, { name: 'Abigail' }, { name: 'Belle' }];
@@ -75,7 +75,7 @@ describe('thy-avatar-list', () => {
         let fixture: ComponentFixture<AvatarListBasicComponent>;
         beforeEach(() => {
             fixture = TestBed.createComponent(AvatarListBasicComponent);
-            avatarListDebugElement = fixture.debugElement.query(By.directive(ThyAvatarListComponent));
+            avatarListDebugElement = fixture.debugElement.query(By.directive(ThyAvatarList));
             componentInstance = fixture.componentInstance;
             avatarListElement = avatarListDebugElement.nativeElement;
             fixture.detectChanges();
@@ -88,14 +88,14 @@ describe('thy-avatar-list', () => {
         });
 
         it('should have correct avatar item', fakeAsync(() => {
-            const avatarComponent = fixture.debugElement.queryAll(By.directive(ThyAvatarComponent));
+            const avatarComponent = fixture.debugElement.queryAll(By.directive(ThyAvatar));
             expect(avatarComponent.length).toEqual(5);
             const moreComponent = fixture.debugElement.query(By.css('.more-36'));
             expect(moreComponent).not.toBeTruthy();
         }));
 
         it('should be 36px size which is the default size When thyAvatarSize is empty', fakeAsync(() => {
-            const avatarComponent = fixture.debugElement.queryAll(By.directive(ThyAvatarComponent));
+            const avatarComponent = fixture.debugElement.queryAll(By.directive(ThyAvatar));
             const avatarElement = avatarComponent[0].nativeElement;
             expect(avatarElement.classList.contains('thy-avatar-36')).toEqual(true);
         }));
@@ -129,7 +129,7 @@ describe('thy-avatar-list', () => {
         it('should be 68px size When input number 80', fakeAsync(() => {
             fixture.componentInstance.size = '80';
             fixture.detectChanges();
-            const avatarComponent = fixture.debugElement.queryAll(By.directive(ThyAvatarComponent));
+            const avatarComponent = fixture.debugElement.queryAll(By.directive(ThyAvatar));
             const avatarElement = avatarComponent[0].nativeElement;
             expect(avatarElement.classList.contains('thy-avatar-68')).toEqual(true);
         }));
@@ -139,7 +139,7 @@ describe('thy-avatar-list', () => {
         let fixture: ComponentFixture<AvatarListTestComponent>;
         beforeEach(() => {
             fixture = TestBed.createComponent(AvatarListTestComponent);
-            avatarListDebugElement = fixture.debugElement.query(By.directive(ThyAvatarListComponent));
+            avatarListDebugElement = fixture.debugElement.query(By.directive(ThyAvatarList));
             avatarListElement = avatarListDebugElement.nativeElement;
             fixture.detectChanges();
         });
@@ -184,7 +184,7 @@ describe('thy-avatar-list', () => {
             fixture.componentInstance.mode = ThyAvatarListMode.overlap;
             fixture.detectChanges();
 
-            const avatarComponent = fixture.debugElement.queryAll(By.directive(ThyAvatarComponent));
+            const avatarComponent = fixture.debugElement.queryAll(By.directive(ThyAvatar));
             expect(avatarComponent[0].styles.zIndex).toBe('5');
             expect(avatarComponent[1].styles.zIndex).toBe('4');
             expect(avatarComponent[2].styles.zIndex).toBe('3');
@@ -193,7 +193,7 @@ describe('thy-avatar-list', () => {
             fixture.componentInstance.data = [fixture.componentInstance.data[0], fixture.componentInstance.data[1]];
             fixture.detectChanges();
 
-            const avatarChangeComponent = fixture.debugElement.queryAll(By.directive(ThyAvatarComponent));
+            const avatarChangeComponent = fixture.debugElement.queryAll(By.directive(ThyAvatar));
             expect(avatarChangeComponent[0].styles.zIndex).toBe('2');
             expect(avatarChangeComponent[1].styles.zIndex).toBe('1');
         });
@@ -203,13 +203,13 @@ describe('thy-avatar-list', () => {
         let fixture: ComponentFixture<AvatarListEmptyComponent>;
         beforeEach(() => {
             fixture = TestBed.createComponent(AvatarListEmptyComponent);
-            avatarListDebugElement = fixture.debugElement.query(By.directive(ThyAvatarListComponent));
+            avatarListDebugElement = fixture.debugElement.query(By.directive(ThyAvatarList));
             fixture.detectChanges();
         });
 
         it('should create when ContentChildren is null ', fakeAsync(() => {
             expect(fixture).toBeTruthy();
-            expect(fixture.debugElement.queryAll(By.directive(ThyAvatarComponent)).length).toEqual(0);
+            expect(fixture.debugElement.queryAll(By.directive(ThyAvatar)).length).toEqual(0);
         }));
     });
 });

--- a/src/back-top/back-top.component.ts
+++ b/src/back-top/back-top.component.ts
@@ -21,7 +21,7 @@ import { Platform } from '@angular/cdk/platform';
 import { throttleTime, takeUntil, switchMap } from 'rxjs/operators';
 import { DOCUMENT, NgIf, NgTemplateOutlet } from '@angular/common';
 import { fadeMotion, InputNumber, ThyScrollService } from 'ngx-tethys/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 
 /**
  * 回到顶部组件
@@ -34,9 +34,9 @@ import { ThyIconComponent } from 'ngx-tethys/icon';
     encapsulation: ViewEncapsulation.None,
     animations: [fadeMotion],
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgTemplateOutlet]
+    imports: [NgIf, ThyIcon, NgTemplateOutlet]
 })
-export class ThyBackTopComponent implements OnInit, OnDestroy, OnChanges {
+export class ThyBackTop implements OnInit, OnDestroy, OnChanges {
     @HostBinding('class.thy-back-top-container') classNames = true;
 
     /**

--- a/src/back-top/back-top.module.ts
+++ b/src/back-top/back-top.module.ts
@@ -1,10 +1,10 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ThyIconModule } from 'ngx-tethys/icon';
-import { ThyBackTopComponent } from './back-top.component';
+import { ThyBackTop } from './back-top.component';
 
 @NgModule({
-    imports: [CommonModule, ThyIconModule, ThyBackTopComponent],
-    exports: [ThyBackTopComponent]
+    imports: [CommonModule, ThyIconModule, ThyBackTop],
+    exports: [ThyBackTop]
 })
 export class ThyBackTopModule {}

--- a/src/back-top/test/back-top.spec.ts
+++ b/src/back-top/test/back-top.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-import { ThyBackTopComponent } from '../back-top.component';
+import { ThyBackTop } from '../back-top.component';
 import { ThyBackTopModule } from '../back-top.module';
 import { ThyScrollService } from '../../core';
 
@@ -11,7 +11,7 @@ describe('Component:thy-back-top', () => {
     let scrollService: MockThyScrollService;
     let fixture: ComponentFixture<TestBackTopComponent>;
     let debugElement: DebugElement;
-    let component: ThyBackTopComponent;
+    let component: ThyBackTop;
     let componentObject: ThyBackTopPageObject;
     const defaultVisibilityHeight = 400;
 
@@ -241,8 +241,8 @@ describe('Component:thy-back-top', () => {
     `
 })
 class TestBackTopComponent {
-    @ViewChild(ThyBackTopComponent, { static: true })
-    thyBackTopComponent!: ThyBackTopComponent;
+    @ViewChild(ThyBackTop, { static: true })
+    thyBackTopComponent!: ThyBackTop;
 
     container: HTMLElement | null = null;
 
@@ -262,8 +262,8 @@ class TestBackTopComponent {
     `
 })
 class TestBackTopTemplateComponent {
-    @ViewChild(ThyBackTopComponent)
-    thyBackTopComponent!: ThyBackTopComponent;
+    @ViewChild(ThyBackTop)
+    thyBackTopComponent!: ThyBackTop;
 }
 
 class MockThyScrollService {

--- a/src/badge/badge.component.ts
+++ b/src/badge/badge.component.ts
@@ -21,7 +21,7 @@ export type ThyBadgeSize = 'md' | 'sm' | 'lg';
     standalone: true,
     imports: [NgIf]
 })
-export class ThyBadgeComponent implements OnInit {
+export class ThyBadge implements OnInit {
     displayContent = '';
 
     badgeClassName = '';

--- a/src/badge/badge.module.ts
+++ b/src/badge/badge.module.ts
@@ -1,10 +1,10 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyBadgeComponent } from './badge.component';
+import { ThyBadge } from './badge.component';
 
 @NgModule({
-    imports: [CommonModule, ThyBadgeComponent],
-    exports: [ThyBadgeComponent]
+    imports: [CommonModule, ThyBadge],
+    exports: [ThyBadge]
 })
 export class ThyBadgeModule {
     constructor() {}

--- a/src/badge/test/badge.spec.ts
+++ b/src/badge/test/badge.spec.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, DebugElement } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { ThyBadgeModule } from '../badge.module';
-import { ThyBadgeComponent } from '../badge.component';
+import { ThyBadge } from '../badge.component';
 import { By } from '@angular/platform-browser';
 
 @Component({
@@ -128,7 +128,7 @@ describe('thy-badge', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(BadgeBasicComponent);
             testComponent = fixture.debugElement.componentInstance;
-            badgeComponent = fixture.debugElement.query(By.directive(ThyBadgeComponent));
+            badgeComponent = fixture.debugElement.query(By.directive(ThyBadge));
             badgeElement = badgeComponent.nativeElement;
         });
 
@@ -211,7 +211,7 @@ describe('thy-badge', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(BadgeContentTestComponent);
             testComponent = fixture.debugElement.componentInstance;
-            badgeComponent = fixture.debugElement.query(By.directive(ThyBadgeComponent));
+            badgeComponent = fixture.debugElement.query(By.directive(ThyBadge));
             badgeElement = badgeComponent.nativeElement;
         });
 
@@ -238,7 +238,7 @@ describe('thy-badge', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(BadgeBasicContextComponent);
             testComponent = fixture.debugElement.componentInstance;
-            badgeComponent = fixture.debugElement.query(By.directive(ThyBadgeComponent));
+            badgeComponent = fixture.debugElement.query(By.directive(ThyBadge));
             badgeElement = badgeComponent.nativeElement;
         });
 
@@ -265,7 +265,7 @@ describe('thy-badge', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(BadgeBasicHollowComponent);
             testComponent = fixture.debugElement.componentInstance;
-            badgeComponent = fixture.debugElement.query(By.directive(ThyBadgeComponent));
+            badgeComponent = fixture.debugElement.query(By.directive(ThyBadge));
             badgeElement = badgeComponent.nativeElement;
         });
 
@@ -291,7 +291,7 @@ describe('thy-badge', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(BadgeBasicDotComponent);
             testComponent = fixture.debugElement.componentInstance;
-            badgeComponent = fixture.debugElement.query(By.directive(ThyBadgeComponent));
+            badgeComponent = fixture.debugElement.query(By.directive(ThyBadge));
             badgeElement = badgeComponent.nativeElement;
         });
 
@@ -317,7 +317,7 @@ describe('thy-badge', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(BadgeBasicCustomColorComponent);
             testComponent = fixture.debugElement.componentInstance;
-            badgeComponent = fixture.debugElement.query(By.directive(ThyBadgeComponent));
+            badgeComponent = fixture.debugElement.query(By.directive(ThyBadge));
             badgeElement = badgeComponent.nativeElement;
         });
 

--- a/src/breadcrumb/breadcrumb-item.component.ts
+++ b/src/breadcrumb/breadcrumb-item.component.ts
@@ -1,5 +1,5 @@
 import { Component, ChangeDetectionStrategy, AfterViewInit, ElementRef, Renderer2 } from '@angular/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 
 /**
  * 面包屑 Item 组件
@@ -15,9 +15,9 @@ import { ThyIconComponent } from 'ngx-tethys/icon';
         class: 'thy-breadcrumb-item'
     },
     standalone: true,
-    imports: [ThyIconComponent]
+    imports: [ThyIcon]
 })
-export class ThyBreadcrumbItemComponent implements AfterViewInit {
+export class ThyBreadcrumbItem implements AfterViewInit {
     constructor(private renderer: Renderer2, private elementRef: ElementRef) {}
 
     ngAfterViewInit() {

--- a/src/breadcrumb/breadcrumb.component.ts
+++ b/src/breadcrumb/breadcrumb.component.ts
@@ -1,5 +1,5 @@
 import { Component, ChangeDetectionStrategy, Input } from '@angular/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgClass } from '@angular/common';
 
 /**
@@ -28,9 +28,9 @@ import { NgIf, NgClass } from '@angular/common';
         '[class.thy-breadcrumb-separator-vertical-line]': 'thySeparator === "vertical-line"'
     },
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgClass]
+    imports: [NgIf, ThyIcon, NgClass]
 })
-export class ThyBreadcrumbComponent {
+export class ThyBreadcrumb {
     iconClasses: string[];
     svgIconName: string;
 

--- a/src/breadcrumb/module.ts
+++ b/src/breadcrumb/module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyBreadcrumbComponent } from './breadcrumb.component';
-import { ThyBreadcrumbItemComponent } from './breadcrumb-item.component';
+import { ThyBreadcrumb } from './breadcrumb.component';
+import { ThyBreadcrumbItem } from './breadcrumb-item.component';
 import { ThyIconModule } from 'ngx-tethys/icon';
 
 @NgModule({
-    imports: [CommonModule, ThyIconModule, ThyBreadcrumbComponent, ThyBreadcrumbItemComponent],
-    exports: [ThyBreadcrumbComponent, ThyBreadcrumbItemComponent]
+    imports: [CommonModule, ThyIconModule, ThyBreadcrumb, ThyBreadcrumbItem],
+    exports: [ThyBreadcrumb, ThyBreadcrumbItem]
 })
 export class ThyBreadcrumbModule {}

--- a/src/breadcrumb/test/breadcrumb.spec.ts
+++ b/src/breadcrumb/test/breadcrumb.spec.ts
@@ -1,9 +1,9 @@
 import { fakeAsync, TestBed, ComponentFixture } from '@angular/core/testing';
 import { ThyBreadcrumbModule } from '../module';
 import { NgModule, Component, DebugElement } from '@angular/core';
-import { ThyBreadcrumbItemComponent } from '../breadcrumb-item.component';
+import { ThyBreadcrumbItem } from '../breadcrumb-item.component';
 import { By } from '@angular/platform-browser';
-import { ThyBreadcrumbComponent } from '../breadcrumb.component';
+import { ThyBreadcrumb } from '../breadcrumb.component';
 import { ThyIconModule } from './../../icon/icon.module';
 
 @Component({
@@ -55,8 +55,8 @@ describe('ThyBreadcrumb', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyDemoBreadcrumbBasicComponent);
         basicTestComponent = fixture.debugElement.componentInstance;
-        breadcrumbItems = fixture.debugElement.queryAll(By.directive(ThyBreadcrumbItemComponent));
-        breadcrumbComponent = fixture.debugElement.query(By.directive(ThyBreadcrumbComponent));
+        breadcrumbItems = fixture.debugElement.queryAll(By.directive(ThyBreadcrumbItem));
+        breadcrumbComponent = fixture.debugElement.query(By.directive(ThyBreadcrumb));
     });
 
     function assertBreadcrumbComponentAndItemsClass() {

--- a/src/button/button-group.component.ts
+++ b/src/button/button-group.component.ts
@@ -24,7 +24,7 @@ const buttonGroupSizeMap = {
     encapsulation: ViewEncapsulation.None,
     standalone: true
 })
-export class ThyButtonGroupComponent implements OnInit {
+export class ThyButtonGroup implements OnInit {
     private initialized = false;
 
     private type: string;

--- a/src/button/button-icon.component.ts
+++ b/src/button/button-icon.component.ts
@@ -2,7 +2,7 @@ import { NgClass, NgIf } from '@angular/common';
 import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, ViewEncapsulation } from '@angular/core';
 import { useHostRenderer } from '@tethys/cdk/dom';
 import { InputBoolean } from 'ngx-tethys/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { coerceBooleanProperty } from 'ngx-tethys/util';
 
 export type ThyButtonIconShape = '' | 'circle-dashed' | 'circle-solid' | 'circle-thick-dashed' | 'circle-thick-solid' | 'self-icon';
@@ -37,9 +37,9 @@ const themeClassesMap: any = {
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgClass]
+    imports: [NgIf, ThyIcon, NgClass]
 })
-export class ThyButtonIconComponent implements OnInit {
+export class ThyButtonIcon implements OnInit {
     /**
      * 大小
      * @type xs | sm | md | lg

--- a/src/button/button-icon.spec.ts
+++ b/src/button/button-icon.spec.ts
@@ -1,9 +1,9 @@
 import { Component, DebugElement } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { ThyButtonModule } from './button.module';
-import { ThyIconComponent } from '../icon';
+import { ThyIcon } from '../icon';
 import { By } from '@angular/platform-browser';
-import { ThyButtonIconComponent } from './button-icon.component';
+import { ThyButtonIcon } from './button-icon.component';
 import { injectDefaultSvgIconSet, bypassSanitizeProvider } from 'ngx-tethys/testing';
 
 @Component({
@@ -33,7 +33,7 @@ describe(`button-icon`, () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(BasicButtonIconComponent);
         fixture.detectChanges();
-        thyButtonDebugElement = fixture.debugElement.query(By.directive(ThyButtonIconComponent));
+        thyButtonDebugElement = fixture.debugElement.query(By.directive(ThyButtonIcon));
         thyButtonElement = thyButtonDebugElement.nativeElement;
     });
 
@@ -43,7 +43,7 @@ describe(`button-icon`, () => {
         expect(thyButtonElement.classList.contains(`btn`)).toBeTruthy();
         expect(thyButtonElement.classList.contains(`btn-icon`)).toBeTruthy();
 
-        const iconDebugElement = thyButtonDebugElement.query(By.directive(ThyIconComponent));
+        const iconDebugElement = thyButtonDebugElement.query(By.directive(ThyIcon));
         expect(iconDebugElement).toBeTruthy();
         expect(iconDebugElement.nativeElement).toBeTruthy();
         expect(iconDebugElement.nativeElement.classList.contains(`thy-icon`)).toBeTruthy();
@@ -51,7 +51,7 @@ describe(`button-icon`, () => {
     });
 
     it(`should have style color`, () => {
-        const iconDebugElement = thyButtonDebugElement.query(By.directive(ThyIconComponent));
+        const iconDebugElement = thyButtonDebugElement.query(By.directive(ThyIcon));
         expect(iconDebugElement).toBeTruthy();
         expect(iconDebugElement.nativeElement.style.color === 'rgb(93, 207, 255)').toBe(true);
         expect(iconDebugElement.nativeElement.style.borderColor === 'rgb(93, 207, 255)').toBe(true);
@@ -72,7 +72,7 @@ describe(`button-icon`, () => {
         expect(wtfIconElement).toBeTruthy();
         expect(wtfIconElement.classList.contains(`wtf-inbox`)).toBeTruthy();
 
-        const iconDebugElement = thyButtonDebugElement.query(By.directive(ThyIconComponent));
+        const iconDebugElement = thyButtonDebugElement.query(By.directive(ThyIcon));
         expect(iconDebugElement).toBeFalsy();
     });
 });

--- a/src/button/button.component.ts
+++ b/src/button/button.component.ts
@@ -13,7 +13,7 @@ import {
 import { InputBoolean } from 'ngx-tethys/core';
 import { assertIconOnly } from 'ngx-tethys/util';
 import { useHostRenderer } from '@tethys/cdk/dom';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgClass } from '@angular/common';
 
 export type ThyButtonType =
@@ -67,9 +67,9 @@ const iconOnlyClass = 'thy-btn-icon-only';
         class: 'thy-btn btn'
     },
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgClass]
+    imports: [NgIf, ThyIcon, NgClass]
 })
-export class ThyButtonComponent implements OnInit, AfterViewInit {
+export class ThyButton implements OnInit, AfterViewInit {
     private _initialized = false;
 
     private _originalText: string;

--- a/src/button/button.module.ts
+++ b/src/button/button.module.ts
@@ -2,12 +2,12 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
 import { ThyIconModule } from 'ngx-tethys/icon';
-import { ThyButtonGroupComponent } from './button-group.component';
-import { ThyButtonIconComponent } from './button-icon.component';
-import { ThyButtonComponent } from './button.component';
+import { ThyButtonGroup } from './button-group.component';
+import { ThyButtonIcon } from './button-icon.component';
+import { ThyButton } from './button.component';
 
 @NgModule({
-    imports: [CommonModule, ThyIconModule, ThyButtonComponent, ThyButtonIconComponent, ThyButtonGroupComponent],
-    exports: [ThyButtonComponent, ThyButtonIconComponent, ThyButtonGroupComponent]
+    imports: [CommonModule, ThyIconModule, ThyButton, ThyButtonIcon, ThyButtonGroup],
+    exports: [ThyButton, ThyButtonIcon, ThyButtonGroup]
 })
 export class ThyButtonModule {}

--- a/src/button/test/button.spec.ts
+++ b/src/button/test/button.spec.ts
@@ -4,9 +4,9 @@ import { Component, DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { ThyButtonGroupComponent } from '../button-group.component';
-import { ThyButtonIconComponent } from '../button-icon.component';
-import { ThyButtonComponent } from '../button.component';
+import { ThyButtonGroup } from '../button-group.component';
+import { ThyButtonIcon } from '../button-icon.component';
+import { ThyButton } from '../button.component';
 import { ThyButtonModule } from '../button.module';
 
 function assertButtonIcon(iconElement: Element, icon: string) {
@@ -54,7 +54,7 @@ describe('ThyButton', () => {
             fixture = TestBed.createComponent(ThyTestButtonBasicComponent);
             basicTestComponent = fixture.componentInstance;
             fixture.detectChanges();
-            buttonComponent = fixture.debugElement.query(By.directive(ThyButtonComponent));
+            buttonComponent = fixture.debugElement.query(By.directive(ThyButton));
         });
 
         it('should get correct classes', () => {
@@ -224,7 +224,7 @@ describe('ThyIconButton', () => {
         fixture = TestBed.createComponent(ThyTestButtonIconBasicComponent);
         basicTestComponent = fixture.componentInstance;
         fixture.detectChanges();
-        buttonIconComponent = fixture.debugElement.query(By.directive(ThyButtonIconComponent));
+        buttonIconComponent = fixture.debugElement.query(By.directive(ThyButtonIcon));
     });
 
     it('should get correct classes', () => {
@@ -349,7 +349,7 @@ describe('ThyButtonGroup', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyDemoButtonGroupComponent);
         basicTestComponent = fixture.debugElement.componentInstance;
-        buttonGroupComponent = fixture.debugElement.query(By.directive(ThyButtonGroupComponent));
+        buttonGroupComponent = fixture.debugElement.query(By.directive(ThyButtonGroup));
         fixture.detectChanges();
     });
 

--- a/src/calendar/calendar-header.component.ts
+++ b/src/calendar/calendar-header.component.ts
@@ -1,9 +1,9 @@
 import { fromUnixTime, getMonth, getYear } from 'date-fns';
-import { DateRangeItemInfo, ThyDateRangeComponent } from 'ngx-tethys/date-range';
+import { DateRangeItemInfo, ThyDateRange } from 'ngx-tethys/date-range';
 import { endOfMonth, FunctionProp, getUnixTime, startOfMonth, TinyDate } from 'ngx-tethys/util';
 
 import { ChangeDetectorRef, Component, EventEmitter, HostBinding, Input, OnInit, Output, TemplateRef } from '@angular/core';
-import { ThyButtonComponent } from 'ngx-tethys/button';
+import { ThyButton } from 'ngx-tethys/button';
 import { NgIf, NgTemplateOutlet, JsonPipe } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 
@@ -16,9 +16,9 @@ import { FormsModule } from '@angular/forms';
     selector: 'thy-calendar-header',
     templateUrl: './calendar-header.component.html',
     standalone: true,
-    imports: [ThyDateRangeComponent, FormsModule, NgIf, ThyButtonComponent, NgTemplateOutlet, JsonPipe]
+    imports: [ThyDateRange, FormsModule, NgIf, ThyButton, NgTemplateOutlet, JsonPipe]
 })
-export class ThyCalendarHeaderComponent implements OnInit {
+export class ThyCalendarHeader implements OnInit {
     @HostBinding('class.thy-calendar-full-header-container') className = true;
 
     /**

--- a/src/calendar/calendar.component.ts
+++ b/src/calendar/calendar.component.ts
@@ -20,9 +20,9 @@ import {
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { ThyCalendarHeaderOperationDirective as HeaderOperation, ThyDateCellDirective as DateCell } from './calendar-cells';
-import { DateTableComponent, MonthTableComponent } from 'ngx-tethys/date-picker';
+import { DateTable, MonthTable } from 'ngx-tethys/date-picker';
 import { NgIf } from '@angular/common';
-import { ThyCalendarHeaderComponent } from './calendar-header.component';
+import { ThyCalendarHeader } from './calendar-header.component';
 
 export type CalendarMode = 'month' | 'year';
 type CalendarDateTemplate = TemplateRef<{ $implicit: Date }>;
@@ -37,11 +37,11 @@ type CalendarDateTemplate = TemplateRef<{ $implicit: Date }>;
     templateUrl: './calendar.component.html',
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
-    providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => ThyCalendarComponent), multi: true }],
+    providers: [{ provide: NG_VALUE_ACCESSOR, useExisting: forwardRef(() => ThyCalendar), multi: true }],
     standalone: true,
-    imports: [ThyCalendarHeaderComponent, NgIf, DateTableComponent, MonthTableComponent]
+    imports: [ThyCalendarHeader, NgIf, DateTable, MonthTable]
 })
-export class ThyCalendarComponent implements OnInit, OnChanges {
+export class ThyCalendar implements OnInit, OnChanges {
     @HostBinding('class.thy-calendar-container') className = true;
 
     @HostBinding('class.thy-calendar-full') className1 = true;

--- a/src/calendar/module.ts
+++ b/src/calendar/module.ts
@@ -3,8 +3,8 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ThySharedModule } from 'ngx-tethys/shared';
 import { ThyIconModule } from 'ngx-tethys/icon';
-import { ThyCalendarHeaderComponent } from './calendar-header.component';
-import { ThyCalendarComponent } from './calendar.component';
+import { ThyCalendarHeader } from './calendar-header.component';
+import { ThyCalendar } from './calendar.component';
 import { ThyCalendarHeaderOperationDirective, ThyDateCellDirective } from './calendar-cells';
 import { LibPackerModule } from 'ngx-tethys/date-picker';
 import { ThySelectModule } from 'ngx-tethys/select';
@@ -23,11 +23,11 @@ import { ThyDateRangeModule } from 'ngx-tethys/date-range';
         ThyRadioModule,
         ThyButtonModule,
         ThyDateRangeModule,
-        ThyCalendarHeaderComponent,
-        ThyCalendarComponent,
+        ThyCalendarHeader,
+        ThyCalendar,
         ThyDateCellDirective,
         ThyCalendarHeaderOperationDirective
     ],
-    exports: [ThyCalendarHeaderComponent, ThyCalendarComponent, ThyDateCellDirective, ThyCalendarHeaderOperationDirective]
+    exports: [ThyCalendarHeader, ThyCalendar, ThyDateCellDirective, ThyCalendarHeaderOperationDirective]
 })
 export class ThyCalendarModule {}

--- a/src/calendar/test/calendar.spec.ts
+++ b/src/calendar/test/calendar.spec.ts
@@ -7,8 +7,8 @@ import { async, ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from 
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
-import { ThyCalendarHeaderComponent } from '../calendar-header.component';
-import { ThyCalendarComponent } from '../calendar.component';
+import { ThyCalendarHeader } from '../calendar-header.component';
+import { ThyCalendar } from '../calendar.component';
 import { ThyCalendarModule } from '../module';
 
 @Component({
@@ -128,7 +128,7 @@ describe('calendar', () => {
             fixture = TestBed.createComponent(TestCalendarBasicComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            debugElement = fixture.debugElement.query(By.directive(ThyCalendarComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyCalendar));
             fixture.detectChanges();
         });
 
@@ -176,7 +176,7 @@ describe('calendar', () => {
             fixture.detectChanges();
             const now = new Date();
 
-            const calendarInstance = fixture.debugElement.queryAll(By.directive(ThyCalendarComponent))[1].componentInstance;
+            const calendarInstance = fixture.debugElement.queryAll(By.directive(ThyCalendar))[1].componentInstance;
             component.value1 = now;
             fixture.detectChanges();
             tick(500);
@@ -187,11 +187,11 @@ describe('calendar', () => {
 
         it('should show the default date in the correct format', waitForAsync(() => {
             fixture.whenStable().then(() => {
-                const calendar = fixture.debugElement.queryAll(By.directive(ThyCalendarComponent))[2];
+                const calendar = fixture.debugElement.queryAll(By.directive(ThyCalendar))[2];
                 const calendarElement = calendar.nativeElement;
                 const selectedDateText = calendarElement.querySelector('.thy-date-range-text').innerText;
 
-                const calendarHeader = calendar.query(By.directive(ThyCalendarHeaderComponent));
+                const calendarHeader = calendar.query(By.directive(ThyCalendarHeader));
                 const calendarHeaderInstance = calendarHeader.componentInstance;
                 const expectedDateText = calendarHeaderInstance._currentDate.format(calendarHeaderInstance.pickerFormat);
 
@@ -216,7 +216,7 @@ describe('calendar', () => {
             fixture = TestBed.createComponent(TestCalendarDisabledDateComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            debugElement = fixture.debugElement.query(By.directive(ThyCalendarComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyCalendar));
             fixture.detectChanges();
         });
 
@@ -246,7 +246,7 @@ describe('calendar-header', () => {
             fixture = TestBed.createComponent(TestCalendarHeaderComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            debugElement = fixture.debugElement.query(By.directive(ThyCalendarHeaderComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyCalendarHeader));
             fixture.detectChanges();
         });
 

--- a/src/card/card.component.ts
+++ b/src/card/card.component.ts
@@ -20,7 +20,7 @@ import { InputBoolean } from 'ngx-tethys/core';
     },
     standalone: true
 })
-export class ThyCardComponent {
+export class ThyCard {
     /**
      * 左右是否有内边距，已废弃，如需配置间距使用 spacing 工具样式覆盖默认间距
      * @deprecated

--- a/src/card/card.module.ts
+++ b/src/card/card.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyCardComponent } from './card.component';
-import { ThyCardHeaderComponent } from './header.component';
-import { ThyCardContentComponent } from './content.component';
+import { ThyCard } from './card.component';
+import { ThyCardHeader } from './header.component';
+import { ThyCardContent } from './content.component';
 
 @NgModule({
-    imports: [CommonModule, ThyCardComponent, ThyCardHeaderComponent, ThyCardContentComponent],
-    exports: [ThyCardComponent, ThyCardHeaderComponent, ThyCardContentComponent]
+    imports: [CommonModule, ThyCard, ThyCardHeader, ThyCardContent],
+    exports: [ThyCard, ThyCardHeader, ThyCardContent]
 })
 export class ThyCardModule {}

--- a/src/card/content.component.ts
+++ b/src/card/content.component.ts
@@ -17,7 +17,7 @@ import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit } from '
     },
     standalone: true
 })
-export class ThyCardContentComponent implements OnInit {
+export class ThyCardContent implements OnInit {
     @HostBinding('class.thy-card-content--scroll') scrollClassName = false;
 
     /**

--- a/src/card/header.component.ts
+++ b/src/card/header.component.ts
@@ -20,7 +20,7 @@ import { NgTemplateOutlet, NgIf } from '@angular/common';
     standalone: true,
     imports: [NgTemplateOutlet, NgIf]
 })
-export class ThyCardHeaderComponent implements OnInit {
+export class ThyCardHeader implements OnInit {
     public iconClass: string;
 
     /**

--- a/src/card/test/card.component.spec.ts
+++ b/src/card/test/card.component.spec.ts
@@ -2,9 +2,9 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { ThyCardModule } from '../card.module';
 import { Component, OnInit, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { ThyCardComponent } from '../card.component';
-import { ThyCardContentComponent } from '../content.component';
-import { ThyCardHeaderComponent } from '../header.component';
+import { ThyCard } from '../card.component';
+import { ThyCardContent } from '../content.component';
+import { ThyCardHeader } from '../header.component';
 
 @Component({
     selector: 'thy-card-test-basic',
@@ -118,7 +118,7 @@ describe('thy-card', () => {
         beforeEach(() => {
             basicFixture = TestBed.createComponent(CardBasicComponent);
             basicFixture.detectChanges();
-            cardBasicDebugElement = basicFixture.debugElement.query(By.directive(ThyCardComponent));
+            cardBasicDebugElement = basicFixture.debugElement.query(By.directive(ThyCard));
         });
 
         it('should get correct thy-card class', () => {
@@ -130,7 +130,7 @@ describe('thy-card', () => {
 
         it('should header and content align', () => {
             const headerDebugElement = cardBasicDebugElement.query(By.css('.card-header-title'));
-            const contentDebugElement = cardBasicDebugElement.query(By.directive(ThyCardContentComponent));
+            const contentDebugElement = cardBasicDebugElement.query(By.directive(ThyCardContent));
             expect((headerDebugElement.nativeElement as HTMLElement).getBoundingClientRect().left).toEqual(
                 (contentDebugElement.nativeElement as HTMLElement).getBoundingClientRect().left
             );
@@ -154,7 +154,7 @@ describe('thy-card', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(CardDividedComponent);
             fixture.detectChanges();
-            cardDebugElement = fixture.debugElement.query(By.directive(ThyCardComponent));
+            cardDebugElement = fixture.debugElement.query(By.directive(ThyCard));
         });
 
         it('should get correct divided thy-card--divided class', () => {
@@ -172,7 +172,7 @@ describe('thy-card', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(CardBorderedComponent);
             fixture.detectChanges();
-            cardDebugElement = fixture.debugElement.query(By.directive(ThyCardComponent));
+            cardDebugElement = fixture.debugElement.query(By.directive(ThyCard));
         });
 
         it('should get correct bordered thy-card--bordered class', () => {
@@ -191,7 +191,7 @@ describe('thy-card', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(CardClearPaddingComponent);
             fixture.detectChanges();
-            cardDebugElement = fixture.debugElement.query(By.directive(ThyCardComponent));
+            cardDebugElement = fixture.debugElement.query(By.directive(ThyCard));
         });
 
         it('should get correct thy-card--clear-left-right-padding class when thyHasLeftRightPadding is false', () => {
@@ -210,7 +210,7 @@ describe('thy-card', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(CardHeaderSizeComponent);
             fixture.detectChanges();
-            cardHeaderComponent = fixture.debugElement.query(By.directive(ThyCardHeaderComponent));
+            cardHeaderComponent = fixture.debugElement.query(By.directive(ThyCardHeader));
             cardHeaderElement = cardHeaderComponent.nativeElement;
         });
 
@@ -235,7 +235,7 @@ describe('thy-card', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(CardContentSizeAndScrollComponent);
             fixture.detectChanges();
-            cardContentComponent = fixture.debugElement.query(By.directive(ThyCardContentComponent));
+            cardContentComponent = fixture.debugElement.query(By.directive(ThyCardContent));
             cardContentElement = cardContentComponent.nativeElement;
         });
 

--- a/src/carousel/carousel.component.ts
+++ b/src/carousel/carousel.component.ts
@@ -35,8 +35,8 @@ import { ThyCarouselSlideEngine, ThyCarouselNoopEngine, ThyCarouselFadeEngine } 
 import { fromEvent, Subject } from 'rxjs';
 import { debounceTime, takeUntil } from 'rxjs/operators';
 import { ThyCarouselService } from './carousel.service';
-import { ThyIconComponent } from 'ngx-tethys/icon';
-import { ThyDotComponent } from 'ngx-tethys/dot';
+import { ThyIcon } from 'ngx-tethys/icon';
+import { ThyDot } from 'ngx-tethys/dot';
 import { NgIf, NgTemplateOutlet, NgFor } from '@angular/common';
 
 /**
@@ -53,9 +53,9 @@ import { NgIf, NgTemplateOutlet, NgFor } from '@angular/common';
         class: 'thy-carousel'
     },
     standalone: true,
-    imports: [NgIf, NgTemplateOutlet, NgFor, ThyDotComponent, ThyIconComponent]
+    imports: [NgIf, NgTemplateOutlet, NgFor, ThyDot, ThyIcon]
 })
-export class ThyCarouselComponent implements OnInit, AfterViewInit, AfterContentInit, OnChanges, OnDestroy {
+export class ThyCarousel implements OnInit, AfterViewInit, AfterContentInit, OnChanges, OnDestroy {
     /**
      * @private
      */

--- a/src/carousel/engine/carousel-base.ts
+++ b/src/carousel/engine/carousel-base.ts
@@ -2,13 +2,13 @@ import { ChangeDetectorRef, Renderer2, QueryList } from '@angular/core';
 import { Platform } from '@angular/cdk/platform';
 import { Observable } from 'rxjs';
 import { ThyCarouselItemDirective } from '../carousel-item.directive';
-import { ThyCarouselComponent } from '../carousel.component';
+import { ThyCarousel } from '../carousel.component';
 import { ThyDistanceVector, ThyCarouselEngine } from '../typings';
 
 export abstract class ThyCarouselBaseEngine implements ThyCarouselEngine {
     protected contentWidth: number;
     protected contentHeight: number;
-    protected readonly carouselComponent: ThyCarouselComponent;
+    protected readonly carouselComponent: ThyCarousel;
     protected wrapperEl: HTMLElement;
     protected playTime: number;
     protected length: number;
@@ -27,7 +27,7 @@ export abstract class ThyCarouselBaseEngine implements ThyCarouselEngine {
     }
 
     protected constructor(
-        thyCarouselComponent: ThyCarouselComponent,
+        thyCarouselComponent: ThyCarousel,
         protected cdr: ChangeDetectorRef,
         protected renderer: Renderer2,
         protected platform: Platform

--- a/src/carousel/engine/carousel-fade.ts
+++ b/src/carousel/engine/carousel-fade.ts
@@ -1,14 +1,14 @@
 import { ChangeDetectorRef, QueryList, Renderer2 } from '@angular/core';
 import { Platform } from '@angular/cdk/platform';
 import { Observable, Subject } from 'rxjs';
-import { ThyCarouselComponent } from '../carousel.component';
+import { ThyCarousel } from '../carousel.component';
 import { ThyDistanceVector } from '../typings';
 import { ThyCarouselItemDirective } from '../carousel-item.directive';
 import { ThyCarouselBaseEngine } from '../engine/carousel-base';
 
 export class ThyCarouselFadeEngine extends ThyCarouselBaseEngine {
     contentsEl: HTMLElement[];
-    constructor(thyCarouselComponent: ThyCarouselComponent, cdr: ChangeDetectorRef, renderer: Renderer2, platform: Platform) {
+    constructor(thyCarouselComponent: ThyCarousel, cdr: ChangeDetectorRef, renderer: Renderer2, platform: Platform) {
         super(thyCarouselComponent, cdr, renderer, platform);
     }
 

--- a/src/carousel/engine/carousel-noop.ts
+++ b/src/carousel/engine/carousel-noop.ts
@@ -1,13 +1,13 @@
 import { ChangeDetectorRef, QueryList, Renderer2 } from '@angular/core';
 import { Platform } from '@angular/cdk/platform';
 import { Observable, Subject } from 'rxjs';
-import { ThyCarouselComponent } from '../carousel.component';
+import { ThyCarousel } from '../carousel.component';
 import { ThyDistanceVector } from '../typings';
 import { ThyCarouselItemDirective } from '../carousel-item.directive';
 import { ThyCarouselBaseEngine } from '../engine/carousel-base';
 
 export class ThyCarouselNoopEngine extends ThyCarouselBaseEngine {
-    constructor(thyCarouselComponent: ThyCarouselComponent, cdr: ChangeDetectorRef, renderer: Renderer2, platform: Platform) {
+    constructor(thyCarouselComponent: ThyCarousel, cdr: ChangeDetectorRef, renderer: Renderer2, platform: Platform) {
         super(thyCarouselComponent, cdr, renderer, platform);
     }
 

--- a/src/carousel/engine/carousel-slide.ts
+++ b/src/carousel/engine/carousel-slide.ts
@@ -1,13 +1,13 @@
 import { ChangeDetectorRef, QueryList, Renderer2 } from '@angular/core';
 import { Platform } from '@angular/cdk/platform';
 import { Observable, Subject } from 'rxjs';
-import { ThyCarouselComponent } from '../carousel.component';
+import { ThyCarousel } from '../carousel.component';
 import { ThyDistanceVector } from '../typings';
 import { ThyCarouselItemDirective } from '../carousel-item.directive';
 import { ThyCarouselBaseEngine } from '../engine/carousel-base';
 
 export class ThyCarouselSlideEngine extends ThyCarouselBaseEngine {
-    constructor(thyCarouselComponent: ThyCarouselComponent, cdr: ChangeDetectorRef, renderer: Renderer2, platform: Platform) {
+    constructor(thyCarouselComponent: ThyCarousel, cdr: ChangeDetectorRef, renderer: Renderer2, platform: Platform) {
         super(thyCarouselComponent, cdr, renderer, platform);
     }
 

--- a/src/carousel/module.ts
+++ b/src/carousel/module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyCarouselComponent } from './carousel.component';
+import { ThyCarousel } from './carousel.component';
 import { ThyCarouselItemDirective } from './carousel-item.directive';
 import { ThyDotModule } from 'ngx-tethys/dot';
 import { ThyIconModule } from 'ngx-tethys/icon';
 
-const COMPONENTS = [ThyCarouselComponent, ThyCarouselItemDirective];
+const COMPONENTS = [ThyCarousel, ThyCarouselItemDirective];
 
 @NgModule({
     exports: [...COMPONENTS],

--- a/src/carousel/test/carousel-events.ts
+++ b/src/carousel/test/carousel-events.ts
@@ -1,14 +1,9 @@
-import { ThyCarouselComponent } from 'ngx-tethys/carousel';
+import { ThyCarousel } from 'ngx-tethys/carousel';
 import { dispatchEvent, dispatchMouseEvent, dispatchTouchEvent } from 'ngx-tethys/testing';
 import { ComponentFixture, tick } from '@angular/core/testing';
 import { SafeAny } from 'ngx-tethys/types';
 
-export function mouseSwipe<T extends ComponentFixture<SafeAny>>(
-    carousel: ThyCarouselComponent,
-    distance: number,
-    delay = 0,
-    fixture?: T
-): void {
+export function mouseSwipe<T extends ComponentFixture<SafeAny>>(carousel: ThyCarousel, distance: number, delay = 0, fixture?: T): void {
     carousel.onDrag(
         new MouseEvent('mousedown', {
             clientX: 500,
@@ -24,7 +19,7 @@ export function mouseSwipe<T extends ComponentFixture<SafeAny>>(
 }
 
 export function touchSwipe<T extends ComponentFixture<SafeAny>>(
-    carousel: ThyCarouselComponent,
+    carousel: ThyCarousel,
     target: HTMLElement,
     distance: number,
     delay = 0,

--- a/src/carousel/test/carousel.component.spec.ts
+++ b/src/carousel/test/carousel.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { By } from '@angular/platform-browser';
 import { dispatchMouseEvent } from 'ngx-tethys/testing';
 import { ThyCarouselModule } from '../module';
-import { ThyCarouselComponent, ThyCarouselPause } from 'ngx-tethys/carousel';
+import { ThyCarousel, ThyCarouselPause } from 'ngx-tethys/carousel';
 import { ThyCarouselItemDirective } from 'ngx-tethys/carousel';
 import { ThyCarouselEffect, ThyCarouselTrigger } from '../typings';
 import { mouseSwipe, touchSwipe, windowResize } from './carousel-events';
@@ -28,7 +28,7 @@ import { mouseSwipe, touchSwipe, windowResize } from './carousel-events';
     `
 })
 class ThyTestCarouselBasicComponent implements OnInit {
-    @ViewChild(ThyCarouselComponent, { static: false }) thyCarouselComponent!: ThyCarouselComponent;
+    @ViewChild(ThyCarousel, { static: false }) thyCarouselComponent!: ThyCarousel;
     constructor() {}
 
     array: string[] = [];
@@ -67,7 +67,7 @@ class ThyTestCarouselBasicComponent implements OnInit {
     `
 })
 class ThyTestCarouselTouchableComponent implements OnInit {
-    @ViewChild(ThyCarouselComponent, { static: false }) thyCarouselComponent!: ThyCarouselComponent;
+    @ViewChild(ThyCarousel, { static: false }) thyCarouselComponent!: ThyCarousel;
 
     array: string[] = [];
 
@@ -99,7 +99,7 @@ describe('carousel', () => {
             fixture = TestBed.createComponent(ThyTestCarouselBasicComponent);
             fixture.detectChanges();
             basicTestComponent = fixture.debugElement.componentInstance;
-            carouselWrapper = fixture.debugElement.query(By.directive(ThyCarouselComponent));
+            carouselWrapper = fixture.debugElement.query(By.directive(ThyCarousel));
             carouselContents = fixture.debugElement.queryAll(By.directive(ThyCarouselItemDirective));
         });
 

--- a/src/carousel/test/carousel.engine.spec.ts
+++ b/src/carousel/test/carousel.engine.spec.ts
@@ -1,5 +1,5 @@
 import { Component, DebugElement, OnInit, ViewChild } from '@angular/core';
-import { ThyCarouselComponent, ThyCarouselEffect, ThyCarouselItemDirective, ThyCarouselModule } from 'ngx-tethys/carousel';
+import { ThyCarousel, ThyCarouselEffect, ThyCarouselItemDirective, ThyCarouselModule } from 'ngx-tethys/carousel';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { mouseSwipe, windowResize } from './carousel-events';
@@ -17,7 +17,7 @@ import { mouseSwipe, windowResize } from './carousel-events';
     `
 })
 class ThyTestCarouselEngineComponent implements OnInit {
-    @ViewChild(ThyCarouselComponent, { static: false }) thyCarouselComponent!: ThyCarouselComponent;
+    @ViewChild(ThyCarousel, { static: false }) thyCarouselComponent!: ThyCarousel;
     constructor() {}
 
     array: string[] = [];
@@ -95,7 +95,7 @@ describe(`carousel`, () => {
             fixture = TestBed.createComponent(ThyTestCarouselEngineComponent);
             fixture.detectChanges();
             basicTestComponent = fixture.debugElement.componentInstance;
-            carouselWrapper = fixture.debugElement.query(By.directive(ThyCarouselComponent));
+            carouselWrapper = fixture.debugElement.query(By.directive(ThyCarousel));
             carouselContents = fixture.debugElement.queryAll(By.directive(ThyCarouselItemDirective));
         });
 

--- a/src/cascader/cascader-li.component.ts
+++ b/src/cascader/cascader-li.component.ts
@@ -1,7 +1,7 @@
-import { ThyCheckboxComponent } from 'ngx-tethys/checkbox';
+import { ThyCheckbox } from 'ngx-tethys/checkbox';
 import { InputBoolean } from 'ngx-tethys/core';
-import { ThyFlexibleTextComponent } from 'ngx-tethys/flexible-text';
-import { ThyRadioComponent } from 'ngx-tethys/radio';
+import { ThyFlexibleText } from 'ngx-tethys/flexible-text';
+import { ThyRadio } from 'ngx-tethys/radio';
 import { ThyStopPropagationDirective } from 'ngx-tethys/shared';
 
 import { NgIf } from '@angular/common';
@@ -20,7 +20,7 @@ import { ThyCascaderOption } from './types';
     selector: '[thy-cascader-option]',
     templateUrl: './cascader-li.component.html',
     standalone: true,
-    imports: [NgIf, ThyFlexibleTextComponent, ThyCheckboxComponent, ThyRadioComponent, FormsModule, ThyStopPropagationDirective]
+    imports: [NgIf, ThyFlexibleText, ThyCheckbox, ThyRadio, FormsModule, ThyStopPropagationDirective]
 })
 export class ThyCascaderOptionComponent implements OnInit {
     @Input() option: ThyCascaderOption;

--- a/src/cascader/cascader-search-option.component.ts
+++ b/src/cascader/cascader-search-option.component.ts
@@ -11,11 +11,11 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ThyBreadcrumbComponent, ThyBreadcrumbItemComponent } from 'ngx-tethys/breadcrumb';
-import { ThyCheckboxComponent } from 'ngx-tethys/checkbox';
+import { ThyBreadcrumb, ThyBreadcrumbItem } from 'ngx-tethys/breadcrumb';
+import { ThyCheckbox } from 'ngx-tethys/checkbox';
 import { InputBoolean } from 'ngx-tethys/core';
-import { ThyFlexibleTextComponent } from 'ngx-tethys/flexible-text';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyFlexibleText } from 'ngx-tethys/flexible-text';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { ThyCascaderSearchOption } from './types';
 
 /**
@@ -28,16 +28,7 @@ import { ThyCascaderSearchOption } from './types';
     selector: '[thy-cascader-search-option]',
     templateUrl: './cascader-search-option.component.html',
     standalone: true,
-    imports: [
-        NgIf,
-        NgFor,
-        ThyFlexibleTextComponent,
-        ThyCheckboxComponent,
-        ThyBreadcrumbComponent,
-        ThyBreadcrumbItemComponent,
-        ThyIconComponent,
-        FormsModule
-    ]
+    imports: [NgIf, NgFor, ThyFlexibleText, ThyCheckbox, ThyBreadcrumb, ThyBreadcrumbItem, ThyIcon, FormsModule]
 })
 export class ThyCascaderSearchOptionComponent implements OnInit {
     @Input() option: ThyCascaderSearchOption;

--- a/src/cascader/cascader.component.ts
+++ b/src/cascader/cascader.component.ts
@@ -6,9 +6,9 @@ import {
     TabIndexDisabledControlValueAccessorMixin,
     ThyClickDispatcher
 } from 'ngx-tethys/core';
-import { ThyEmptyComponent } from 'ngx-tethys/empty';
-import { ThyIconComponent } from 'ngx-tethys/icon';
-import { SelectControlSize, SelectOptionBase, ThySelectControlComponent } from 'ngx-tethys/shared';
+import { ThyEmpty } from 'ngx-tethys/empty';
+import { ThyIcon } from 'ngx-tethys/icon';
+import { SelectControlSize, SelectOptionBase, ThySelectControl } from 'ngx-tethys/shared';
 import { coerceBooleanProperty, elementMatchClosest, isEmpty } from 'ngx-tethys/util';
 import { BehaviorSubject, Observable, Subject, Subscription, timer } from 'rxjs';
 import { debounceTime, distinctUntilChanged, filter, take, takeUntil } from 'rxjs/operators';
@@ -55,7 +55,7 @@ import { scaleYMotion } from 'ngx-tethys/core';
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThyCascaderComponent),
+            useExisting: forwardRef(() => ThyCascader),
             multi: true
         },
         ThyCascaderService
@@ -69,7 +69,7 @@ import { scaleYMotion } from 'ngx-tethys/core';
     imports: [
         CdkOverlayOrigin,
         NgIf,
-        ThySelectControlComponent,
+        ThySelectControl,
         NgClass,
         NgTemplateOutlet,
         CdkConnectedOverlay,
@@ -77,12 +77,12 @@ import { scaleYMotion } from 'ngx-tethys/core';
         NgFor,
         ThyCascaderOptionComponent,
         ThyCascaderSearchOptionComponent,
-        ThyEmptyComponent,
-        ThyIconComponent
+        ThyEmpty,
+        ThyIcon
     ],
     animations: [scaleYMotion]
 })
-export class ThyCascaderComponent
+export class ThyCascader
     extends TabIndexDisabledControlValueAccessorMixin
     implements ControlValueAccessor, OnInit, OnChanges, OnDestroy, AfterContentInit
 {

--- a/src/cascader/examples/any-level-selectable/any-level-selectable.component.ts
+++ b/src/cascader/examples/any-level-selectable/any-level-selectable.component.ts
@@ -1,5 +1,5 @@
-import { ThyCascaderComponent } from 'ngx-tethys/cascader';
-import { ThyFormGroupComponent } from 'ngx-tethys/form';
+import { ThyCascader } from 'ngx-tethys/cascader';
+import { ThyFormGroup } from 'ngx-tethys/form';
 import { ThyNotifyService } from 'ngx-tethys/notify';
 
 import { CommonModule } from '@angular/common';
@@ -13,7 +13,7 @@ import { ThyTagModule } from 'ngx-tethys/tag';
     selector: 'thy-cascader-any-level-selectable-example',
     templateUrl: './any-level-selectable.component.html',
     standalone: true,
-    imports: [ThyFormGroupComponent, ThyCascaderComponent, ThyTagModule, CommonModule, FormsModule]
+    imports: [ThyFormGroup, ThyCascader, ThyTagModule, CommonModule, FormsModule]
 })
 export class ThyCascaderAnyLevelSelectableExampleComponent implements OnInit {
     public areaCode = clone(options);

--- a/src/cascader/examples/auto-expand/auto-expand.component.ts
+++ b/src/cascader/examples/auto-expand/auto-expand.component.ts
@@ -1,8 +1,8 @@
 import { CommonModule } from '@angular/common';
 import { Component, OnInit } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ThyCascaderComponent } from 'ngx-tethys/cascader';
-import { ThyFormGroupComponent } from 'ngx-tethys/form';
+import { ThyCascader } from 'ngx-tethys/cascader';
+import { ThyFormGroup } from 'ngx-tethys/form';
 import { clone, options } from '../cascader-address-options';
 import { ThyNotifyService } from 'ngx-tethys/notify';
 
@@ -10,7 +10,7 @@ import { ThyNotifyService } from 'ngx-tethys/notify';
     selector: 'thy-cascader-auto-expand-example',
     templateUrl: './auto-expand.component.html',
     standalone: true,
-    imports: [ThyFormGroupComponent, ThyCascaderComponent, CommonModule, FormsModule]
+    imports: [ThyFormGroup, ThyCascader, CommonModule, FormsModule]
 })
 export class AutoExpandComponent implements OnInit {
     public areaCode = clone(options);

--- a/src/cascader/module.ts
+++ b/src/cascader/module.ts
@@ -10,7 +10,7 @@ import { ThyInputModule } from 'ngx-tethys/input';
 import { ThySelectCommonModule } from 'ngx-tethys/shared';
 import { ThyCascaderOptionComponent } from './cascader-li.component';
 import { ThyCascaderSearchOptionComponent } from './cascader-search-option.component';
-import { ThyCascaderComponent } from './cascader.component';
+import { ThyCascader } from './cascader.component';
 
 @NgModule({
     imports: [
@@ -23,10 +23,10 @@ import { ThyCascaderComponent } from './cascader.component';
         ThySelectCommonModule,
         ThyCheckboxModule,
         ThyFlexibleTextModule,
-        ThyCascaderComponent,
+        ThyCascader,
         ThyCascaderOptionComponent,
         ThyCascaderSearchOptionComponent
     ],
-    exports: [ThyCascaderComponent]
+    exports: [ThyCascader]
 })
 export class ThyCascaderModule {}

--- a/src/cascader/test/cascader.spec.ts
+++ b/src/cascader/test/cascader.spec.ts
@@ -1,4 +1,4 @@
-import { ThyCascaderComponent } from 'ngx-tethys/cascader';
+import { ThyCascader } from 'ngx-tethys/cascader';
 import { EXPANDED_DROPDOWN_POSITIONS } from 'ngx-tethys/core';
 import { dispatchFakeEvent, typeInElement } from 'ngx-tethys/testing';
 import { SafeAny } from 'ngx-tethys/types';
@@ -279,7 +279,7 @@ const loadDataOption: { [key: string]: { children?: any[]; [key: string]: any }[
     `
 })
 class CascaderBasicComponent {
-    @ViewChild(ThyCascaderComponent, { static: false }) cascader: ThyCascaderComponent;
+    @ViewChild(ThyCascader, { static: false }) cascader: ThyCascader;
 
     public thyTriggerAction: ThyCascaderTriggerType = 'click';
     public thyExpandTriggerAction: ThyCascaderExpandTrigger = 'click';
@@ -298,7 +298,7 @@ class CascaderBasicComponent {
     public thyAutoExpand = true;
     public hasBackdrop: boolean;
 
-    @ViewChild('cascader', { static: true }) cascaderRef: ThyCascaderComponent;
+    @ViewChild('cascader', { static: true }) cascaderRef: ThyCascader;
 
     thyExpandStatusChange = jasmine.createSpy('thyExpandStatusChange callback');
 
@@ -817,7 +817,7 @@ describe('thy-cascader', () => {
         it('should call onFocus methods when focus', fakeAsync(() => {
             fixture.detectChanges();
             const focusSpy = spyOn<any>(fixture.componentInstance.cascader, 'onFocus').and.callThrough();
-            const cascaderElement = fixture.debugElement.query(By.directive(ThyCascaderComponent)).nativeElement;
+            const cascaderElement = fixture.debugElement.query(By.directive(ThyCascader)).nativeElement;
             dispatchFakeEvent(cascaderElement, 'focus');
             fixture.detectChanges();
 
@@ -827,7 +827,7 @@ describe('thy-cascader', () => {
         it('should call onBlur methods when blur', fakeAsync(() => {
             fixture.detectChanges();
             const blurSpy = spyOn<any>(fixture.componentInstance.cascader, 'onBlur').and.callThrough();
-            const cascaderElement = fixture.debugElement.query(By.directive(ThyCascaderComponent)).nativeElement;
+            const cascaderElement = fixture.debugElement.query(By.directive(ThyCascader)).nativeElement;
             dispatchFakeEvent(cascaderElement, 'blur');
             fixture.detectChanges();
 

--- a/src/checkbox/checkbox.component.ts
+++ b/src/checkbox/checkbox.component.ts
@@ -16,7 +16,7 @@ import { NgClass, NgIf } from '@angular/common';
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThyCheckboxComponent),
+            useExisting: forwardRef(() => ThyCheckbox),
             multi: true
         }
     ],
@@ -28,7 +28,7 @@ import { NgClass, NgIf } from '@angular/common';
     standalone: true,
     imports: [NgClass, NgIf]
 })
-export class ThyCheckboxComponent extends ThyFormCheckBaseComponent {
+export class ThyCheckbox extends ThyFormCheckBaseComponent {
     isIndeterminate = false;
 
     /**

--- a/src/checkbox/module.ts
+++ b/src/checkbox/module.ts
@@ -1,10 +1,10 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ThyCheckboxComponent } from './checkbox.component';
+import { ThyCheckbox } from './checkbox.component';
 
 @NgModule({
-    imports: [CommonModule, FormsModule, ThyCheckboxComponent],
-    exports: [ThyCheckboxComponent]
+    imports: [CommonModule, FormsModule, ThyCheckbox],
+    exports: [ThyCheckbox]
 })
 export class ThyCheckboxModule {}

--- a/src/checkbox/test/checkbox.component.spec.ts
+++ b/src/checkbox/test/checkbox.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
-import { ThyCheckboxComponent } from '../checkbox.component';
+import { ThyCheckbox } from '../checkbox.component';
 import { ThyCheckboxModule } from '../module';
 
 @Component({
@@ -54,7 +54,7 @@ describe('checkbox component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(CheckboxTestComponent);
         checkboxTestComponent = fixture.debugElement.componentInstance;
-        checkboxComponent = fixture.debugElement.query(By.directive(ThyCheckboxComponent));
+        checkboxComponent = fixture.debugElement.query(By.directive(ThyCheckbox));
     });
 
     it('should create', () => {

--- a/src/collapse/collapse-item.component.ts
+++ b/src/collapse/collapse-item.component.ts
@@ -13,10 +13,10 @@ import {
     TemplateRef
 } from '@angular/core';
 
-import { ThyCollapseComponent } from './collapse.component';
+import { ThyCollapse } from './collapse.component';
 import { SafeAny } from 'ngx-tethys/types';
 import { isString } from 'ngx-tethys/util';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgTemplateOutlet } from '@angular/common';
 
 const DEFAULT_ARROW_ICON = 'angle-right';
@@ -39,9 +39,9 @@ const DEFAULT_ARROW_ICON = 'angle-right';
     },
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgIf, NgTemplateOutlet, ThyIconComponent]
+    imports: [NgIf, NgTemplateOutlet, ThyIcon]
 })
-export class ThyCollapseItemComponent implements OnInit, OnDestroy {
+export class ThyCollapseItem implements OnInit, OnDestroy {
     public showArrow: boolean = true;
 
     public arrowIconTemplate: TemplateRef<SafeAny>;
@@ -98,7 +98,7 @@ export class ThyCollapseItemComponent implements OnInit, OnDestroy {
      */
     @Output() thyActiveChange = new EventEmitter<{ active: boolean; event: Event }>();
 
-    constructor(private cdr: ChangeDetectorRef, @Host() private thyCollapseComponent: ThyCollapseComponent) {}
+    constructor(private cdr: ChangeDetectorRef, @Host() private thyCollapseComponent: ThyCollapse) {}
 
     ngOnInit() {
         this.thyCollapseComponent.addPanel(this);

--- a/src/collapse/collapse.component.ts
+++ b/src/collapse/collapse.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
 import { InputBoolean } from 'ngx-tethys/core';
 
-import { ThyCollapseItemComponent } from './collapse-item.component';
+import { ThyCollapseItem } from './collapse-item.component';
 
 export type ThyCollapseTheme = 'divided' | 'bordered' | 'ghost';
 
@@ -30,7 +30,7 @@ export type ThyCollapsedIconPosition = 'left' | 'right';
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true
 })
-export class ThyCollapseComponent implements OnInit {
+export class ThyCollapse implements OnInit {
     /**
      * 折叠面板主题，支持 `divided` | `bordered` | `ghost`
      */
@@ -48,21 +48,21 @@ export class ThyCollapseComponent implements OnInit {
      */
     @Input() thyArrowIconPosition: ThyCollapsedIconPosition = 'left';
 
-    private listOfCollapsePanelComponent: ThyCollapseItemComponent[] = [];
+    private listOfCollapsePanelComponent: ThyCollapseItem[] = [];
 
     constructor() {}
 
     ngOnInit() {}
 
-    addPanel(value: ThyCollapseItemComponent): void {
+    addPanel(value: ThyCollapseItem): void {
         this.listOfCollapsePanelComponent.push(value);
     }
 
-    removePanel(value: ThyCollapseItemComponent): void {
+    removePanel(value: ThyCollapseItem): void {
         this.listOfCollapsePanelComponent.splice(this.listOfCollapsePanelComponent.indexOf(value), 1);
     }
 
-    click(collapseItem: ThyCollapseItemComponent, event: Event): void {
+    click(collapseItem: ThyCollapseItem, event: Event): void {
         if (this.thyAccordion && !collapseItem.thyActive) {
             this.listOfCollapsePanelComponent
                 .filter(item => item !== collapseItem)

--- a/src/collapse/module.ts
+++ b/src/collapse/module.ts
@@ -6,11 +6,11 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ThyCollapseItemComponent } from './collapse-item.component';
-import { ThyCollapseComponent } from './collapse.component';
+import { ThyCollapseItem } from './collapse-item.component';
+import { ThyCollapse } from './collapse.component';
 
 @NgModule({
-    imports: [CommonModule, FormsModule, OverlayModule, ThyInputModule, ThyIconModule, ThyCollapseComponent, ThyCollapseItemComponent],
-    exports: [ThyCollapseComponent, ThyCollapseItemComponent]
+    imports: [CommonModule, FormsModule, OverlayModule, ThyInputModule, ThyIconModule, ThyCollapse, ThyCollapseItem],
+    exports: [ThyCollapse, ThyCollapseItem]
 })
 export class ThyCollapseModule {}

--- a/src/collapse/test/collapse.spec.ts
+++ b/src/collapse/test/collapse.spec.ts
@@ -1,5 +1,5 @@
-import { ThyCollapseComponent, ThyCollapseItemComponent, ThyCollapseModule } from 'ngx-tethys/collapse';
-import { ThyIconComponent, ThyIconModule } from 'ngx-tethys/icon';
+import { ThyCollapse, ThyCollapseItem, ThyCollapseModule } from 'ngx-tethys/collapse';
+import { ThyIcon, ThyIconModule } from 'ngx-tethys/icon';
 import { dispatchFakeEvent } from 'ngx-tethys/testing';
 
 import { CommonModule } from '@angular/common';
@@ -79,8 +79,8 @@ describe('collapse', () => {
             fixture = TestBed.createComponent(TestCollapseBasicComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            debugElement = fixture.debugElement.query(By.directive(ThyCollapseComponent));
-            icon = fixture.debugElement.query(By.directive(ThyIconComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyCollapse));
+            icon = fixture.debugElement.query(By.directive(ThyIcon));
 
             iconRotateSpy = spyOn(icon.componentInstance.render, 'setStyle');
             fixture.detectChanges();
@@ -203,8 +203,8 @@ describe('collapse-panel', () => {
             fixture = TestBed.createComponent(TestCollapsePanelBasicComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            debugElement = fixture.debugElement.query(By.directive(ThyCollapseComponent));
-            icon = fixture.debugElement.query(By.directive(ThyIconComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyCollapse));
+            icon = fixture.debugElement.query(By.directive(ThyIcon));
 
             iconRotateSpy = spyOn(icon.componentInstance.render, 'setStyle');
             fixture.detectChanges();
@@ -254,7 +254,7 @@ describe('collapse-panel', () => {
         it('should set correct icon when set arrowIcon as boolean', () => {
             fixture.detectChanges();
             const withoutArrowIcon = fixture.debugElement.query(By.css('#without-arrow-icon'));
-            const collapseItem = withoutArrowIcon.componentInstance as ThyCollapseItemComponent;
+            const collapseItem = withoutArrowIcon.componentInstance as ThyCollapseItem;
             collapseItem.thyArrowIcon = true;
             expect(collapseItem.arrowIcon).toEqual('angle-right');
             expect(collapseItem.showArrow).toEqual(true);

--- a/src/color-picker/color-picker-custom-panel.component.ts
+++ b/src/color-picker/color-picker-custom-panel.component.ts
@@ -1,10 +1,10 @@
 import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit } from '@angular/core';
 import { ThyColor } from './helpers/color.class';
-import { ThyColorInputsComponent } from './parts/inputs/inputs.component';
-import { ThyIndicatorComponent } from './parts/indicator/indicator.component';
-import { ThyAlphaComponent } from './parts/alpha/alpha.component';
-import { ThyHueComponent } from './parts/hue/hue.component';
-import { ThySaturationComponent } from './parts/saturation/saturation.component';
+import { ThyColorInputs } from './parts/inputs/inputs.component';
+import { ThyIndicator } from './parts/indicator/indicator.component';
+import { ThyAlpha } from './parts/alpha/alpha.component';
+import { ThyHue } from './parts/hue/hue.component';
+import { ThySaturation } from './parts/saturation/saturation.component';
 
 /**
  * @internal
@@ -14,9 +14,9 @@ import { ThySaturationComponent } from './parts/saturation/saturation.component'
     templateUrl: './color-picker-custom-panel.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [ThySaturationComponent, ThyHueComponent, ThyAlphaComponent, ThyIndicatorComponent, ThyColorInputsComponent]
+    imports: [ThySaturation, ThyHue, ThyAlpha, ThyIndicator, ThyColorInputs]
 })
-export class ThyColorPickerCustomPanelComponent implements OnInit {
+export class ThyColorPickerCustomPanel implements OnInit {
     @HostBinding('class.thy-color-picker-custom-panel') className = true;
 
     colorInstance: ThyColor;

--- a/src/color-picker/color-picker-panel.component.ts
+++ b/src/color-picker/color-picker-panel.component.ts
@@ -1,9 +1,9 @@
 import { ChangeDetectionStrategy, Component, HostBinding, Input, OnInit, ViewContainerRef } from '@angular/core';
 import { InputBoolean } from 'ngx-tethys/core';
 import { ThyPopover, ThyPopoverRef } from 'ngx-tethys/popover';
-import { ThyColorPickerCustomPanelComponent } from './color-picker-custom-panel.component';
+import { ThyColorPickerCustomPanel } from './color-picker-custom-panel.component';
 import { ThyColor } from './helpers/color.class';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgClass, NgTemplateOutlet, NgFor, NgStyle } from '@angular/common';
 
 /**
@@ -17,9 +17,9 @@ import { NgIf, NgClass, NgTemplateOutlet, NgFor, NgStyle } from '@angular/common
         '[class.pt-4]': '!transparentColorSelectable'
     },
     standalone: true,
-    imports: [NgIf, NgClass, NgTemplateOutlet, NgFor, ThyIconComponent, NgStyle]
+    imports: [NgIf, NgClass, NgTemplateOutlet, NgFor, ThyIcon, NgStyle]
 })
-export class ThyColorPickerPanelComponent implements OnInit {
+export class ThyColorPickerPanel implements OnInit {
     @HostBinding('class.thy-color-picker-panel') className = true;
 
     @Input() color: string;
@@ -44,12 +44,12 @@ export class ThyColorPickerPanelComponent implements OnInit {
 
     newColor: string;
 
-    customPanelPopoverRef: ThyPopoverRef<ThyColorPickerCustomPanelComponent>;
+    customPanelPopoverRef: ThyPopoverRef<ThyColorPickerCustomPanel>;
 
     constructor(
         private thyPopover: ThyPopover,
         private viewContainerRef: ViewContainerRef,
-        private thyPopoverRef: ThyPopoverRef<ThyColorPickerPanelComponent>
+        private thyPopoverRef: ThyPopoverRef<ThyColorPickerPanel>
     ) {}
 
     ngOnInit(): void {
@@ -67,7 +67,7 @@ export class ThyColorPickerPanelComponent implements OnInit {
 
     showMoreColor(event: Event) {
         if (!this.customPanelPopoverRef) {
-            this.customPanelPopoverRef = this.thyPopover.open(ThyColorPickerCustomPanelComponent, {
+            this.customPanelPopoverRef = this.thyPopover.open(ThyColorPickerCustomPanel, {
                 origin: event.currentTarget as HTMLElement,
                 offset: -4,
                 placement: 'rightBottom',

--- a/src/color-picker/color-picker.component.ts
+++ b/src/color-picker/color-picker.component.ts
@@ -13,7 +13,7 @@ import {
 } from 'ngx-tethys/core';
 import { ThyPopover, ThyPopoverRef } from 'ngx-tethys/popover';
 import { fromEvent, Subject } from 'rxjs';
-import { ThyColorPickerPanelComponent } from './color-picker-panel.component';
+import { ThyColorPickerPanel } from './color-picker-panel.component';
 import { DEFAULT_COLORS } from './constant';
 import { ThyColor } from './helpers/color.class';
 import { takeUntil } from 'rxjs/operators';
@@ -88,16 +88,12 @@ export class ThyColorPickerDirective extends _BaseMixin implements OnInit, OnDes
     /**
      * panel 展开后触发
      */
-    @Output() thyPanelOpen: EventEmitter<ThyPopoverRef<ThyColorPickerPanelComponent>> = new EventEmitter<
-        ThyPopoverRef<ThyColorPickerPanelComponent>
-    >();
+    @Output() thyPanelOpen: EventEmitter<ThyPopoverRef<ThyColorPickerPanel>> = new EventEmitter<ThyPopoverRef<ThyColorPickerPanel>>();
 
     /**
      * panel 关闭后触发
      */
-    @Output() thyPanelClose: EventEmitter<ThyPopoverRef<ThyColorPickerPanelComponent>> = new EventEmitter<
-        ThyPopoverRef<ThyColorPickerPanelComponent>
-    >();
+    @Output() thyPanelClose: EventEmitter<ThyPopoverRef<ThyColorPickerPanel>> = new EventEmitter<ThyPopoverRef<ThyColorPickerPanel>>();
 
     /**
      * 弹出悬浮层的触发方式
@@ -144,7 +140,7 @@ export class ThyColorPickerDirective extends _BaseMixin implements OnInit, OnDes
 
     color: string;
 
-    private popoverRef: ThyPopoverRef<ThyColorPickerPanelComponent>;
+    private popoverRef: ThyPopoverRef<ThyColorPickerPanel>;
 
     private closePanel = true;
 
@@ -191,7 +187,7 @@ export class ThyColorPickerDirective extends _BaseMixin implements OnInit, OnDes
 
     togglePanel() {
         this.closePanel = false;
-        this.popoverRef = this.thyPopover.open(ThyColorPickerPanelComponent, {
+        this.popoverRef = this.thyPopover.open(ThyColorPickerPanel, {
             origin: this.elementRef.nativeElement as HTMLElement,
             offset: this.thyOffset,
             manualClosure: true,

--- a/src/color-picker/module.ts
+++ b/src/color-picker/module.ts
@@ -3,15 +3,15 @@ import { ThyInputModule } from 'ngx-tethys/input';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ThyColorPickerDirective } from './color-picker.component';
-import { ThyColorPickerCustomPanelComponent } from './color-picker-custom-panel.component';
-import { ThySaturationComponent } from './parts/saturation/saturation.component';
+import { ThyColorPickerCustomPanel } from './color-picker-custom-panel.component';
+import { ThySaturation } from './parts/saturation/saturation.component';
 import { ThyDialogModule } from 'ngx-tethys/dialog';
-import { ThyHueComponent } from './parts/hue/hue.component';
-import { ThyAlphaComponent } from './parts/alpha/alpha.component';
-import { ThyIndicatorComponent } from './parts/indicator/indicator.component';
+import { ThyHue } from './parts/hue/hue.component';
+import { ThyAlpha } from './parts/alpha/alpha.component';
+import { ThyIndicator } from './parts/indicator/indicator.component';
 import { ThyCoordinatesDirective } from './coordinates.directive';
-import { ThyColorPickerPanelComponent } from './color-picker-panel.component';
-import { ThyColorInputsComponent } from './parts/inputs/inputs.component';
+import { ThyColorPickerPanel } from './color-picker-panel.component';
+import { ThyColorInputs } from './parts/inputs/inputs.component';
 import { FormsModule } from '@angular/forms';
 import { ThyInputNumberModule } from 'ngx-tethys/input-number';
 import { ThySharedModule } from 'ngx-tethys/shared';
@@ -26,14 +26,14 @@ import { ThySharedModule } from 'ngx-tethys/shared';
         ThyInputNumberModule,
         ThySharedModule,
         ThyColorPickerDirective,
-        ThyColorPickerCustomPanelComponent,
-        ThySaturationComponent,
-        ThyHueComponent,
-        ThyAlphaComponent,
-        ThyIndicatorComponent,
+        ThyColorPickerCustomPanel,
+        ThySaturation,
+        ThyHue,
+        ThyAlpha,
+        ThyIndicator,
         ThyCoordinatesDirective,
-        ThyColorPickerPanelComponent,
-        ThyColorInputsComponent
+        ThyColorPickerPanel,
+        ThyColorInputs
     ],
     exports: [ThyColorPickerDirective]
 })

--- a/src/color-picker/parts/alpha/alpha.component.ts
+++ b/src/color-picker/parts/alpha/alpha.component.ts
@@ -24,7 +24,7 @@ import { ThyColor } from '../../helpers/color.class';
     standalone: true,
     imports: [ThyCoordinatesDirective]
 })
-export class ThyAlphaComponent implements OnChanges {
+export class ThyAlpha implements OnChanges {
     @HostBinding('class.thy-alpha') className = true;
 
     @Input() color: ThyColor;

--- a/src/color-picker/parts/hue/hue.component.ts
+++ b/src/color-picker/parts/hue/hue.component.ts
@@ -24,7 +24,7 @@ import { ThyColor } from '../../helpers/color.class';
     standalone: true,
     imports: [ThyCoordinatesDirective]
 })
-export class ThyHueComponent implements OnChanges {
+export class ThyHue implements OnChanges {
     @HostBinding('class.thy-hue') className = true;
 
     @Input() color: ThyColor;

--- a/src/color-picker/parts/indicator/indicator.component.ts
+++ b/src/color-picker/parts/indicator/indicator.component.ts
@@ -9,7 +9,7 @@ import { ThyColor } from '../../helpers/color.class';
     templateUrl: './indicator.component.html',
     standalone: true
 })
-export class ThyIndicatorComponent {
+export class ThyIndicator {
     @HostBinding('class.thy-indicator') className = true;
 
     @Input()

--- a/src/color-picker/parts/inputs/inputs.component.ts
+++ b/src/color-picker/parts/inputs/inputs.component.ts
@@ -1,7 +1,7 @@
 import { Component, EventEmitter, HostBinding, Input, Output } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ThyInputDirective } from 'ngx-tethys/input';
-import { ThyInputNumberComponent } from 'ngx-tethys/input-number';
+import { ThyInputNumber } from 'ngx-tethys/input-number';
 import { ThyEnterDirective } from 'ngx-tethys/shared';
 import { ThyColor } from '../../helpers/color.class';
 
@@ -12,9 +12,9 @@ import { ThyColor } from '../../helpers/color.class';
     selector: 'thy-color-inputs',
     templateUrl: './inputs.component.html',
     standalone: true,
-    imports: [ThyInputDirective, FormsModule, ThyEnterDirective, ThyInputNumberComponent]
+    imports: [ThyInputDirective, FormsModule, ThyEnterDirective, ThyInputNumber]
 })
-export class ThyColorInputsComponent {
+export class ThyColorInputs {
     @HostBinding('class.thy-color-inputs') className = true;
 
     innerColor: ThyColor;

--- a/src/color-picker/parts/saturation/saturation.component.ts
+++ b/src/color-picker/parts/saturation/saturation.component.ts
@@ -22,7 +22,7 @@ import { ThyColor } from '../../helpers/color.class';
     standalone: true,
     imports: [ThyCoordinatesDirective]
 })
-export class ThySaturationComponent implements OnChanges {
+export class ThySaturation implements OnChanges {
     @HostBinding('class.thy-saturation') className = true;
 
     @ViewChild('panel', { static: true })

--- a/src/color-picker/test/color-picker.spec.ts
+++ b/src/color-picker/test/color-picker.spec.ts
@@ -9,8 +9,8 @@ import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform
 import { ThyDialogModule } from 'ngx-tethys/dialog';
 import { ThyPopover, ThyPopoverModule, ThyPopoverRef } from 'ngx-tethys/popover';
 import { dispatchMouseEvent, dispatchTouchEvent } from 'ngx-tethys/testing';
-import { ThyColorPickerCustomPanelComponent } from '../color-picker-custom-panel.component';
-import { ThyColorPickerPanelComponent } from '../color-picker-panel.component';
+import { ThyColorPickerCustomPanel } from '../color-picker-custom-panel.component';
+import { ThyColorPickerPanel } from '../color-picker-panel.component';
 import { ThyColorPickerDirective } from '../color-picker.component';
 import { ThyCoordinatesDirective } from '../coordinates.directive';
 import { ThyColor } from '../helpers/color.class';
@@ -49,7 +49,7 @@ import { ThyColorPickerModule } from '../module';
 })
 class ThyDemoColorPickerComponent {
     @ViewChild(ThyColorPickerDirective, { static: true }) colorPicker: ThyColorPickerDirective;
-    @ViewChild(ThyColorPickerPanelComponent) defaultPanel: ThyColorPickerPanelComponent;
+    @ViewChild(ThyColorPickerPanel) defaultPanel: ThyColorPickerPanel;
     color = '#ddd';
 
     defaultPanelColor = '#fafafa';
@@ -66,7 +66,7 @@ class ThyDemoColorPickerComponent {
 
     disabled = false;
 
-    constructor(public elementRef: ElementRef<HTMLElement>, private thyPopoverRef: ThyPopoverRef<ThyColorPickerPanelComponent>) {}
+    constructor(public elementRef: ElementRef<HTMLElement>, private thyPopoverRef: ThyPopoverRef<ThyColorPickerPanel>) {}
 
     change(color: string) {}
 
@@ -90,7 +90,7 @@ class ThyDemoColorPickerComponent {
     `
 })
 class ThyDemoColorDefaultPanelComponent {
-    @ViewChild(ThyColorPickerPanelComponent) defaultPanel: ThyColorPickerPanelComponent;
+    @ViewChild(ThyColorPickerPanel) defaultPanel: ThyColorPickerPanel;
     defaultPanelColor = '#fafafa';
     defaultColor = '';
     transparentColorSelectable: boolean;
@@ -105,7 +105,7 @@ class ThyDemoColorDefaultPanelComponent {
     template: ` <thy-color-picker-custom-panel [pickerColorChange]="pickerColorChange" [color]="color"></thy-color-picker-custom-panel> `
 })
 class ThyDemoPickerPanelComponent {
-    @ViewChild(ThyColorPickerCustomPanelComponent) pickerPanel: ThyColorPickerCustomPanelComponent;
+    @ViewChild(ThyColorPickerCustomPanel) pickerPanel: ThyColorPickerCustomPanel;
 
     color = '#fafafa';
     constructor(public elementRef: ElementRef<HTMLElement>) {}
@@ -175,7 +175,7 @@ describe(`color-picker`, () => {
                 ThyColorPickerModule,
                 ThyPopoverModule,
                 BrowserAnimationsModule,
-                ThyColorPickerPanelComponent,
+                ThyColorPickerPanel,
                 NoopAnimationsModule
             ],
             providers: [ThyPopover, ThyPopoverRef],
@@ -439,7 +439,7 @@ describe('color-default-panel', () => {
                 ThyColorPickerModule,
                 ThyPopoverModule,
                 BrowserAnimationsModule,
-                ThyColorPickerPanelComponent,
+                ThyColorPickerPanel,
                 NoopAnimationsModule
             ],
             providers: [
@@ -572,7 +572,7 @@ describe('picker-panel', () => {
                 ThyColorPickerModule,
                 ThyPopoverModule,
                 BrowserAnimationsModule,
-                ThyColorPickerCustomPanelComponent,
+                ThyColorPickerCustomPanel,
                 NoopAnimationsModule
             ],
             providers: [ThyPopover, ThyPopoverRef],
@@ -671,7 +671,7 @@ describe(`for touch usage`, () => {
                 ThyColorPickerModule,
                 ThyPopoverModule,
                 NoopAnimationsModule,
-                ThyColorPickerPanelComponent
+                ThyColorPickerPanel
             ],
             providers: [ThyPopover, ThyPopoverRef, { provide: Platform, useFactory: () => platform }],
             declarations: [ThyDemoColorPickerComponent]

--- a/src/color-picker/test/parts.spec.ts
+++ b/src/color-picker/test/parts.spec.ts
@@ -1,4 +1,4 @@
-import { ThyInputNumberComponent } from 'ngx-tethys/input-number';
+import { ThyInputNumber } from 'ngx-tethys/input-number';
 import { dispatchEvent, dispatchFakeEvent, dispatchMouseEvent } from 'ngx-tethys/testing';
 
 import { CommonModule } from '@angular/common';
@@ -9,11 +9,11 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ThyColor } from '../helpers/color.class';
 import { ThyColorPickerModule } from '../module';
-import { ThyAlphaComponent } from '../parts/alpha/alpha.component';
-import { ThyHueComponent } from '../parts/hue/hue.component';
-import { ThyIndicatorComponent } from '../parts/indicator/indicator.component';
-import { ThyColorInputsComponent } from '../parts/inputs/inputs.component';
-import { ThySaturationComponent } from '../parts/saturation/saturation.component';
+import { ThyAlpha } from '../parts/alpha/alpha.component';
+import { ThyHue } from '../parts/hue/hue.component';
+import { ThyIndicator } from '../parts/indicator/indicator.component';
+import { ThyColorInputs } from '../parts/inputs/inputs.component';
+import { ThySaturation } from '../parts/saturation/saturation.component';
 
 @Component({
     selector: 'thy-demo-alpha',
@@ -30,7 +30,7 @@ import { ThySaturationComponent } from '../parts/saturation/saturation.component
     ]
 })
 class ThyDemoAlphaComponent {
-    @ViewChild(ThyAlphaComponent) alphaComponent: ThyAlphaComponent;
+    @ViewChild(ThyAlpha) alphaComponent: ThyAlpha;
 
     color = new ThyColor('#fafafa');
 
@@ -46,7 +46,7 @@ class ThyDemoAlphaComponent {
     template: ` <thy-hue [color]="color" (colorChange)="colorChangeEvent($event)"></thy-hue> `
 })
 class ThyDemoHueComponent {
-    @ViewChild(ThyHueComponent) hueComponent: ThyHueComponent;
+    @ViewChild(ThyHue) hueComponent: ThyHue;
 
     color = new ThyColor('#fafafa');
 
@@ -62,7 +62,7 @@ class ThyDemoHueComponent {
     template: ` <thy-saturation [color]="color" (colorChange)="colorChangeEvent($event)"></thy-saturation> `
 })
 class ThyDemoSaturationComponent {
-    @ViewChild(ThySaturationComponent) hueComponent: ThySaturationComponent;
+    @ViewChild(ThySaturation) hueComponent: ThySaturation;
 
     color = new ThyColor('#fafafa');
 
@@ -78,8 +78,8 @@ class ThyDemoSaturationComponent {
     template: ` <thy-color-inputs [color]="color" (colorChange)="colorChangeEvent($event)"></thy-color-inputs> `
 })
 class ThyDemoColorInputsComponent {
-    @ViewChild(ThyColorInputsComponent) colorInputsComponent: ThyColorInputsComponent;
-    @ViewChild(ThyInputNumberComponent) inputNumber: ThyInputNumberComponent;
+    @ViewChild(ThyColorInputs) colorInputsComponent: ThyColorInputs;
+    @ViewChild(ThyInputNumber) inputNumber: ThyInputNumber;
 
     color = new ThyColor('#fafafa');
 
@@ -95,7 +95,7 @@ class ThyDemoColorInputsComponent {
     template: ` <thy-indicator [color]="color" (colorChange)="colorChangeEvent($event)"></thy-indicator> `
 })
 class ThyDemoIndicatorComponent {
-    @ViewChild(ThyIndicatorComponent) colorIndicatorComponent: ThyIndicatorComponent;
+    @ViewChild(ThyIndicator) colorIndicatorComponent: ThyIndicator;
 
     color = new ThyColor('#ddd');
 
@@ -112,7 +112,7 @@ describe('thy-alpha', () => {
     let alphaElement: HTMLElement;
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [CommonModule, FormsModule, ThyColorPickerModule, BrowserAnimationsModule, ThyAlphaComponent],
+            imports: [CommonModule, FormsModule, ThyColorPickerModule, BrowserAnimationsModule, ThyAlpha],
             providers: [],
             declarations: [ThyDemoAlphaComponent]
         });
@@ -169,7 +169,7 @@ describe('thy-hue', () => {
     let fixtureInstance: ThyDemoHueComponent;
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [CommonModule, FormsModule, ThyColorPickerModule, BrowserAnimationsModule, ThyHueComponent],
+            imports: [CommonModule, FormsModule, ThyColorPickerModule, BrowserAnimationsModule, ThyHue],
             providers: [],
             declarations: [ThyDemoHueComponent]
         });
@@ -227,7 +227,7 @@ describe('thy-saturation', () => {
     let fixtureInstance: ThyDemoSaturationComponent;
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [CommonModule, FormsModule, ThyColorPickerModule, BrowserAnimationsModule, ThySaturationComponent],
+            imports: [CommonModule, FormsModule, ThyColorPickerModule, BrowserAnimationsModule, ThySaturation],
             providers: [],
             declarations: [ThyDemoSaturationComponent]
         });
@@ -290,7 +290,7 @@ describe('thy-color-inputs', () => {
     let fixtureInstance: ThyDemoColorInputsComponent;
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [CommonModule, FormsModule, ThyColorPickerModule, BrowserAnimationsModule, ThyColorInputsComponent],
+            imports: [CommonModule, FormsModule, ThyColorPickerModule, BrowserAnimationsModule, ThyColorInputs],
             providers: [],
             declarations: [ThyDemoColorInputsComponent]
         });
@@ -345,7 +345,7 @@ describe('thy-indicator', () => {
     let fixtureInstance: ThyDemoIndicatorComponent;
     beforeEach(() => {
         TestBed.configureTestingModule({
-            imports: [CommonModule, FormsModule, ThyColorPickerModule, BrowserAnimationsModule, ThyIndicatorComponent],
+            imports: [CommonModule, FormsModule, ThyColorPickerModule, BrowserAnimationsModule, ThyIndicator],
             providers: [],
             declarations: [ThyDemoIndicatorComponent]
         });

--- a/src/comment/comment.component.ts
+++ b/src/comment/comment.component.ts
@@ -1,7 +1,7 @@
 import { isTemplateRef } from 'ngx-tethys/util';
 import { SafeAny } from 'ngx-tethys/types';
 import { ChangeDetectionStrategy, Component, Input, TemplateRef } from '@angular/core';
-import { ThyAvatarComponent } from 'ngx-tethys/avatar';
+import { ThyAvatar } from 'ngx-tethys/avatar';
 import { ThyStringOrTemplateOutletDirective } from 'ngx-tethys/shared';
 import { NgIf, NgTemplateOutlet } from '@angular/common';
 
@@ -17,9 +17,9 @@ import { NgIf, NgTemplateOutlet } from '@angular/common';
     },
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgIf, NgTemplateOutlet, ThyStringOrTemplateOutletDirective, ThyAvatarComponent]
+    imports: [NgIf, NgTemplateOutlet, ThyStringOrTemplateOutletDirective, ThyAvatar]
 })
-export class ThyCommentComponent {
+export class ThyComment {
     /**
      * 展示评论作者
      */

--- a/src/comment/comment.module.ts
+++ b/src/comment/comment.module.ts
@@ -1,7 +1,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ThySharedModule } from 'ngx-tethys/shared';
-import { ThyCommentComponent } from './comment.component';
+import { ThyComment } from './comment.component';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyAvatarModule } from 'ngx-tethys/avatar';
 import { ThyCommentContentDirective } from './comment-content.directive';
@@ -12,11 +12,11 @@ import { ThyCommentActionsDirective } from './comment-actions.directive';
         ThySharedModule,
         ThyIconModule,
         ThyAvatarModule,
-        ThyCommentComponent,
+        ThyComment,
         ThyCommentContentDirective,
         ThyCommentActionsDirective
     ],
-    exports: [ThyCommentComponent, ThyCommentContentDirective, ThyCommentActionsDirective],
+    exports: [ThyComment, ThyCommentContentDirective, ThyCommentActionsDirective],
     providers: []
 })
 export class ThyCommentModule {}

--- a/src/comment/test/comment.component.spec.ts
+++ b/src/comment/test/comment.component.spec.ts
@@ -1,4 +1,4 @@
-import { ThyCommentComponent, ThyCommentModule } from 'ngx-tethys/comment';
+import { ThyComment, ThyCommentModule } from 'ngx-tethys/comment';
 import { waitForAsync, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ThyCommentNestExampleComponent } from './../examples/nest/nest.component';
@@ -15,7 +15,7 @@ describe('thyCommentComponent', () => {
     describe('basic', () => {
         it('should basic work', () => {
             const fixture = TestBed.createComponent(ThyCommentBasicExampleComponent);
-            const comment = fixture.debugElement.query(By.directive(ThyCommentComponent));
+            const comment = fixture.debugElement.query(By.directive(ThyComment));
 
             fixture.detectChanges();
             expect(comment.nativeElement.classList).toContain('thy-comment');
@@ -36,13 +36,13 @@ describe('thyCommentComponent', () => {
             const fixture = TestBed.createComponent(ThyCommentNestExampleComponent);
             fixture.detectChanges();
 
-            const rootComment = fixture.debugElement.query(By.directive(ThyCommentComponent));
+            const rootComment = fixture.debugElement.query(By.directive(ThyComment));
             expect(rootComment.nativeElement).toBeTruthy();
 
-            const levelTwoComment = rootComment.query(By.directive(ThyCommentComponent));
+            const levelTwoComment = rootComment.query(By.directive(ThyComment));
             expect(levelTwoComment.nativeElement).toBeTruthy();
 
-            const levelThreeComments = levelTwoComment.queryAll(By.directive(ThyCommentComponent));
+            const levelThreeComments = levelTwoComment.queryAll(By.directive(ThyComment));
             expect(levelThreeComments.length).toBe(2);
         });
     });

--- a/src/date-picker/abstract-picker.component.ts
+++ b/src/date-picker/abstract-picker.component.ts
@@ -17,7 +17,7 @@ import {
 import { ControlValueAccessor } from '@angular/forms';
 
 import { CompatibleValue, RangeAdvancedValue } from './inner-types';
-import { ThyPickerComponent } from './picker.component';
+import { ThyPicker } from './picker.component';
 import { makeValue, transformDateValue } from './picker.util';
 import {
     CompatibleDate,
@@ -172,7 +172,7 @@ export abstract class AbstractPickerComponent
 
     @Output() readonly thyOpenChange = new EventEmitter<boolean>();
 
-    @ViewChild(ThyPickerComponent, { static: true }) public picker: ThyPickerComponent;
+    @ViewChild(ThyPicker, { static: true }) public picker: ThyPicker;
 
     /**
      * 是否禁用

--- a/src/date-picker/abstract-picker.directive.ts
+++ b/src/date-picker/abstract-picker.directive.ts
@@ -21,7 +21,7 @@ import {
 } from '@angular/core';
 
 import { AbstractPickerComponent } from './abstract-picker.component';
-import { DatePopupComponent } from './lib/popups/date-popup.component';
+import { DatePopup } from './lib/popups/date-popup.component';
 import { ThyDateChangeEvent, ThyPanelMode, ThyShortcutValueChange } from './standard-types';
 import { CompatibleValue } from './inner-types';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -139,7 +139,7 @@ export abstract class PickerDirective extends AbstractPickerComponent implements
     private openOverlay(): void {
         this.getInitialState();
         const popoverRef = this.thyPopover.open(
-            DatePopupComponent,
+            DatePopup,
             Object.assign(
                 {
                     origin: this.el,

--- a/src/date-picker/base-picker.component.ts
+++ b/src/date-picker/base-picker.component.ts
@@ -21,7 +21,7 @@ import {
 import { AbstractPickerComponent } from './abstract-picker.component';
 import { CompatibleValue, RangeAdvancedValue } from './inner-types';
 import { CompatibleDate, ThyPanelMode } from './standard-types';
-import { ThyPickerComponent } from './picker.component';
+import { ThyPicker } from './picker.component';
 import { hasTimeInStringDate, isValidStringDate, parseStringDate, transformDateValue } from './picker.util';
 import { isPlatformBrowser } from '@angular/common';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
@@ -38,7 +38,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
         '(blur)': 'onBlur($event)'
     }
 })
-export class BasePickerComponent extends AbstractPickerComponent implements OnInit, OnChanges {
+export class BasePicker extends AbstractPickerComponent implements OnInit, OnChanges {
     showWeek = false;
 
     panelMode: ThyPanelMode | ThyPanelMode[];
@@ -47,7 +47,7 @@ export class BasePickerComponent extends AbstractPickerComponent implements OnIn
 
     private innerPreviousDate: string;
 
-    @ViewChild('thyPicker', { static: true }) thyPicker: ThyPickerComponent;
+    @ViewChild('thyPicker', { static: true }) thyPicker: ThyPicker;
 
     @Input() thyDateRender: FunctionProp<TemplateRef<Date> | string>;
 

--- a/src/date-picker/date-picker.component.spec.ts
+++ b/src/date-picker/date-picker.component.spec.ts
@@ -9,12 +9,12 @@ import { Component, DebugElement, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, flush, inject, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { ThyDatePickerComponent } from './date-picker.component';
+import { ThyDatePicker } from './date-picker.component';
 import { ThyDatePickerModule } from './date-picker.module';
-import { ThyPickerComponent } from './picker.component';
+import { ThyPicker } from './picker.component';
 import { DateEntry, DisabledDateFn } from './standard-types';
 import { THY_DATE_PICKER_CONFIG } from './date-picker.config';
-import { DatePopupComponent } from './lib/popups/date-popup.component';
+import { DatePopup } from './lib/popups/date-popup.component';
 import { TinyDate } from 'ngx-tethys/util';
 import { take } from 'rxjs/operators';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -141,7 +141,7 @@ describe('ThyDatePickerComponent', () => {
             fixture.detectChanges();
             openPickerByClickTrigger();
 
-            const datePopupComponent = fixture.debugElement.query(By.directive(DatePopupComponent)).componentInstance;
+            const datePopupComponent = fixture.debugElement.query(By.directive(DatePopup)).componentInstance;
             datePopupComponent.shortcutSetValue({ value: null });
 
             const input = getPickerTrigger();
@@ -227,7 +227,7 @@ describe('ThyDatePickerComponent', () => {
         it('should call onFocus methods when focus', fakeAsync(() => {
             fixture.detectChanges();
             const focusSpy = spyOn<any>(fixture.componentInstance.datePicker, 'onFocus').and.callThrough();
-            const dataPickerElement = fixture.debugElement.query(By.directive(ThyDatePickerComponent)).nativeElement;
+            const dataPickerElement = fixture.debugElement.query(By.directive(ThyDatePicker)).nativeElement;
             dispatchFakeEvent(dataPickerElement, 'focus');
             fixture.detectChanges();
             flush();
@@ -237,7 +237,7 @@ describe('ThyDatePickerComponent', () => {
         it('should call onBlur methods when blur', fakeAsync(() => {
             fixture.detectChanges();
             const blurSpy = spyOn<any>(fixture.componentInstance.datePicker, 'onBlur').and.callThrough();
-            const datePickerElement = fixture.debugElement.query(By.directive(ThyDatePickerComponent)).nativeElement;
+            const datePickerElement = fixture.debugElement.query(By.directive(ThyDatePicker)).nativeElement;
             dispatchFakeEvent(datePickerElement, 'blur');
             fixture.detectChanges();
             flush();
@@ -805,7 +805,7 @@ describe('ThyDatePickerComponent', () => {
             fixtureInstance.thyPlacement = placement;
             fixture.detectChanges();
             openPickerByClickTrigger();
-            const pickComponentInstance = fixture.debugElement.query(By.directive(ThyPickerComponent)).componentInstance;
+            const pickComponentInstance = fixture.debugElement.query(By.directive(ThyPicker)).componentInstance;
             expect(pickComponentInstance.overlayPositions[0].originY).toEqual(placement);
         }));
 
@@ -1337,7 +1337,7 @@ class ThyTestDatePickerComponent {
     useSuite: 1 | 2 | 3;
     @ViewChild('tplDateRender', { static: true }) tplDateRender: TemplateRef<Date>;
 
-    @ViewChild(ThyDatePickerComponent, { static: false }) datePicker: ThyDatePickerComponent;
+    @ViewChild(ThyDatePicker, { static: false }) datePicker: ThyDatePicker;
 
     // --- Suite 1
     hasBackdrop: boolean = true;

--- a/src/date-picker/date-picker.component.ts
+++ b/src/date-picker/date-picker.component.ts
@@ -3,9 +3,9 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { useHostRenderer } from '@tethys/cdk/dom';
 
 import { NgIf } from '@angular/common';
-import { BasePickerComponent } from './base-picker.component';
-import { DatePopupComponent } from './lib/popups/date-popup.component';
-import { ThyPickerComponent } from './picker.component';
+import { BasePicker } from './base-picker.component';
+import { DatePopup } from './lib/popups/date-popup.component';
+import { ThyPicker } from './picker.component';
 
 /**
  * 日期选择组件
@@ -21,16 +21,16 @@ import { ThyPickerComponent } from './picker.component';
         {
             provide: NG_VALUE_ACCESSOR,
             multi: true,
-            useExisting: forwardRef(() => ThyDatePickerComponent)
+            useExisting: forwardRef(() => ThyDatePicker)
         }
     ],
     standalone: true,
-    imports: [ThyPickerComponent, NgIf, DatePopupComponent],
+    imports: [ThyPicker, NgIf, DatePopup],
     host: {
         '[attr.tabindex]': 'tabIndex'
     }
 })
-export class ThyDatePickerComponent extends BasePickerComponent implements OnInit {
+export class ThyDatePicker extends BasePicker implements OnInit {
     isRange = false;
 
     private hostRenderer = useHostRenderer();

--- a/src/date-picker/date-picker.directive.spec.ts
+++ b/src/date-picker/date-picker.directive.spec.ts
@@ -12,10 +12,10 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { addDays, startOfDay } from 'date-fns';
 
 import { ThyPopover } from '../popover/popover.service';
-import { ThyPropertyOperationComponent, ThyPropertyOperationModule } from '../property-operation';
+import { ThyPropertyOperation, ThyPropertyOperationModule } from '../property-operation';
 import { ThyDatePickerDirective } from './date-picker.directive';
 import { ThyDatePickerModule } from './date-picker.module';
-import { DatePopupComponent } from './lib/popups/date-popup.component';
+import { DatePopup } from './lib/popups/date-popup.component';
 import { ThyPopoverConfig, ThyPopoverModule } from '../popover';
 import { CompatiblePresets, ThyShortcutPosition } from './standard-types';
 
@@ -188,7 +188,7 @@ describe('ThyPickerDirective', () => {
                 openPickerByClickTrigger();
 
                 expect(spy).toHaveBeenCalled();
-                expect(spy).toHaveBeenCalledWith(DatePopupComponent, {
+                expect(spy).toHaveBeenCalledWith(DatePopup, {
                     origin: debugElement.nativeElement.childNodes[0],
                     hasBackdrop: true,
                     backdropClass: 'thy-overlay-transparent-backdrop',
@@ -204,7 +204,7 @@ describe('ThyPickerDirective', () => {
                 fixture.detectChanges();
                 openPickerByClickTrigger();
 
-                expect(spy).toHaveBeenCalledWith(DatePopupComponent, {
+                expect(spy).toHaveBeenCalledWith(DatePopup, {
                     origin: debugElement.nativeElement.childNodes[0],
                     hasBackdrop: false,
                     backdropClass: 'thy-overlay-transparent-backdrop',
@@ -231,7 +231,7 @@ describe('ThyPickerDirective', () => {
 
                 expect(spy).toHaveBeenCalled();
                 expect(spy).toHaveBeenCalledWith(
-                    DatePopupComponent,
+                    DatePopup,
                     Object.assign(
                         {
                             origin: debugElement.nativeElement.childNodes[0],
@@ -259,7 +259,7 @@ describe('ThyPickerDirective', () => {
         });
 
         function getPickerTriggerWrapper() {
-            const element = debugElement.query(By.directive(ThyPropertyOperationComponent)).nativeElement;
+            const element = debugElement.query(By.directive(ThyPropertyOperation)).nativeElement;
             return element;
         }
 
@@ -324,7 +324,7 @@ describe('ThyPickerDirective', () => {
                 openPickerByClickTrigger();
 
                 expect(spy).toHaveBeenCalled();
-                expect(spy).toHaveBeenCalledWith(DatePopupComponent, {
+                expect(spy).toHaveBeenCalledWith(DatePopup, {
                     origin: debugElement.nativeElement.childNodes[0],
                     hasBackdrop: true,
                     backdropClass: 'thy-overlay-transparent-backdrop',
@@ -338,7 +338,7 @@ describe('ThyPickerDirective', () => {
 
         describe('should Date Popup Component enablePrevNext', () => {
             it('should Date Popup Component enablePrevNext', fakeAsync(() => {
-                const popoverRef = popover.open(DatePopupComponent, {
+                const popoverRef = popover.open(DatePopup, {
                     origin: debugElement.nativeElement.childNodes[0],
                     hasBackdrop: true,
                     backdropClass: 'thy-overlay-transparent-backdrop',
@@ -361,7 +361,7 @@ describe('ThyPickerDirective', () => {
         });
 
         function getPickerTriggerWrapper() {
-            const element = debugElement.query(By.directive(ThyPropertyOperationComponent)).nativeElement;
+            const element = debugElement.query(By.directive(ThyPropertyOperation)).nativeElement;
             return element;
         }
 

--- a/src/date-picker/date-picker.module.ts
+++ b/src/date-picker/date-picker.module.ts
@@ -5,13 +5,13 @@ import localeZhHans from '@angular/common/locales/zh-Hans';
 
 import { LibPackerModule } from './lib/lib-packer.module';
 
-import { BasePickerComponent } from './base-picker.component';
-import { ThyDatePickerComponent } from './date-picker.component';
-import { ThyMonthPickerComponent } from './month-picker.component';
-import { ThyRangePickerComponent } from './range-picker.component';
-import { ThyWeekPickerComponent } from './week-picker.component';
-import { ThyYearPickerComponent } from './year-picker.component';
-import { ThyPickerComponent } from './picker.component';
+import { BasePicker } from './base-picker.component';
+import { ThyDatePicker } from './date-picker.component';
+import { ThyMonthPicker } from './month-picker.component';
+import { ThyRangePicker } from './range-picker.component';
+import { ThyWeekPicker } from './week-picker.component';
+import { ThyYearPicker } from './year-picker.component';
+import { ThyPicker } from './picker.component';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyInputModule } from 'ngx-tethys/input';
 import { DatePickerRequiredValidator, RangePickerRequiredValidator } from './picker.validators';
@@ -20,7 +20,7 @@ import { ThyDatePickerDirective } from './date-picker.directive';
 import { ThyRangePickerDirective } from './range-picker.directive';
 import { ThyPopoverModule } from 'ngx-tethys/popover';
 import { ThyDatePickerConfigService } from './date-picker.service';
-import { ThyQuarterPickerComponent } from './quarter-picker.component';
+import { ThyQuarterPicker } from './quarter-picker.component';
 
 registerLocaleData(localeZhHans, 'zh-Hans');
 
@@ -32,14 +32,14 @@ registerLocaleData(localeZhHans, 'zh-Hans');
         ThyIconModule,
         ThyInputModule,
         ThyPopoverModule,
-        BasePickerComponent,
-        ThyPickerComponent,
-        ThyDatePickerComponent,
-        ThyMonthPickerComponent,
-        ThyYearPickerComponent,
-        ThyQuarterPickerComponent,
-        ThyWeekPickerComponent,
-        ThyRangePickerComponent,
+        BasePicker,
+        ThyPicker,
+        ThyDatePicker,
+        ThyMonthPicker,
+        ThyYearPicker,
+        ThyQuarterPicker,
+        ThyWeekPicker,
+        ThyRangePicker,
         DatePickerRequiredValidator,
         RangePickerRequiredValidator,
         ThyDatePickerFormatPipe,
@@ -49,12 +49,12 @@ registerLocaleData(localeZhHans, 'zh-Hans');
         ThyRangePickerDirective
     ],
     exports: [
-        ThyDatePickerComponent,
-        ThyRangePickerComponent,
-        ThyMonthPickerComponent,
-        ThyYearPickerComponent,
-        ThyQuarterPickerComponent,
-        ThyWeekPickerComponent,
+        ThyDatePicker,
+        ThyRangePicker,
+        ThyMonthPicker,
+        ThyYearPicker,
+        ThyQuarterPicker,
+        ThyWeekPicker,
         DatePickerRequiredValidator,
         RangePickerRequiredValidator,
         ThyDatePickerFormatPipe,

--- a/src/date-picker/decade-table.component.spec.ts
+++ b/src/date-picker/decade-table.component.spec.ts
@@ -2,7 +2,7 @@ import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { DecadeTableComponent } from './lib/decade/decade-table.component';
+import { DecadeTable } from './lib/decade/decade-table.component';
 import { LibPackerModule } from './lib/lib-packer.module';
 
 describe('DecadeTableComponent', () => {
@@ -21,7 +21,7 @@ describe('DecadeTableComponent', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyTestDecadeTableComponent);
         fixtureInstance = fixture.componentInstance;
-        decadeComponent = fixture.debugElement.query(By.directive(DecadeTableComponent));
+        decadeComponent = fixture.debugElement.query(By.directive(DecadeTable));
     });
 
     it('should be created table component', () => {

--- a/src/date-picker/lib/calendar/calendar-footer.component.ts
+++ b/src/date-picker/lib/calendar/calendar-footer.component.ts
@@ -12,10 +12,10 @@ import {
 } from '@angular/core';
 
 import { TinyDate } from 'ngx-tethys/util';
-import { ThyButtonComponent } from 'ngx-tethys/button';
+import { ThyButton } from 'ngx-tethys/button';
 import { FormsModule } from '@angular/forms';
-import { ThyInnerTimePickerComponent } from 'ngx-tethys/time-picker';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyInnerTimePicker } from 'ngx-tethys/time-picker';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf } from '@angular/common';
 import { InputBoolean } from 'ngx-tethys/core';
 
@@ -29,9 +29,9 @@ import { InputBoolean } from 'ngx-tethys/core';
     exportAs: 'calendarFooter',
     templateUrl: 'calendar-footer.component.html',
     standalone: true,
-    imports: [NgIf, ThyIconComponent, ThyInnerTimePickerComponent, FormsModule, ThyButtonComponent]
+    imports: [NgIf, ThyIcon, ThyInnerTimePicker, FormsModule, ThyButton]
 })
-export class CalendarFooterComponent implements OnInit, OnChanges {
+export class CalendarFooter implements OnInit, OnChanges {
     @Input() showTime = false;
     @Input() mustShowTime = false;
     @Input() value: TinyDate;

--- a/src/date-picker/lib/date-carousel/date-carousel.component.spec.ts
+++ b/src/date-picker/lib/date-carousel/date-carousel.component.spec.ts
@@ -7,7 +7,7 @@ import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { LibPackerModule } from 'ngx-tethys/date-picker';
 import { dispatchMouseEvent } from 'ngx-tethys/testing';
-import { DateCarouselComponent } from './date-carousel.component';
+import { DateCarousel } from './date-carousel.component';
 import { RangeAdvancedValue } from '../../inner-types';
 
 registerLocaleData(zh);
@@ -32,7 +32,7 @@ describe('TestDateCarouselComponent', () => {
         fixture = TestBed.createComponent(TestDateCarouselComponent);
         fixtureInstance = fixture.componentInstance;
         debugElement = fixture.debugElement;
-        nativeElement = fixture.debugElement.query(By.directive(DateCarouselComponent)).nativeElement;
+        nativeElement = fixture.debugElement.query(By.directive(DateCarousel)).nativeElement;
     });
 
     describe('date-carousel testing', () => {

--- a/src/date-picker/lib/date-carousel/date-carousel.component.ts
+++ b/src/date-picker/lib/date-carousel/date-carousel.component.ts
@@ -1,8 +1,8 @@
 import { NgClass, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, forwardRef, HostBinding, Input, OnDestroy, OnInit } from '@angular/core';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { ThyButtonComponent } from 'ngx-tethys/button';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyButton } from 'ngx-tethys/button';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { TinyDate } from 'ngx-tethys/util';
 import { Subject } from 'rxjs';
 import { AdvancedSelectableCell, RangeAdvancedValue } from '../../inner-types';
@@ -21,13 +21,13 @@ import { ThyDateGranularity } from '../../standard-types';
         {
             provide: NG_VALUE_ACCESSOR,
             multi: true,
-            useExisting: forwardRef(() => DateCarouselComponent)
+            useExisting: forwardRef(() => DateCarousel)
         }
     ],
     standalone: true,
-    imports: [NgTemplateOutlet, ThyButtonComponent, ThyIconComponent, NgFor, NgClass, NgIf, DatePickerAdvancedShowYearTipPipe]
+    imports: [NgTemplateOutlet, ThyButton, ThyIcon, NgFor, NgClass, NgIf, DatePickerAdvancedShowYearTipPipe]
 })
-export class DateCarouselComponent implements OnInit, ControlValueAccessor, OnDestroy {
+export class DateCarousel implements OnInit, ControlValueAccessor, OnDestroy {
     @HostBinding('class') className = 'thy-date-picker-advanced-carousel';
 
     @Input() activeDate: TinyDate;

--- a/src/date-picker/lib/date/date-header.component.ts
+++ b/src/date-picker/lib/date/date-header.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { DateHelperService } from '../../../date-picker/date-helper.service';
 import { CalendarHeader, PanelSelector } from '../calendar/calendar-header.component';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgFor } from '@angular/common';
 
 /**
@@ -13,9 +13,9 @@ import { NgIf, NgFor } from '@angular/common';
     selector: 'date-header',
     templateUrl: '../calendar/calendar-header.component.html',
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgFor]
+    imports: [NgIf, ThyIcon, NgFor]
 })
-export class DateHeaderComponent extends CalendarHeader {
+export class DateHeader extends CalendarHeader {
     constructor(public dateHelper: DateHelperService) {
         super(dateHelper);
     }

--- a/src/date-picker/lib/date/date-table-cell.component.ts
+++ b/src/date-picker/lib/date/date-table-cell.component.ts
@@ -16,7 +16,7 @@ import { NgSwitch, NgSwitchCase, NgTemplateOutlet, NgSwitchDefault, NgIf } from 
     standalone: true,
     imports: [NgSwitch, NgSwitchCase, NgTemplateOutlet, NgSwitchDefault, NgIf]
 })
-export class DateTableCellComponent {
+export class DateTableCell {
     isTemplateRef = isTemplateRef;
 
     @Input() prefixCls: 'thy-calendar';

--- a/src/date-picker/lib/date/date-table.component.ts
+++ b/src/date-picker/lib/date/date-table.component.ts
@@ -3,7 +3,7 @@ import { ChangeDetectionStrategy, Component, EventEmitter, OnChanges, Output } f
 import { DateHelperService } from '../../date-helper.service';
 import { DateCell, DateBodyRow } from './types';
 import { CalendarTable } from '../calendar/calendar-table.component';
-import { DateTableCellComponent } from './date-table-cell.component';
+import { DateTableCell } from './date-table-cell.component';
 import { NgIf, NgFor, NgClass } from '@angular/common';
 import { ThyDatePickerConfigService } from '../../date-picker.service';
 
@@ -17,9 +17,9 @@ import { ThyDatePickerConfigService } from '../../date-picker.service';
     exportAs: 'dateTable',
     templateUrl: 'date-table.component.html',
     standalone: true,
-    imports: [NgIf, NgFor, NgClass, DateTableCellComponent]
+    imports: [NgIf, NgFor, NgClass, DateTableCell]
 })
-export class DateTableComponent extends CalendarTable implements OnChanges {
+export class DateTable extends CalendarTable implements OnChanges {
     @Output() readonly dayHover = new EventEmitter<TinyDate>(); // Emitted when hover on a day by mouse enter
 
     constructor(private dateHelper: DateHelperService, private datePickerConfigService: ThyDatePickerConfigService) {

--- a/src/date-picker/lib/decade/decade-header.component.ts
+++ b/src/date-picker/lib/decade/decade-header.component.ts
@@ -2,7 +2,7 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
 
 import { DateHelperService } from '../../../date-picker/date-helper.service';
 import { CalendarHeader, PanelSelector } from '../calendar/calendar-header.component';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgFor } from '@angular/common';
 
 /**
@@ -14,9 +14,9 @@ import { NgIf, NgFor } from '@angular/common';
     selector: 'decade-header',
     templateUrl: '../calendar/calendar-header.component.html',
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgFor]
+    imports: [NgIf, ThyIcon, NgFor]
 })
-export class DecadeHeaderComponent extends CalendarHeader {
+export class DecadeHeader extends CalendarHeader {
     constructor(public dateHelper: DateHelperService) {
         super(dateHelper);
     }

--- a/src/date-picker/lib/decade/decade-table.component.ts
+++ b/src/date-picker/lib/decade/decade-table.component.ts
@@ -16,7 +16,7 @@ import { NgFor, NgClass } from '@angular/common';
     standalone: true,
     imports: [NgFor, NgClass]
 })
-export class DecadeTableComponent extends CalendarTable implements OnChanges {
+export class DecadeTable extends CalendarTable implements OnChanges {
     MAX_ROW = 4;
     MAX_COL = 3;
 

--- a/src/date-picker/lib/lib-packer.module.ts
+++ b/src/date-picker/lib/lib-packer.module.ts
@@ -1,27 +1,27 @@
-import { MonthHeaderComponent } from './month/month-header.component';
+import { MonthHeader } from './month/month-header.component';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { CalendarFooterComponent } from './calendar/calendar-footer.component';
-import { DatePopupComponent } from './popups/date-popup.component';
-import { InnerPopupComponent } from './popups/inner-popup.component';
-import { MonthTableComponent } from './month/month-table.component';
-import { DateTableComponent } from './date/date-table.component';
-import { DateTableCellComponent } from './date/date-table-cell.component';
+import { CalendarFooter } from './calendar/calendar-footer.component';
+import { DatePopup } from './popups/date-popup.component';
+import { InnerPopup } from './popups/inner-popup.component';
+import { MonthTable } from './month/month-table.component';
+import { DateTable } from './date/date-table.component';
+import { DateTableCell } from './date/date-table-cell.component';
 import { ThyButtonModule } from 'ngx-tethys/button';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyTimePickerModule } from 'ngx-tethys/time-picker';
-import { YearTableComponent } from './year/year-table.component';
-import { YearHeaderComponent } from './year/year-header.component';
-import { DecadeHeaderComponent } from './decade/decade-header.component';
-import { DecadeTableComponent } from './decade/decade-table.component';
-import { DateHeaderComponent } from './date/date-header.component';
+import { YearTable } from './year/year-table.component';
+import { YearHeader } from './year/year-header.component';
+import { DecadeHeader } from './decade/decade-header.component';
+import { DecadeTable } from './decade/decade-table.component';
+import { DateHeader } from './date/date-header.component';
 import { ThyNavModule } from 'ngx-tethys/nav';
 import { ThyInputModule } from 'ngx-tethys/input';
-import { DateCarouselComponent } from './date-carousel/date-carousel.component';
+import { DateCarousel } from './date-carousel/date-carousel.component';
 import { DatePickerAdvancedShowYearTipPipe } from '../picker.pipes';
-import { QuarterTableComponent } from './quarter/quarter-table.component';
+import { QuarterTable } from './quarter/quarter-table.component';
 
 @NgModule({
     imports: [
@@ -32,37 +32,37 @@ import { QuarterTableComponent } from './quarter/quarter-table.component';
         ThyTimePickerModule,
         ThyNavModule,
         ThyInputModule,
-        CalendarFooterComponent,
-        DateTableComponent,
-        DateHeaderComponent,
-        YearTableComponent,
-        YearHeaderComponent,
-        MonthTableComponent,
-        MonthHeaderComponent,
-        QuarterTableComponent,
-        DecadeHeaderComponent,
-        DecadeTableComponent,
-        InnerPopupComponent,
-        DatePopupComponent,
-        DateTableCellComponent,
-        DateCarouselComponent,
+        CalendarFooter,
+        DateTable,
+        DateHeader,
+        YearTable,
+        YearHeader,
+        MonthTable,
+        MonthHeader,
+        QuarterTable,
+        DecadeHeader,
+        DecadeTable,
+        InnerPopup,
+        DatePopup,
+        DateTableCell,
+        DateCarousel,
         DatePickerAdvancedShowYearTipPipe
     ],
     exports: [
-        CalendarFooterComponent,
-        DateTableComponent,
-        DateHeaderComponent,
-        YearTableComponent,
-        YearHeaderComponent,
-        MonthTableComponent,
-        MonthHeaderComponent,
-        QuarterTableComponent,
-        DecadeHeaderComponent,
-        DecadeTableComponent,
-        InnerPopupComponent,
-        DatePopupComponent,
-        DateTableCellComponent,
-        DateCarouselComponent
+        CalendarFooter,
+        DateTable,
+        DateHeader,
+        YearTable,
+        YearHeader,
+        MonthTable,
+        MonthHeader,
+        QuarterTable,
+        DecadeHeader,
+        DecadeTable,
+        InnerPopup,
+        DatePopup,
+        DateTableCell,
+        DateCarousel
     ]
 })
 export class LibPackerModule {}

--- a/src/date-picker/lib/month/month-header.component.ts
+++ b/src/date-picker/lib/month/month-header.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { DateHelperService } from '../../../date-picker/date-helper.service';
 import { CalendarHeader, PanelSelector } from '../calendar/calendar-header.component';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgFor } from '@angular/common';
 
 /**
@@ -13,9 +13,9 @@ import { NgIf, NgFor } from '@angular/common';
     selector: 'month-header',
     templateUrl: '../calendar/calendar-header.component.html',
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgFor]
+    imports: [NgIf, ThyIcon, NgFor]
 })
-export class MonthHeaderComponent extends CalendarHeader {
+export class MonthHeader extends CalendarHeader {
     constructor(public dateHelper: DateHelperService) {
         super(dateHelper);
     }

--- a/src/date-picker/lib/month/month-table.component.ts
+++ b/src/date-picker/lib/month/month-table.component.ts
@@ -17,7 +17,7 @@ import { NgFor, NgClass, NgSwitch, NgSwitchCase } from '@angular/common';
     standalone: true,
     imports: [NgFor, NgClass, NgSwitch, NgSwitchCase]
 })
-export class MonthTableComponent extends CalendarTable implements OnChanges {
+export class MonthTable extends CalendarTable implements OnChanges {
     MAX_ROW = 4;
 
     MAX_COL = 3;

--- a/src/date-picker/lib/popups/date-popup.component.ts
+++ b/src/date-picker/lib/popups/date-popup.component.ts
@@ -16,8 +16,8 @@ import {
 
 import { NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ThyButtonIconComponent } from 'ngx-tethys/button';
-import { ThyNavComponent, ThyNavItemDirective } from 'ngx-tethys/nav';
+import { ThyButtonIcon } from 'ngx-tethys/button';
+import { ThyNav, ThyNavItemDirective } from 'ngx-tethys/nav';
 import { ThyDatePickerConfigService } from '../../date-picker.service';
 import { CompatibleValue, DatePickerFlexibleTab, RangeAdvancedValue, RangePartType } from '../../inner-types';
 import { dateAddAmount, getShortcutValue, hasValue, makeValue, transformDateValue } from '../../picker.util';
@@ -34,9 +34,9 @@ import {
     ThyShortcutValue,
     ThyShortcutValueChange
 } from '../../standard-types';
-import { CalendarFooterComponent } from '../calendar/calendar-footer.component';
-import { DateCarouselComponent } from '../date-carousel/date-carousel.component';
-import { InnerPopupComponent } from './inner-popup.component';
+import { CalendarFooter } from '../calendar/calendar-footer.component';
+import { DateCarousel } from '../date-carousel/date-carousel.component';
+import { InnerPopup } from './inner-popup.component';
 
 /**
  * @private
@@ -51,17 +51,17 @@ import { InnerPopupComponent } from './inner-popup.component';
     imports: [
         NgIf,
         NgFor,
-        ThyNavComponent,
+        ThyNav,
         ThyNavItemDirective,
-        ThyButtonIconComponent,
-        DateCarouselComponent,
+        ThyButtonIcon,
+        DateCarousel,
         FormsModule,
         NgTemplateOutlet,
-        InnerPopupComponent,
-        CalendarFooterComponent
+        InnerPopup,
+        CalendarFooter
     ]
 })
-export class DatePopupComponent implements OnChanges, OnInit {
+export class DatePopup implements OnChanges, OnInit {
     @Input() isRange: boolean;
     @Input() showWeek: boolean;
 
@@ -134,7 +134,7 @@ export class DatePopupComponent implements OnChanges, OnInit {
 
     constructor(private cdr: ChangeDetectorRef, private datePickerConfigService: ThyDatePickerConfigService) {}
 
-    setProperty<T extends keyof DatePopupComponent>(key: T, value: this[T]): void {
+    setProperty<T extends keyof DatePopup>(key: T, value: this[T]): void {
         this[key] = value;
         this.cdr.markForCheck();
     }

--- a/src/date-picker/lib/popups/inner-popup.component.ts
+++ b/src/date-picker/lib/popups/inner-popup.component.ts
@@ -15,18 +15,18 @@ import { DateHelperService } from '../../date-helper.service';
 import { RangePartType } from '../../inner-types';
 import { isAfterMoreThanLessOneYear, isAfterMoreThanOneDecade, isAfterMoreThanOneMonth, isAfterMoreThanOneYear } from '../../picker.util';
 import { DisabledDateFn, ThyPanelMode } from '../../standard-types';
-import { DateHeaderComponent } from '../date/date-header.component';
-import { DateTableComponent } from '../date/date-table.component';
+import { DateHeader } from '../date/date-header.component';
+import { DateTable } from '../date/date-table.component';
 
 import { NgIf, NgSwitch, NgSwitchCase, NgSwitchDefault } from '@angular/common';
 import { ThyInputDirective } from 'ngx-tethys/input';
-import { DecadeHeaderComponent } from '../decade/decade-header.component';
-import { DecadeTableComponent } from '../decade/decade-table.component';
-import { MonthHeaderComponent } from '../month/month-header.component';
-import { MonthTableComponent } from '../month/month-table.component';
-import { YearHeaderComponent } from '../year/year-header.component';
-import { YearTableComponent } from '../year/year-table.component';
-import { QuarterTableComponent } from '../quarter/quarter-table.component';
+import { DecadeHeader } from '../decade/decade-header.component';
+import { DecadeTable } from '../decade/decade-table.component';
+import { MonthHeader } from '../month/month-header.component';
+import { MonthTable } from '../month/month-table.component';
+import { YearHeader } from '../year/year-header.component';
+import { YearTable } from '../year/year-table.component';
+import { QuarterTable } from '../quarter/quarter-table.component';
 
 /**
  * @private
@@ -43,19 +43,19 @@ import { QuarterTableComponent } from '../quarter/quarter-table.component';
         ThyInputDirective,
         NgSwitch,
         NgSwitchCase,
-        DecadeHeaderComponent,
-        DecadeTableComponent,
-        YearHeaderComponent,
-        YearTableComponent,
-        MonthHeaderComponent,
-        MonthTableComponent,
-        QuarterTableComponent,
+        DecadeHeader,
+        DecadeTable,
+        YearHeader,
+        YearTable,
+        MonthHeader,
+        MonthTable,
+        QuarterTable,
         NgSwitchDefault,
-        DateHeaderComponent,
-        DateTableComponent
+        DateHeader,
+        DateTable
     ]
 })
-export class InnerPopupComponent implements OnChanges {
+export class InnerPopup implements OnChanges {
     @HostBinding('class.thy-calendar-picker-inner-popup') className = true;
     @HostBinding('class.thy-calendar-picker-inner-popup-with-range-input') _showDateRangeInput = false;
 

--- a/src/date-picker/lib/quarter/quarter-table.component.ts
+++ b/src/date-picker/lib/quarter/quarter-table.component.ts
@@ -17,7 +17,7 @@ import { NgFor, NgClass, NgSwitch, NgSwitchCase } from '@angular/common';
     standalone: true,
     imports: [NgFor, NgClass]
 })
-export class QuarterTableComponent extends CalendarTable implements OnChanges {
+export class QuarterTable extends CalendarTable implements OnChanges {
     MAX_ROW = 1;
 
     MAX_COL = 4;

--- a/src/date-picker/lib/year/year-header.component.ts
+++ b/src/date-picker/lib/year/year-header.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { DateHelperService } from '../../../date-picker/date-helper.service';
 import { CalendarHeader, PanelSelector } from '../calendar/calendar-header.component';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgFor } from '@angular/common';
 
 /**
@@ -13,9 +13,9 @@ import { NgIf, NgFor } from '@angular/common';
     selector: 'year-header',
     templateUrl: '../calendar/calendar-header.component.html',
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgFor]
+    imports: [NgIf, ThyIcon, NgFor]
 })
-export class YearHeaderComponent extends CalendarHeader {
+export class YearHeader extends CalendarHeader {
     get startYear(): number {
         return parseInt(`${this.value.getYear() / 10}`, 10) * 10;
     }

--- a/src/date-picker/lib/year/year-table.component.ts
+++ b/src/date-picker/lib/year/year-table.component.ts
@@ -15,7 +15,7 @@ import { NgFor, NgClass } from '@angular/common';
     standalone: true,
     imports: [NgFor, NgClass]
 })
-export class YearTableComponent extends CalendarTable implements OnChanges {
+export class YearTable extends CalendarTable implements OnChanges {
     MAX_ROW = 4;
 
     MAX_COL = 3;

--- a/src/date-picker/month-picker.component.ts
+++ b/src/date-picker/month-picker.component.ts
@@ -3,9 +3,9 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { useHostRenderer } from '@tethys/cdk/dom';
 
 import { NgIf } from '@angular/common';
-import { BasePickerComponent } from './base-picker.component';
-import { DatePopupComponent } from './lib/popups/date-popup.component';
-import { ThyPickerComponent } from './picker.component';
+import { BasePicker } from './base-picker.component';
+import { DatePopup } from './lib/popups/date-popup.component';
+import { ThyPicker } from './picker.component';
 
 /**
  * 月份选择组件
@@ -21,13 +21,13 @@ import { ThyPickerComponent } from './picker.component';
         {
             provide: NG_VALUE_ACCESSOR,
             multi: true,
-            useExisting: forwardRef(() => ThyMonthPickerComponent)
+            useExisting: forwardRef(() => ThyMonthPicker)
         }
     ],
     standalone: true,
-    imports: [ThyPickerComponent, NgIf, DatePopupComponent]
+    imports: [ThyPicker, NgIf, DatePopup]
 })
-export class ThyMonthPickerComponent extends BasePickerComponent {
+export class ThyMonthPicker extends BasePicker {
     /**
      * 展示的月份格式
      */

--- a/src/date-picker/picker.component.spec.ts
+++ b/src/date-picker/picker.component.spec.ts
@@ -1,9 +1,9 @@
 import { Component, DebugElement, ElementRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed, fakeAsync, flush } from '@angular/core/testing';
-import { ThyPickerComponent } from './picker.component';
+import { ThyPicker } from './picker.component';
 import { CdkConnectedOverlay, CdkOverlayOrigin, OverlayModule } from '@angular/cdk/overlay';
 import { CommonModule, registerLocaleData } from '@angular/common';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { By } from '@angular/platform-browser';
 import zh from '@angular/common/locales/zh';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
@@ -29,7 +29,7 @@ describe('ThyPickerComponent', () => {
 
     beforeEach(fakeAsync(() => {
         TestBed.configureTestingModule({
-            imports: [CommonModule, OverlayModule, ThyPickerComponent, HttpClientTestingModule, ThyIconComponent],
+            imports: [CommonModule, OverlayModule, ThyPicker, HttpClientTestingModule, ThyIcon],
             declarations: [ThyTestPickerComponent],
             providers: [
                 {
@@ -134,7 +134,7 @@ describe('ThyPickerComponent', () => {
     `
 })
 class ThyTestPickerComponent {
-    @ViewChild('thyPicker', { static: true }) thyPicker: ThyPickerComponent;
+    @ViewChild('thyPicker', { static: true }) thyPicker: ThyPicker;
 
     thyValue = new TinyDate(new Date());
     thyDisabled = false;

--- a/src/date-picker/picker.component.ts
+++ b/src/date-picker/picker.component.ts
@@ -17,7 +17,7 @@ import {
 } from '@angular/core';
 
 import { AsyncPipe, NgClass, NgIf, NgTemplateOutlet } from '@angular/common';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { ThyInputDirective } from 'ngx-tethys/input';
 import { DateHelperService } from './date-helper.service';
 import { CompatibleValue, RangePartType } from './inner-types';
@@ -42,13 +42,13 @@ import { scaleMotion, scaleXMotion, scaleYMotion } from 'ngx-tethys/core';
         AsyncPipe,
         NgTemplateOutlet,
         NgIf,
-        ThyIconComponent,
+        ThyIcon,
         NgClass,
         CdkConnectedOverlay
     ],
     animations: [scaleXMotion, scaleYMotion, scaleMotion]
 })
-export class ThyPickerComponent implements OnChanges, AfterViewInit {
+export class ThyPicker implements OnChanges, AfterViewInit {
     @Input() isRange = false;
     @Input() open: boolean | undefined = undefined;
     @Input() disabled: boolean;

--- a/src/date-picker/quarter-picker.component.spec.ts
+++ b/src/date-picker/quarter-picker.component.spec.ts
@@ -6,7 +6,7 @@ import { By } from '@angular/platform-browser';
 import { dispatchMouseEvent } from 'ngx-tethys/testing';
 import { ThyDatePickerModule } from './date-picker.module';
 import { TinyDate } from '../util';
-import { ThyQuarterPickerComponent } from './quarter-picker.component';
+import { ThyQuarterPicker } from './quarter-picker.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 describe('ThyQuarterPickerComponent', () => {
@@ -292,7 +292,7 @@ describe('ThyQuarterPickerComponent', () => {
     `
 })
 class TestQuarterPickerComponent {
-    @ViewChild('thyQuarterPicker', { static: true }) thyQuarterPicker: ThyQuarterPickerComponent;
+    @ViewChild('thyQuarterPicker', { static: true }) thyQuarterPicker: ThyQuarterPicker;
     thyAllowClear: boolean;
     thyDisabled: boolean;
     thyDisabledDate: (d: Date) => boolean;

--- a/src/date-picker/quarter-picker.component.ts
+++ b/src/date-picker/quarter-picker.component.ts
@@ -3,9 +3,9 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { useHostRenderer } from '@tethys/cdk/dom';
 
 import { NgIf } from '@angular/common';
-import { BasePickerComponent } from './base-picker.component';
-import { DatePopupComponent } from './lib/popups/date-popup.component';
-import { ThyPickerComponent } from './picker.component';
+import { BasePicker } from './base-picker.component';
+import { DatePopup } from './lib/popups/date-popup.component';
+import { ThyPicker } from './picker.component';
 import { ThyPanelMode } from './standard-types';
 
 /**
@@ -22,13 +22,13 @@ import { ThyPanelMode } from './standard-types';
         {
             provide: NG_VALUE_ACCESSOR,
             multi: true,
-            useExisting: forwardRef(() => ThyQuarterPickerComponent)
+            useExisting: forwardRef(() => ThyQuarterPicker)
         }
     ],
     standalone: true,
-    imports: [ThyPickerComponent, NgIf, DatePopupComponent]
+    imports: [ThyPicker, NgIf, DatePopup]
 })
-export class ThyQuarterPickerComponent extends BasePickerComponent {
+export class ThyQuarterPicker extends BasePicker {
     /**
      * 展示的季度格式
      * @type string

--- a/src/date-picker/range-picker.component.ts
+++ b/src/date-picker/range-picker.component.ts
@@ -4,9 +4,9 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { useHostRenderer } from '@tethys/cdk/dom';
 
 import { NgIf } from '@angular/common';
-import { BasePickerComponent } from './base-picker.component';
-import { DatePopupComponent } from './lib/popups/date-popup.component';
-import { ThyPickerComponent } from './picker.component';
+import { BasePicker } from './base-picker.component';
+import { DatePopup } from './lib/popups/date-popup.component';
+import { ThyPicker } from './picker.component';
 import { helpers } from 'ngx-tethys/util';
 
 /**
@@ -23,13 +23,13 @@ import { helpers } from 'ngx-tethys/util';
         {
             provide: NG_VALUE_ACCESSOR,
             multi: true,
-            useExisting: forwardRef(() => ThyRangePickerComponent)
+            useExisting: forwardRef(() => ThyRangePicker)
         }
     ],
     standalone: true,
-    imports: [ThyPickerComponent, NgIf, DatePopupComponent]
+    imports: [ThyPicker, NgIf, DatePopup]
 })
-export class ThyRangePickerComponent extends BasePickerComponent implements OnInit {
+export class ThyRangePicker extends BasePicker implements OnInit {
     isRange = true;
 
     private hostRenderer = useHostRenderer();

--- a/src/date-picker/range-picker.directive.spec.ts
+++ b/src/date-picker/range-picker.directive.spec.ts
@@ -11,7 +11,7 @@ import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule, NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ThyDatePickerModule } from './date-picker.module';
-import { ThyPropertyOperationComponent, ThyPropertyOperationModule } from 'ngx-tethys/property-operation';
+import { ThyPropertyOperation, ThyPropertyOperationModule } from 'ngx-tethys/property-operation';
 import { CompatiblePresets, ThyDateRangeEntry, ThyShortcutPosition, ThyShortcutRange } from './standard-types';
 
 registerLocaleData(zh);
@@ -206,7 +206,7 @@ describe('ThyRangePickerDirective', () => {
         }
 
         function getPickerTriggerWrapper(): HTMLInputElement {
-            return debugElement.query(By.directive(ThyPropertyOperationComponent)).nativeElement;
+            return debugElement.query(By.directive(ThyPropertyOperation)).nativeElement;
         }
 
         function dispatchClickEvent(selector: HTMLElement | HTMLInputElement): void {

--- a/src/date-picker/week-picker.component.ts
+++ b/src/date-picker/week-picker.component.ts
@@ -2,10 +2,10 @@ import { ChangeDetectionStrategy, ChangeDetectorRef, Component, ElementRef, forw
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { useHostRenderer } from '@tethys/cdk/dom';
 
-import { BasePickerComponent } from './base-picker.component';
-import { DatePopupComponent } from './lib/popups/date-popup.component';
+import { BasePicker } from './base-picker.component';
+import { DatePopup } from './lib/popups/date-popup.component';
 import { NgIf } from '@angular/common';
-import { ThyPickerComponent } from './picker.component';
+import { ThyPicker } from './picker.component';
 
 /**
  * 周选择组件
@@ -21,13 +21,13 @@ import { ThyPickerComponent } from './picker.component';
         {
             provide: NG_VALUE_ACCESSOR,
             multi: true,
-            useExisting: forwardRef(() => ThyWeekPickerComponent)
+            useExisting: forwardRef(() => ThyWeekPicker)
         }
     ],
     standalone: true,
-    imports: [ThyPickerComponent, NgIf, DatePopupComponent]
+    imports: [ThyPicker, NgIf, DatePopup]
 })
-export class ThyWeekPickerComponent extends BasePickerComponent {
+export class ThyWeekPicker extends BasePicker {
     showWeek = true;
 
     private hostRenderer = useHostRenderer();

--- a/src/date-picker/year-picker.component.ts
+++ b/src/date-picker/year-picker.component.ts
@@ -3,9 +3,9 @@ import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { useHostRenderer } from '@tethys/cdk/dom';
 
 import { NgIf } from '@angular/common';
-import { BasePickerComponent } from './base-picker.component';
-import { DatePopupComponent } from './lib/popups/date-popup.component';
-import { ThyPickerComponent } from './picker.component';
+import { BasePicker } from './base-picker.component';
+import { DatePopup } from './lib/popups/date-popup.component';
+import { ThyPicker } from './picker.component';
 import { ThyPanelMode } from './standard-types';
 
 /**
@@ -22,13 +22,13 @@ import { ThyPanelMode } from './standard-types';
         {
             provide: NG_VALUE_ACCESSOR,
             multi: true,
-            useExisting: forwardRef(() => ThyYearPickerComponent)
+            useExisting: forwardRef(() => ThyYearPicker)
         }
     ],
     standalone: true,
-    imports: [ThyPickerComponent, NgIf, DatePopupComponent]
+    imports: [ThyPicker, NgIf, DatePopup]
 })
-export class ThyYearPickerComponent extends BasePickerComponent {
+export class ThyYearPicker extends BasePicker {
     /**
      * 展示的年份格式
      * @type string

--- a/src/date-range/date-range.component.ts
+++ b/src/date-range/date-range.component.ts
@@ -2,7 +2,7 @@ import { Component, forwardRef, OnInit, Input, ChangeDetectorRef, Output, EventE
 import { NG_VALUE_ACCESSOR, ControlValueAccessor } from '@angular/forms';
 import { DateRangeItemInfo } from './date-range.class';
 import { ThyPopover } from 'ngx-tethys/popover';
-import { OptionalDateRangesComponent } from './optional-dates/optional-dates.component';
+import { OptionalDateRanges } from './optional-dates/optional-dates.component';
 
 import {
     getUnixTime,
@@ -18,8 +18,8 @@ import {
     startOfDay
 } from 'date-fns';
 import { ThyDatePickerFormatPipe } from 'ngx-tethys/date-picker';
-import { ThyIconComponent } from 'ngx-tethys/icon';
-import { ThyActionComponent } from 'ngx-tethys/action';
+import { ThyIcon } from 'ngx-tethys/icon';
+import { ThyAction } from 'ngx-tethys/action';
 import { NgIf, NgClass } from '@angular/common';
 import { InputBoolean } from 'ngx-tethys/core';
 
@@ -27,7 +27,7 @@ const allDayTimestamp = 24 * 60 * 60;
 
 const INPUT_CONTROL_VALUE_ACCESSOR: any = {
     provide: NG_VALUE_ACCESSOR,
-    useExisting: forwardRef(() => ThyDateRangeComponent),
+    useExisting: forwardRef(() => ThyDateRange),
     multi: true
 };
 
@@ -41,9 +41,9 @@ const INPUT_CONTROL_VALUE_ACCESSOR: any = {
     templateUrl: './date-range.component.html',
     providers: [INPUT_CONTROL_VALUE_ACCESSOR],
     standalone: true,
-    imports: [NgIf, ThyActionComponent, ThyIconComponent, NgClass, ThyDatePickerFormatPipe]
+    imports: [NgIf, ThyAction, ThyIcon, NgClass, ThyDatePickerFormatPipe]
 })
-export class ThyDateRangeComponent implements OnInit, ControlValueAccessor {
+export class ThyDateRange implements OnInit, ControlValueAccessor {
     /**
      * 自定义可选值列表项
      * @type DateRangeItemInfo[]
@@ -257,7 +257,7 @@ export class ThyDateRangeComponent implements OnInit, ControlValueAccessor {
         if (this.thyHiddenMenu) {
             return;
         }
-        this.thyPopover.open(OptionalDateRangesComponent, {
+        this.thyPopover.open(OptionalDateRanges, {
             origin: event.currentTarget as HTMLElement,
             hasBackdrop: true,
             backdropClass: 'thy-overlay-transparent-backdrop',

--- a/src/date-range/module.ts
+++ b/src/date-range/module.ts
@@ -2,11 +2,11 @@ import { ThyIconModule } from 'ngx-tethys/icon';
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ThyDateRangeComponent } from './date-range.component';
+import { ThyDateRange } from './date-range.component';
 import { ThyDropdownModule } from 'ngx-tethys/dropdown';
 import { ThySharedModule } from 'ngx-tethys/shared';
 import { ThyDatePickerModule } from 'ngx-tethys/date-picker';
-import { OptionalDateRangesComponent } from './optional-dates/optional-dates.component';
+import { OptionalDateRanges } from './optional-dates/optional-dates.component';
 import { ThyNavModule } from 'ngx-tethys/nav';
 @NgModule({
     imports: [
@@ -17,9 +17,9 @@ import { ThyNavModule } from 'ngx-tethys/nav';
         ThyIconModule,
         ThyDatePickerModule,
         ThyNavModule,
-        ThyDateRangeComponent,
-        OptionalDateRangesComponent
+        ThyDateRange,
+        OptionalDateRanges
     ],
-    exports: [ThyDateRangeComponent]
+    exports: [ThyDateRange]
 })
 export class ThyDateRangeModule {}

--- a/src/date-range/optional-dates/optional-dates.component.ts
+++ b/src/date-range/optional-dates/optional-dates.component.ts
@@ -3,7 +3,7 @@ import { DateRangeItemInfo } from '../date-range.class';
 import { ThyPopover } from 'ngx-tethys/popover';
 import { FormsModule } from '@angular/forms';
 import { ThyRangePickerDirective } from 'ngx-tethys/date-picker';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import {
     ThyDropdownMenuComponent,
     ThyDropdownMenuItemDirective,
@@ -27,12 +27,12 @@ import { NgIf, NgFor } from '@angular/common';
         ThyDropdownMenuItemDirective,
         ThyDropdownMenuItemNameDirective,
         ThyDropdownMenuItemExtendIconDirective,
-        ThyIconComponent,
+        ThyIcon,
         ThyRangePickerDirective,
         FormsModule
     ]
 })
-export class OptionalDateRangesComponent implements OnInit {
+export class OptionalDateRanges implements OnInit {
     hiddenMenu = false;
 
     optionalDateRanges: DateRangeItemInfo[];

--- a/src/dialog/body/dialog-body.component.ts
+++ b/src/dialog/body/dialog-body.component.ts
@@ -16,7 +16,7 @@ import { CdkScrollable } from '@angular/cdk/scrolling';
     standalone: true,
     hostDirectives: [CdkScrollable]
 })
-export class DialogBodyComponent implements OnInit {
+export class DialogBody implements OnInit {
     @HostBinding(`class.dialog-body`) _isDialogBody = true;
 
     @HostBinding(`class.dialog-body-clear-padding`)

--- a/src/dialog/confirm/confirm.component.ts
+++ b/src/dialog/confirm/confirm.component.ts
@@ -1,15 +1,15 @@
-import { ThyFormDirective, ThyFormGroupFooterAlign, ThyFormGroupFooterComponent } from 'ngx-tethys/form';
+import { ThyFormDirective, ThyFormGroupFooterAlign, ThyFormGroupFooter } from 'ngx-tethys/form';
 import { finalize } from 'rxjs/operators';
 
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Inject, Input, OnDestroy, OnInit } from '@angular/core';
 
 import { NgClass } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ThyButtonComponent } from 'ngx-tethys/button';
-import { DialogBodyComponent } from '../body/dialog-body.component';
+import { ThyButton } from 'ngx-tethys/button';
+import { DialogBody } from '../body/dialog-body.component';
 import { ThyConfirmConfig, THY_CONFIRM_DEFAULT_OPTIONS, THY_CONFIRM_DEFAULT_OPTIONS_VALUE } from '../confirm.config';
 import { ThyDialogRef } from '../dialog-ref';
-import { DialogHeaderComponent } from '../header/dialog-header.component';
+import { DialogHeader } from '../header/dialog-header.component';
 
 /**
  * @private
@@ -19,17 +19,9 @@ import { DialogHeaderComponent } from '../header/dialog-header.component';
     templateUrl: './confirm.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [
-        DialogHeaderComponent,
-        DialogBodyComponent,
-        FormsModule,
-        ThyFormDirective,
-        ThyFormGroupFooterComponent,
-        NgClass,
-        ThyButtonComponent
-    ]
+    imports: [DialogHeader, DialogBody, FormsModule, ThyFormDirective, ThyFormGroupFooter, NgClass, ThyButton]
 })
-export class ThyConfirmComponent implements OnInit, OnDestroy {
+export class ThyConfirm implements OnInit, OnDestroy {
     loading: boolean;
 
     @Input() options: ThyConfirmConfig;
@@ -49,7 +41,7 @@ export class ThyConfirmComponent implements OnInit, OnDestroy {
     public footerAlign: ThyFormGroupFooterAlign;
 
     constructor(
-        private dialogRef: ThyDialogRef<ThyConfirmComponent>,
+        private dialogRef: ThyDialogRef<ThyConfirm>,
         private changeDetectorRef: ChangeDetectorRef,
         @Inject(THY_CONFIRM_DEFAULT_OPTIONS) private defaultConfig: ThyConfirmConfig
     ) {

--- a/src/dialog/dialog-container.component.ts
+++ b/src/dialog/dialog-container.component.ts
@@ -50,7 +50,7 @@ import { dialogAbstractOverlayOptions } from './dialog.options';
     standalone: true,
     imports: [PortalModule, ThyPortalOutlet]
 })
-export class ThyDialogContainerComponent extends ThyAbstractOverlayContainer implements OnDestroy {
+export class ThyDialogContainer extends ThyAbstractOverlayContainer implements OnDestroy {
     animationOpeningDone: Observable<AnimationEvent>;
     animationClosingDone: Observable<AnimationEvent>;
 

--- a/src/dialog/dialog-ref.ts
+++ b/src/dialog/dialog-ref.ts
@@ -2,7 +2,7 @@ import { ThyAbstractInternalOverlayRef, ThyAbstractOverlayPosition, ThyAbstractO
 
 import { GlobalPositionStrategy, OverlayRef } from '@angular/cdk/overlay';
 
-import { ThyDialogContainerComponent } from './dialog-container.component';
+import { ThyDialogContainer } from './dialog-container.component';
 import { ThyDialogConfig } from './dialog.config';
 import { dialogAbstractOverlayOptions } from './dialog.options';
 
@@ -10,10 +10,10 @@ import { dialogAbstractOverlayOptions } from './dialog.options';
  * @publicApi
  * @order 30
  */
-export abstract class ThyDialogRef<T, TResult = unknown> extends ThyAbstractOverlayRef<T, ThyDialogContainerComponent, TResult> {}
+export abstract class ThyDialogRef<T, TResult = unknown> extends ThyAbstractOverlayRef<T, ThyDialogContainer, TResult> {}
 
-export class ThyInternalDialogRef<T, TResult = unknown> extends ThyAbstractInternalOverlayRef<T, ThyDialogContainerComponent, TResult> {
-    constructor(overlayRef: OverlayRef, containerInstance: ThyDialogContainerComponent, config: ThyDialogConfig<T>) {
+export class ThyInternalDialogRef<T, TResult = unknown> extends ThyAbstractInternalOverlayRef<T, ThyDialogContainer, TResult> {
+    constructor(overlayRef: OverlayRef, containerInstance: ThyDialogContainer, config: ThyDialogConfig<T>) {
         super(dialogAbstractOverlayOptions, overlayRef, containerInstance, config);
     }
 

--- a/src/dialog/dialog.module.ts
+++ b/src/dialog/dialog.module.ts
@@ -8,15 +8,15 @@ import { ThyButtonModule } from 'ngx-tethys/button';
 import { ThyFormModule } from 'ngx-tethys/form';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThySharedModule } from 'ngx-tethys/shared';
-import { DialogBodyComponent } from './body/dialog-body.component';
+import { DialogBody } from './body/dialog-body.component';
 import { THY_CONFIRM_DEFAULT_OPTIONS_PROVIDER } from './confirm.config';
-import { ThyConfirmComponent } from './confirm/confirm.component';
+import { ThyConfirm } from './confirm/confirm.component';
 import { THY_CONFIRM_COMPONENT_TOKEN } from './confirm/token';
-import { ThyDialogContainerComponent } from './dialog-container.component';
+import { ThyDialogContainer } from './dialog-container.component';
 import { THY_DIALOG_DEFAULT_OPTIONS_PROVIDER, THY_DIALOG_LAYOUT_CONFIG_PROVIDER } from './dialog.config';
 import { ThyDialog } from './dialog.service';
-import { DialogFooterComponent } from './footer/dialog-footer.component';
-import { DialogHeaderComponent } from './header/dialog-header.component';
+import { DialogFooter } from './footer/dialog-footer.component';
+import { DialogHeader } from './header/dialog-header.component';
 
 @NgModule({
     imports: [
@@ -29,11 +29,11 @@ import { DialogHeaderComponent } from './header/dialog-header.component';
         ThyFormModule,
         FormsModule,
         ThyActionModule,
-        ThyDialogContainerComponent,
-        DialogHeaderComponent,
-        DialogBodyComponent,
-        DialogFooterComponent,
-        ThyConfirmComponent
+        ThyDialogContainer,
+        DialogHeader,
+        DialogBody,
+        DialogFooter,
+        ThyConfirm
     ],
     providers: [
         ThyDialog,
@@ -42,9 +42,9 @@ import { DialogHeaderComponent } from './header/dialog-header.component';
         THY_DIALOG_LAYOUT_CONFIG_PROVIDER,
         {
             provide: THY_CONFIRM_COMPONENT_TOKEN,
-            useValue: ThyConfirmComponent
+            useValue: ThyConfirm
         }
     ],
-    exports: [ThyDialogContainerComponent, DialogHeaderComponent, DialogBodyComponent, DialogFooterComponent]
+    exports: [ThyDialogContainer, DialogHeader, DialogBody, DialogFooter]
 })
 export class ThyDialogModule {}

--- a/src/dialog/dialog.service.ts
+++ b/src/dialog/dialog.service.ts
@@ -8,7 +8,7 @@ import { Inject, Injectable, Injector, OnDestroy, Optional, StaticProvider, Temp
 
 import { ThyConfirmConfig } from './confirm.config';
 import { ThyConfirmAbstractComponent, THY_CONFIRM_COMPONENT_TOKEN } from './confirm/token';
-import { ThyDialogContainerComponent } from './dialog-container.component';
+import { ThyDialogContainer } from './dialog-container.component';
 import { ThyDialogRef, ThyInternalDialogRef } from './dialog-ref';
 import { THY_DIALOG_DEFAULT_OPTIONS, ThyDialogConfig, ThyDialogSizes } from './dialog.config';
 import { dialogAbstractOverlayOptions } from './dialog.options';
@@ -18,7 +18,7 @@ import { dialogAbstractOverlayOptions } from './dialog.options';
  * @order 10
  */
 @Injectable()
-export class ThyDialog extends ThyAbstractOverlayService<ThyDialogConfig, ThyDialogContainerComponent> implements OnDestroy {
+export class ThyDialog extends ThyAbstractOverlayService<ThyDialogConfig, ThyDialogContainer> implements OnDestroy {
     protected buildOverlayConfig(config: ThyDialogConfig<any>): OverlayConfig {
         const size = config.size || ThyDialogSizes.md;
         const overlayConfig = this.buildBaseOverlayConfig(config, [`dialog-${size}`]);
@@ -27,35 +27,31 @@ export class ThyDialog extends ThyAbstractOverlayService<ThyDialogConfig, ThyDia
         return overlayConfig;
     }
 
-    protected attachOverlayContainer(overlay: OverlayRef, config: ThyDialogConfig<any>): ThyDialogContainerComponent {
+    protected attachOverlayContainer(overlay: OverlayRef, config: ThyDialogConfig<any>): ThyDialogContainer {
         const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
         const injector = Injector.create({
             parent: userInjector || this.injector,
             providers: [{ provide: ThyDialogConfig, useValue: config }]
         });
-        const containerPortal = new ComponentPortal(ThyDialogContainerComponent, config.viewContainerRef, injector);
-        const containerRef = overlay.attach<ThyDialogContainerComponent>(containerPortal);
+        const containerPortal = new ComponentPortal(ThyDialogContainer, config.viewContainerRef, injector);
+        const containerRef = overlay.attach<ThyDialogContainer>(containerPortal);
 
         return containerRef.instance;
     }
 
     protected createAbstractOverlayRef<T, TResult>(
         overlayRef: OverlayRef,
-        containerInstance: ThyDialogContainerComponent,
+        containerInstance: ThyDialogContainer,
         config: ThyDialogConfig<any>
-    ): ThyAbstractOverlayRef<T, ThyDialogContainerComponent, TResult> {
+    ): ThyAbstractOverlayRef<T, ThyDialogContainer, TResult> {
         return new ThyInternalDialogRef(overlayRef, containerInstance, config);
     }
 
-    protected createInjector<T>(
-        config: ThyDialogConfig,
-        dialogRef: ThyDialogRef<T>,
-        dialogContainer: ThyDialogContainerComponent
-    ): Injector {
+    protected createInjector<T>(config: ThyDialogConfig, dialogRef: ThyDialogRef<T>, dialogContainer: ThyDialogContainer): Injector {
         const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
 
         const injectionTokens: StaticProvider[] = [
-            { provide: ThyDialogContainerComponent, useValue: dialogContainer },
+            { provide: ThyDialogContainer, useValue: dialogContainer },
             {
                 provide: ThyDialogRef,
                 useValue: dialogRef

--- a/src/dialog/footer/dialog-footer.component.ts
+++ b/src/dialog/footer/dialog-footer.component.ts
@@ -19,7 +19,7 @@ import { InputBoolean } from 'ngx-tethys/core';
     standalone: true,
     imports: [NgIf, NgTemplateOutlet]
 })
-export class DialogFooterComponent implements OnInit {
+export class DialogFooter implements OnInit {
     /**
      * 自定义弹出框底部的描述模板
      * @type TemplateRef

--- a/src/dialog/header/dialog-header.component.ts
+++ b/src/dialog/header/dialog-header.component.ts
@@ -1,10 +1,10 @@
 import { Component, Input, Output, EventEmitter, ContentChild, TemplateRef, OnInit, Optional, ElementRef } from '@angular/core';
 import { ThyDialog } from '../dialog.service';
-import { ThyDialogContainerComponent } from '../dialog-container.component';
+import { ThyDialogContainer } from '../dialog-container.component';
 import { InputBoolean, ThyTranslate } from 'ngx-tethys/core';
 import { ThyInternalDialogRef } from '../dialog-ref';
-import { ThyActionComponent } from 'ngx-tethys/action';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyAction } from 'ngx-tethys/action';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgTemplateOutlet } from '@angular/common';
 
 /**
@@ -23,9 +23,9 @@ import { NgIf, NgTemplateOutlet } from '@angular/common';
         '[class.thy-dialog-header-divided]': `thyDivided`
     },
     standalone: true,
-    imports: [NgIf, NgTemplateOutlet, ThyIconComponent, ThyActionComponent]
+    imports: [NgIf, NgTemplateOutlet, ThyIcon, ThyAction]
 })
-export class DialogHeaderComponent implements OnInit {
+export class DialogHeader implements OnInit {
     /**
      * 自定义头部模板
      */
@@ -74,7 +74,7 @@ export class DialogHeaderComponent implements OnInit {
         private elementRef: ElementRef,
         private dialog: ThyDialog,
         private translate: ThyTranslate,
-        @Optional() private dialogContainer: ThyDialogContainerComponent
+        @Optional() private dialogContainer: ThyDialogContainer
     ) {}
 
     ngOnInit() {

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -7,5 +7,5 @@ export * from './dialog-container.component';
 export * from './header/dialog-header.component';
 export * from './body/dialog-body.component';
 export * from './footer/dialog-footer.component';
-export { ThyConfirmComponent as ThyConfirmComponent$1 } from './confirm/confirm.component';
+export { ThyConfirm as ThyConfirmComponent$1 } from './confirm/confirm.component';
 export * from './dialog-animations';

--- a/src/dialog/test/dialog-layout.spec.ts
+++ b/src/dialog/test/dialog-layout.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { ThyDialogModule } from '../dialog.module';
 import { Component, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { DialogHeaderComponent } from '../header/dialog-header.component';
+import { DialogHeader } from '../header/dialog-header.component';
 import { bypassSanitizeProvider, injectDefaultSvgIconSet } from 'ngx-tethys/testing';
 import { THY_DIALOG_LAYOUT_CONFIG } from '../dialog.config';
 
@@ -63,7 +63,7 @@ describe('dialog-layout', () => {
         beforeEach(() => {
             dialogBasicFixture = TestBed.createComponent(DialogHeaderBasicComponent);
             dialogBasicFixture.detectChanges();
-            dialogHeaderDebugElement = dialogBasicFixture.debugElement.query(By.directive(DialogHeaderComponent));
+            dialogHeaderDebugElement = dialogBasicFixture.debugElement.query(By.directive(DialogHeader));
             dialogHeaderElement = dialogHeaderDebugElement.nativeElement;
         });
 
@@ -113,7 +113,7 @@ describe('dialog-layout', () => {
         beforeEach(() => {
             dialogBasicFixture = TestBed.createComponent(DialogHeaderTitleTranslationComponent);
             dialogBasicFixture.detectChanges();
-            dialogHeaderDebugElement = dialogBasicFixture.debugElement.query(By.directive(DialogHeaderComponent));
+            dialogHeaderDebugElement = dialogBasicFixture.debugElement.query(By.directive(DialogHeader));
             dialogHeaderElement = dialogHeaderDebugElement.nativeElement;
         });
 

--- a/src/dialog/test/dialog.spec.ts
+++ b/src/dialog/test/dialog.spec.ts
@@ -8,7 +8,7 @@ import { bypassSanitizeProvider, dispatchKeyboardEvent, injectDefaultSvgIconSet 
 import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { A, ESCAPE } from '../../util/keycodes';
-import { ThyDialogContainerComponent } from '../dialog-container.component';
+import { ThyDialogContainer } from '../dialog-container.component';
 import { ThyDialogRef } from '../dialog-ref';
 import { ThyDialogSizes } from '../dialog.config';
 import { ThyDialog, ThyDialogModule, THY_CONFIRM_DEFAULT_OPTIONS } from '../index';
@@ -789,8 +789,8 @@ describe('ThyDialog', () => {
 
     it('should set the proper animation states', () => {
         const dialogRef = dialog.open(DialogSimpleContentComponent, { viewContainerRef: testViewContainerRef });
-        const dialogContainer: ThyDialogContainerComponent = viewContainerFixture.debugElement.query(
-            By.directive(ThyDialogContainerComponent)
+        const dialogContainer: ThyDialogContainer = viewContainerFixture.debugElement.query(
+            By.directive(ThyDialogContainer)
         ).componentInstance;
 
         expect(dialogContainer.animationState).toBe('void');
@@ -802,7 +802,7 @@ describe('ThyDialog', () => {
 
     it('should has "pointer-event: none" at dialog-container when animation phaseName equal start and toState equal exit', fakeAsync(() => {
         const dialogRef = dialog.open(DialogSimpleContentComponent, { viewContainerRef: testViewContainerRef });
-        const dialogContainer = viewContainerFixture.debugElement.query(By.directive(ThyDialogContainerComponent)).componentInstance;
+        const dialogContainer = viewContainerFixture.debugElement.query(By.directive(ThyDialogContainer)).componentInstance;
 
         expect((getDialogContainerElement() as HTMLElement).style.pointerEvents).toEqual('');
 

--- a/src/divider/divider.component.ts
+++ b/src/divider/divider.component.ts
@@ -40,7 +40,7 @@ export type ThyDividerColor = 'lighter' | 'light' | 'danger' | 'primary' | 'succ
     standalone: true,
     imports: [NgIf, NgTemplateOutlet]
 })
-export class ThyDividerComponent implements OnChanges, OnInit {
+export class ThyDivider implements OnChanges, OnInit {
     templateContent: TemplateRef<HTMLElement>;
 
     textContent: string;

--- a/src/divider/divider.module.ts
+++ b/src/divider/divider.module.ts
@@ -3,11 +3,11 @@ import { CommonModule } from '@angular/common';
 import { ThySharedModule } from 'ngx-tethys/shared';
 import { ThyIconModule } from 'ngx-tethys/icon';
 
-import { ThyDividerComponent } from './divider.component';
+import { ThyDivider } from './divider.component';
 
 @NgModule({
-    imports: [CommonModule, ThySharedModule, ThyIconModule, ThyDividerComponent],
-    exports: [ThyDividerComponent],
+    imports: [CommonModule, ThySharedModule, ThyIconModule, ThyDivider],
+    exports: [ThyDivider],
     providers: []
 })
 export class ThyDividerModule {}

--- a/src/dot/dot.component.ts
+++ b/src/dot/dot.component.ts
@@ -38,7 +38,7 @@ export const DEFAULT_SHAPE_NAME = 'circle';
     },
     standalone: true
 })
-export class ThyDotComponent {
+export class ThyDot {
     public size: ThySizeType = DEFAULT_SIZE_NAME;
     public theme: ThyThemeType = DEFAULT_THEME_NAME;
     public shape: ThyShapeType = DEFAULT_SHAPE_NAME;

--- a/src/dot/dot.module.ts
+++ b/src/dot/dot.module.ts
@@ -1,9 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { ThyDotComponent } from './dot.component';
+import { ThyDot } from './dot.component';
 
 @NgModule({
-    imports: [CommonModule, ThyDotComponent],
-    exports: [ThyDotComponent]
+    imports: [CommonModule, ThyDot],
+    exports: [ThyDot]
 })
 export class ThyDotModule {}

--- a/src/dot/test/dot.spec.ts
+++ b/src/dot/test/dot.spec.ts
@@ -9,7 +9,7 @@ import {
     DEFAULT_SIZE_NAME,
     DEFAULT_THEME_NAME,
     ThyColorType,
-    ThyDotComponent,
+    ThyDot,
     ThyShapeType,
     ThySizeType,
     ThyThemeType
@@ -38,7 +38,7 @@ describe('ThyDot', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyDemoDotComponent);
         basicTestComponent = fixture.debugElement.componentInstance;
-        dotComponent = fixture.debugElement.query(By.directive(ThyDotComponent));
+        dotComponent = fixture.debugElement.query(By.directive(ThyDot));
     });
 
     const getRandomAttributes = <T extends string>(list: string[]): T => {

--- a/src/dropdown/dropdown-menu.component.ts
+++ b/src/dropdown/dropdown-menu.component.ts
@@ -92,7 +92,7 @@ export class ThyDropdownMenuComponent {
     },
     standalone: true
 })
-export class ThyDropdownMenuGroupComponent {
+export class ThyDropdownMenuGroup {
     title: string;
 
     /**
@@ -119,6 +119,6 @@ export class ThyDropdownMenuGroupComponent {
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true
 })
-export class ThyDropdownMenuDividerComponent {
+export class ThyDropdownMenuDivider {
     constructor() {}
 }

--- a/src/dropdown/dropdown-submenu.component.ts
+++ b/src/dropdown/dropdown-submenu.component.ts
@@ -28,7 +28,7 @@ const SUBMENU_CLASS_PREFIX = 'dropdown-submenu';
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true
 })
-export class ThyDropdownSubmenuComponent extends _MixinBase implements OnInit, OnDestroy {
+export class ThyDropdownSubmenu extends _MixinBase implements OnInit, OnDestroy {
     private direction: InnerDropdownSubmenuDirection = 'right';
 
     /**

--- a/src/dropdown/module.ts
+++ b/src/dropdown/module.ts
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ThyPopoverModule } from 'ngx-tethys/popover';
 import { ThyDropdownDirective } from './dropdown.directive';
-import { ThyDropdownMenuComponent, ThyDropdownMenuDividerComponent, ThyDropdownMenuGroupComponent } from './dropdown-menu.component';
+import { ThyDropdownMenuComponent, ThyDropdownMenuDivider, ThyDropdownMenuGroup } from './dropdown-menu.component';
 import {
     ThyDropdownMenuItemDirective,
     ThyDropdownMenuItemNameDirective,
@@ -12,7 +12,7 @@ import {
     ThyDropdownMenuItemExtendIconDirective,
     ThyDropdownMenuItemActiveDirective
 } from './dropdown-menu-item.directive';
-import { ThyDropdownSubmenuComponent } from './dropdown-submenu.component';
+import { ThyDropdownSubmenu } from './dropdown-submenu.component';
 import { ThyDropdownActiveDirective } from './dropdown-active.directive';
 
 @NgModule({
@@ -22,9 +22,9 @@ import { ThyDropdownActiveDirective } from './dropdown-active.directive';
         ThyDropdownDirective,
         ThyDropdownActiveDirective,
         ThyDropdownMenuComponent,
-        ThyDropdownSubmenuComponent,
-        ThyDropdownMenuGroupComponent,
-        ThyDropdownMenuDividerComponent,
+        ThyDropdownSubmenu,
+        ThyDropdownMenuGroup,
+        ThyDropdownMenuDivider,
         ThyDropdownMenuItemDirective,
         ThyDropdownMenuItemNameDirective,
         ThyDropdownMenuItemIconDirective,
@@ -37,9 +37,9 @@ import { ThyDropdownActiveDirective } from './dropdown-active.directive';
         ThyDropdownDirective,
         ThyDropdownActiveDirective,
         ThyDropdownMenuComponent,
-        ThyDropdownSubmenuComponent,
-        ThyDropdownMenuGroupComponent,
-        ThyDropdownMenuDividerComponent,
+        ThyDropdownSubmenu,
+        ThyDropdownMenuGroup,
+        ThyDropdownMenuDivider,
         ThyDropdownMenuItemDirective,
         ThyDropdownMenuItemNameDirective,
         ThyDropdownMenuItemIconDirective,

--- a/src/empty/empty.component.ts
+++ b/src/empty/empty.component.ts
@@ -18,7 +18,7 @@ import { ThyEmptyConfig } from './empty.config';
 import { PRESET_SVG } from './svgs';
 import { DomSanitizer } from '@angular/platform-browser';
 import { SafeAny } from 'ngx-tethys/types';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgClass, NgTemplateOutlet } from '@angular/common';
 
 const sizeClassMap = {
@@ -60,9 +60,9 @@ export type ThyEmptyImageFetchPriority = 'high' | 'low' | 'auto';
     selector: 'thy-empty',
     templateUrl: './empty.component.html',
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgClass, NgTemplateOutlet]
+    imports: [NgIf, ThyIcon, NgClass, NgTemplateOutlet]
 })
-export class ThyEmptyComponent implements OnInit, AfterViewInit, OnChanges {
+export class ThyEmpty implements OnInit, AfterViewInit, OnChanges {
     /**
      * 显示文本提示信息。同时传入 thyMessage，thyTranslationKey，thyEntityName，thyEntityNameTranslateKey 时优先级最高
      */

--- a/src/empty/empty.module.ts
+++ b/src/empty/empty.module.ts
@@ -4,12 +4,12 @@ import { ThySharedModule } from 'ngx-tethys/shared';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ThyEmptyComponent } from './empty.component';
+import { ThyEmpty } from './empty.component';
 import { ThyEmptyConfig } from './empty.config';
 
 @NgModule({
-    imports: [CommonModule, ThySharedModule, ThyIconModule, ThyEmptyComponent],
-    exports: [ThyEmptyComponent],
+    imports: [CommonModule, ThySharedModule, ThyIconModule, ThyEmpty],
+    exports: [ThyEmpty],
     providers: [ThyEmptyConfig]
 })
 export class ThyEmptyModule {}

--- a/src/empty/test/empty.spec.ts
+++ b/src/empty/test/empty.spec.ts
@@ -3,7 +3,7 @@ import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
-import { ThyEmptyComponent, ThyEmptyImageFetchPriority, ThyEmptyImageLoading } from '../empty.component';
+import { ThyEmpty, ThyEmptyImageFetchPriority, ThyEmptyImageLoading } from '../empty.component';
 import { ThyEmptyConfig } from '../empty.config';
 import { ThyEmptyModule } from '../empty.module';
 
@@ -52,7 +52,7 @@ import { ThyEmptyModule } from '../empty.module';
     ]
 })
 class EmptyTestComponent {
-    @ViewChild('ThyEmptyComponent', { static: true }) thyEmptyComponent: ThyEmptyComponent;
+    @ViewChild('ThyEmptyComponent', { static: true }) thyEmptyComponent: ThyEmpty;
     thyMessage = '暂无数据';
     thyTranslationKey = '暂无活动';
     thyTranslationValues: any;
@@ -84,7 +84,7 @@ describe('EmptyComponent', () => {
 
     it('should create thy-empty', () => {
         expect(componentInstance).toBeTruthy();
-        const empty: DebugElement = fixture.debugElement.query(By.directive(ThyEmptyComponent));
+        const empty: DebugElement = fixture.debugElement.query(By.directive(ThyEmpty));
         expect(empty).toBeTruthy();
         expect(empty.nativeElement).toBeTruthy();
     });
@@ -92,7 +92,7 @@ describe('EmptyComponent', () => {
     it('should should translationKey', () => {
         componentInstance.thyMessage = '';
         fixture.detectChanges();
-        const empty = fixture.debugElement.query(By.directive(ThyEmptyComponent));
+        const empty = fixture.debugElement.query(By.directive(ThyEmpty));
         expect(empty.nativeElement.querySelector('.thy-empty-text').textContent).toContain('暂无活动');
     });
 
@@ -100,7 +100,7 @@ describe('EmptyComponent', () => {
         componentInstance.thyMessage = '';
         componentInstance.thyTranslationKey = '';
         fixture.detectChanges();
-        const empty = fixture.debugElement.query(By.directive(ThyEmptyComponent));
+        const empty = fixture.debugElement.query(By.directive(ThyEmpty));
         expect(empty.nativeElement.querySelector('.thy-empty-text').textContent).toContain('common.tips.NO_RESULT_TARGET');
     });
 
@@ -109,7 +109,7 @@ describe('EmptyComponent', () => {
         componentInstance.thyTranslationKey = '';
         componentInstance.thyEntityName = '';
         fixture.detectChanges();
-        const empty = fixture.debugElement.query(By.directive(ThyEmptyComponent));
+        const empty = fixture.debugElement.query(By.directive(ThyEmpty));
         expect(empty.nativeElement.querySelector('.thy-empty-text').textContent).toContain('common.tips.NO_RESULT_TARGET');
     });
 
@@ -119,33 +119,33 @@ describe('EmptyComponent', () => {
         componentInstance.thyEntityName = '';
         componentInstance.thyEntityNameTranslateKey = '';
         fixture.detectChanges();
-        const empty = fixture.debugElement.query(By.directive(ThyEmptyComponent));
+        const empty = fixture.debugElement.query(By.directive(ThyEmpty));
         expect(empty.nativeElement.querySelector('.thy-empty-text').textContent).toContain('common.tips.NO_RESULT');
     });
 
     it('should should contain outer class', () => {
         fixture.detectChanges();
-        const empty = fixture.debugElement.query(By.directive(ThyEmptyComponent));
+        const empty = fixture.debugElement.query(By.directive(ThyEmpty));
         expect(empty.nativeElement.classList).toContain('empty-test-example');
     });
 
     it('should should create a lg empty', () => {
         fixture.detectChanges();
-        const empty = fixture.debugElement.query(By.directive(ThyEmptyComponent));
+        const empty = fixture.debugElement.query(By.directive(ThyEmpty));
         expect(empty.nativeElement.classList).toContain('thy-empty-state--lg');
     });
 
     it('should should create a sm empty', () => {
         componentInstance.thySize = 'sm';
         fixture.detectChanges();
-        const empty = fixture.debugElement.query(By.directive(ThyEmptyComponent));
+        const empty = fixture.debugElement.query(By.directive(ThyEmpty));
         expect(empty.nativeElement.classList).toContain('thy-empty-state--sm');
     });
 
     it('should should create a md empty', () => {
         componentInstance.thySize = '';
         fixture.detectChanges();
-        const empty = fixture.debugElement.query(By.directive(ThyEmptyComponent));
+        const empty = fixture.debugElement.query(By.directive(ThyEmpty));
         expect(empty.nativeElement.classList).toContain('thy-empty-state');
         expect(empty.nativeElement.classList).not.toContain('thy-empty-state--sm');
         expect(empty.nativeElement.classList).not.toContain('thy-empty-state--lg');
@@ -154,7 +154,7 @@ describe('EmptyComponent', () => {
     it('should should create correct size empty', () => {
         componentInstance.thySize = 'lg';
         fixture.detectChanges();
-        const empty = fixture.debugElement.query(By.directive(ThyEmptyComponent));
+        const empty = fixture.debugElement.query(By.directive(ThyEmpty));
         expect(empty.nativeElement.classList).toContain('thy-empty-state--lg');
         componentInstance.thySize = 'sm';
         fixture.detectChanges();

--- a/src/flexible-text/flexible-text.component.ts
+++ b/src/flexible-text/flexible-text.component.ts
@@ -18,7 +18,7 @@ import { debounceTime, take, takeUntil } from 'rxjs/operators';
     hostDirectives: [ThyTooltipDirective],
     standalone: true
 })
-export class ThyFlexibleTextComponent implements OnInit, AfterContentInit, OnDestroy {
+export class ThyFlexibleText implements OnInit, AfterContentInit, OnDestroy {
     isOverflow = false;
 
     content: string | TemplateRef<HTMLElement>;
@@ -138,7 +138,7 @@ export class ThyFlexibleTextComponent implements OnInit, AfterContentInit, OnDes
                         this.applyOverflow();
                     });
 
-                ThyFlexibleTextComponent.createResizeObserver(this.elementRef.nativeElement)
+                ThyFlexibleText.createResizeObserver(this.elementRef.nativeElement)
                     .pipe(debounceTime(100), takeUntil(this.destroy$))
                     .subscribe(() => {
                         this.applyOverflow();

--- a/src/flexible-text/flexible-text.module.ts
+++ b/src/flexible-text/flexible-text.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyFlexibleTextComponent } from './flexible-text.component';
+import { ThyFlexibleText } from './flexible-text.component';
 import { ThyTooltipModule } from 'ngx-tethys/tooltip';
 import { ObserversModule } from '@angular/cdk/observers';
 
 @NgModule({
-    imports: [CommonModule, ThyTooltipModule, ObserversModule, ThyFlexibleTextComponent],
-    exports: [ThyFlexibleTextComponent]
+    imports: [CommonModule, ThyTooltipModule, ObserversModule, ThyFlexibleText],
+    exports: [ThyFlexibleText]
 })
 export class ThyFlexibleTextModule {}

--- a/src/flexible-text/test/flexible-text.spec.ts
+++ b/src/flexible-text/test/flexible-text.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angul
 import { By } from '@angular/platform-browser';
 import { Subject } from 'rxjs';
 import { ThyTooltipModule } from '../../tooltip';
-import { ThyFlexibleTextComponent } from '../flexible-text.component';
+import { ThyFlexibleText } from '../flexible-text.component';
 import { ThyFlexibleTextModule } from '../flexible-text.module';
 
 @Component({
@@ -48,7 +48,7 @@ import { ThyFlexibleTextModule } from '../flexible-text.module';
     ]
 })
 class FlexibleTextTestComponent {
-    @ViewChild('FlexibleText', { static: true }) flexibleText: ThyFlexibleTextComponent;
+    @ViewChild('FlexibleText', { static: true }) flexibleText: ThyFlexibleText;
     tooltipContent = '默认内容。。。';
     placement = 'bottom';
     content = '默认内容。。。';
@@ -90,7 +90,7 @@ describe('FlexibleTextComponent', () => {
         }).compileComponents();
 
         // fake resize observer before create component
-        const createResizeSpy = spyOn(ThyFlexibleTextComponent, 'createResizeObserver');
+        const createResizeSpy = spyOn(ThyFlexibleText, 'createResizeObserver');
         createResizeSpy.and.returnValue(fakeResizeObserver);
 
         fixture = TestBed.createComponent(FlexibleTextTestComponent);

--- a/src/form/form-group-error/form-group-error.component.ts
+++ b/src/form/form-group-error/form-group-error.component.ts
@@ -1,7 +1,7 @@
 import { InputBoolean } from 'ngx-tethys/core';
 import { Component, HostBinding, ViewEncapsulation, OnInit, Optional, Input } from '@angular/core';
 import { ThyFormDirective } from '../form.directive';
-import { ThyAlertComponent } from 'ngx-tethys/alert';
+import { ThyAlert } from 'ngx-tethys/alert';
 import { NgClass, NgFor } from '@angular/common';
 
 /**
@@ -13,9 +13,9 @@ import { NgClass, NgFor } from '@angular/common';
     templateUrl: './form-group-error.component.html',
     encapsulation: ViewEncapsulation.None,
     standalone: true,
-    imports: [NgClass, NgFor, ThyAlertComponent]
+    imports: [NgClass, NgFor, ThyAlert]
 })
-export class ThyFormGroupErrorComponent implements OnInit {
+export class ThyFormGroupError implements OnInit {
     public errors: string[];
 
     @Input() @InputBoolean() thyShowFirst = true;

--- a/src/form/form-group.component.ts
+++ b/src/form/form-group.component.ts
@@ -1,6 +1,6 @@
 import { NgClass, NgIf, NgTemplateOutlet } from '@angular/common';
 import { InputBoolean, ThyTranslate } from 'ngx-tethys/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { ThyTooltipDirective } from 'ngx-tethys/tooltip';
 import { coerceBooleanProperty } from 'ngx-tethys/util';
 
@@ -35,9 +35,9 @@ type TipsMode = 'default' | 'label';
     encapsulation: ViewEncapsulation.None,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgIf, NgTemplateOutlet, ThyIconComponent, NgClass, ThyTooltipDirective]
+    imports: [NgIf, NgTemplateOutlet, ThyIcon, NgClass, ThyTooltipDirective]
 })
-export class ThyFormGroupComponent implements OnInit {
+export class ThyFormGroup implements OnInit {
     labelText: string;
     labelRequired = false;
     labelPaddingTopClear = false;

--- a/src/form/from-group-footer/form-group-footer.component.ts
+++ b/src/form/from-group-footer/form-group-footer.component.ts
@@ -15,7 +15,7 @@ import { NgClass, NgIf, NgTemplateOutlet } from '@angular/common';
     standalone: true,
     imports: [NgClass, NgIf, NgTemplateOutlet]
 })
-export class ThyFormGroupFooterComponent implements OnInit {
+export class ThyFormGroupFooter implements OnInit {
     @HostBinding('class.form-group') _isFormGroup = true;
 
     @HostBinding('class.row') isHorizontal = true;

--- a/src/form/module.ts
+++ b/src/form/module.ts
@@ -7,14 +7,14 @@ import { CommonModule } from '@angular/common';
 import { ModuleWithProviders, NgModule } from '@angular/core';
 import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 
-import { ThyFormGroupErrorComponent } from './form-group-error/form-group-error.component';
+import { ThyFormGroupError } from './form-group-error/form-group-error.component';
 import { ThyFormGroupLabelDirective } from './form-group-label.directive';
-import { ThyFormGroupComponent } from './form-group.component';
+import { ThyFormGroup } from './form-group.component';
 import { ThyFormSubmitDirective } from './form-submit.directive';
 import { ThyFormValidatorLoader } from './form-validator-loader';
 import { ThyFormValidatorGlobalConfig, THY_FORM_CONFIG_PROVIDER, THY_VALIDATOR_CONFIG } from './form.class';
 import { ThyFormDirective } from './form.directive';
-import { ThyFormGroupFooterComponent } from './from-group-footer/form-group-footer.component';
+import { ThyFormGroupFooter } from './from-group-footer/form-group-footer.component';
 import { ThyConfirmValidatorDirective, ThyMaxDirective, ThyMinDirective, ThyUniqueCheckValidator } from './validator/index';
 
 @NgModule({
@@ -27,24 +27,24 @@ import { ThyConfirmValidatorDirective, ThyMaxDirective, ThyMinDirective, ThyUniq
         ThyIconModule,
         ThyTooltipModule,
         ThyFormDirective,
-        ThyFormGroupComponent,
+        ThyFormGroup,
         ThyFormGroupLabelDirective,
         ThyFormSubmitDirective,
-        ThyFormGroupFooterComponent,
+        ThyFormGroupFooter,
         ThyUniqueCheckValidator,
-        ThyFormGroupErrorComponent,
+        ThyFormGroupError,
         ThyMinDirective,
         ThyMaxDirective,
         ThyConfirmValidatorDirective
     ],
     exports: [
         ThyFormDirective,
-        ThyFormGroupComponent,
+        ThyFormGroup,
         ThyFormGroupLabelDirective,
         ThyFormSubmitDirective,
-        ThyFormGroupFooterComponent,
+        ThyFormGroupFooter,
         ThyUniqueCheckValidator,
-        ThyFormGroupErrorComponent,
+        ThyFormGroupError,
         ThyMinDirective,
         ThyMaxDirective,
         ThyConfirmValidatorDirective

--- a/src/form/test/form-group-error.spec.ts
+++ b/src/form/test/form-group-error.spec.ts
@@ -3,10 +3,10 @@ import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
-import { ThyFormGroupFooterComponent } from '../from-group-footer/form-group-footer.component';
+import { ThyFormGroupFooter } from '../from-group-footer/form-group-footer.component';
 import { ThyFormDirective } from '../form.directive';
 import { THY_FORM_CONFIG } from '../form.class';
-import { ThyFormGroupErrorComponent } from '../form-group-error/form-group-error.component';
+import { ThyFormGroupError } from '../form-group-error/form-group-error.component';
 
 @Component({
     selector: 'thy-test-form-group-error-basic',
@@ -52,7 +52,7 @@ describe('form-group-error', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(TestFormGroupErrorBasicComponent);
             formGroupFooterComponent = fixture.debugElement.componentInstance;
-            debugElement = fixture.debugElement.query(By.directive(ThyFormGroupErrorComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyFormGroupError));
             thyFormDirective = TestBed.inject(ThyFormDirective);
         });
 
@@ -104,7 +104,7 @@ describe('form-group-error', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(TestFormGroupErrorBasicComponent);
             formGroupFooterComponent = fixture.debugElement.componentInstance;
-            debugElement = fixture.debugElement.query(By.directive(ThyFormGroupErrorComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyFormGroupError));
             thyFormDirective = TestBed.inject(ThyFormDirective);
         });
 

--- a/src/form/test/form-group-footer.spec.ts
+++ b/src/form/test/form-group-footer.spec.ts
@@ -3,7 +3,7 @@ import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { FormsModule } from '@angular/forms';
-import { ThyFormGroupFooterComponent } from '../from-group-footer/form-group-footer.component';
+import { ThyFormGroupFooter } from '../from-group-footer/form-group-footer.component';
 import { ThyFormDirective } from '../form.directive';
 import { THY_FORM_CONFIG } from '../form.class';
 
@@ -48,7 +48,7 @@ describe('form-group-footer', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(FormGroupFooterComponent);
             formGroupFooterComponent = fixture.debugElement.componentInstance;
-            debugElement = fixture.debugElement.query(By.directive(ThyFormGroupFooterComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyFormGroupFooter));
             thyFormDirective = TestBed.get(ThyFormDirective);
         });
         it('should has correct class when form.isHorizontal = false', () => {
@@ -111,7 +111,7 @@ describe('form-group-footer', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(FormGroupFooterComponent);
             formGroupFooterComponent = fixture.debugElement.componentInstance;
-            debugElement = fixture.debugElement.query(By.directive(ThyFormGroupFooterComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyFormGroupFooter));
             thyFormDirective = TestBed.get(ThyFormDirective);
         });
 

--- a/src/form/test/form-group.spec.ts
+++ b/src/form/test/form-group.spec.ts
@@ -6,7 +6,7 @@ import { FormsModule } from '@angular/forms';
 import { ThyButtonModule } from 'ngx-tethys/button';
 import { bypassSanitizeProvider, injectDefaultSvgIconSet } from 'ngx-tethys/testing';
 import { By } from '@angular/platform-browser';
-import { ThyFormGroupComponent } from '../form-group.component';
+import { ThyFormGroup } from '../form-group.component';
 import { ThyTranslate } from 'ngx-tethys/core';
 import { ThyFormGroupLabelDirective } from '../form-group-label.directive';
 
@@ -79,7 +79,7 @@ describe('form-group basic', () => {
         fixture = TestBed.createComponent(TestFormWithGroupComponent);
         fixture.detectChanges();
         testComponent = fixture.componentInstance;
-        formGroupDebugElements = fixture.debugElement.queryAll(By.directive(ThyFormGroupComponent));
+        formGroupDebugElements = fixture.debugElement.queryAll(By.directive(ThyFormGroup));
     });
 
     function getFormGroup(index = 0) {
@@ -217,7 +217,7 @@ describe('form-group in vertical', () => {
         fixture = TestBed.createComponent(TestFormGroupVerticalComponent);
         fixture.detectChanges();
         testComponent = fixture.componentInstance;
-        formGroupDebugElement = fixture.debugElement.query(By.directive(ThyFormGroupComponent));
+        formGroupDebugElement = fixture.debugElement.query(By.directive(ThyFormGroup));
     });
 
     it('should get correct form group for vertical', () => {
@@ -286,7 +286,7 @@ describe('form-group for TranslateKey', () => {
         fixture = TestBed.createComponent(TestFormGroupTranslateKeyComponent);
         fixture.detectChanges();
         testComponent = fixture.componentInstance;
-        formGroupDebugElement = fixture.debugElement.query(By.directive(ThyFormGroupComponent));
+        formGroupDebugElement = fixture.debugElement.query(By.directive(ThyFormGroup));
     });
 
     it('should get correct label and tips', () => {

--- a/src/grid/module.ts
+++ b/src/grid/module.ts
@@ -2,14 +2,14 @@ import { NgModule } from '@angular/core';
 import { ThyRowDirective } from './thy-row.directive';
 import { ThyColDirective } from './thy-col.directive';
 import { ThyGrid, ThyGridComponent } from './thy-grid.component';
-import { ThyGridItemComponent } from './thy-grid-item.component';
+import { ThyGridItem } from './thy-grid-item.component';
 import { ThyFlex, ThyFlexComponent, ThyFlexItem, ThyFlexItemComponent } from './flex';
 
 @NgModule({
     exports: [
         ThyGrid,
         ThyGridComponent,
-        ThyGridItemComponent,
+        ThyGridItem,
         ThyRowDirective,
         ThyColDirective,
         ThyFlex,
@@ -20,7 +20,7 @@ import { ThyFlex, ThyFlexComponent, ThyFlexItem, ThyFlexItemComponent } from './
     imports: [
         ThyGrid,
         ThyGridComponent,
-        ThyGridItemComponent,
+        ThyGridItem,
         ThyRowDirective,
         ThyColDirective,
         ThyFlex,

--- a/src/grid/test/grid.spec.ts
+++ b/src/grid/test/grid.spec.ts
@@ -4,7 +4,7 @@ import { By } from '@angular/platform-browser';
 import {
     ThyGrid,
     ThyGridComponent,
-    ThyGridItemComponent,
+    ThyGridItem,
     ThyGridModule,
     ThyGridResponsiveDescription,
     ThyGridResponsiveMode
@@ -82,7 +82,7 @@ describe('grid', () => {
             expect(gridElement).toBeTruthy();
             expect(gridElement.classList.contains('thy-grid')).toBeTruthy();
 
-            const gridItems = gridDebugElement.queryAll(By.directive(ThyGridItemComponent));
+            const gridItems = gridDebugElement.queryAll(By.directive(ThyGridItem));
             expect(gridItems).toBeTruthy();
             expect(gridItems.length).toBe(2);
         });
@@ -102,7 +102,7 @@ describe('grid', () => {
         });
 
         it('should have correct default value for grid item', () => {
-            const gridItems = gridDebugElement.queryAll(By.directive(ThyGridItemComponent));
+            const gridItems = gridDebugElement.queryAll(By.directive(ThyGridItem));
             expect(gridItems).toBeTruthy();
             expect(gridItems.length).toBe(2);
             gridItems.forEach(gridItem => {
@@ -220,7 +220,7 @@ describe('grid', () => {
 
         describe('thySpan', () => {
             it('should support default thySpan', () => {
-                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItemComponent))[1];
+                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItem))[1];
                 const gridItemElement = gridItem.nativeElement;
                 expect(gridItemElement.style.gridColumn).toContain('span 1');
             });
@@ -230,7 +230,7 @@ describe('grid', () => {
                 fixture.detectChanges();
                 gridInstance.ngAfterContentInit();
 
-                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItemComponent))[0];
+                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItem))[0];
                 const gridItemElement = gridItem.nativeElement;
                 expect(gridItemElement.style.display).toBe('none');
             });
@@ -240,7 +240,7 @@ describe('grid', () => {
                 fixture.detectChanges();
                 gridInstance.ngAfterContentInit();
 
-                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItemComponent))[1];
+                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItem))[1];
                 const gridItemElement = gridItem.nativeElement;
                 expect(gridItemElement.style.gridColumn).toContain('span 2');
             });
@@ -253,7 +253,7 @@ describe('grid', () => {
                 gridInstance.ngOnInit();
                 gridInstance.ngAfterContentInit();
 
-                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItemComponent))[0];
+                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItem))[0];
                 const gridItemElement = gridItem.nativeElement;
                 assertResponsiveSpan(500, 0);
                 assertResponsiveSpan(600, 2);
@@ -275,14 +275,14 @@ describe('grid', () => {
 
         describe('thyOffset', () => {
             it('should support default thyOffset', () => {
-                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItemComponent))[0];
+                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItem))[0];
                 const gridItemElement = gridItem.nativeElement;
                 expect(gridItemElement.style.gridColumn).toContain('span 1');
                 expect(gridItemElement.style.marginLeft).toBe('');
             });
 
             it('should support thyOffset is a number', () => {
-                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItemComponent))[1];
+                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItem))[1];
                 const gridItemElement = gridItem.nativeElement;
 
                 testComponent.offset2 = 1;
@@ -307,7 +307,7 @@ describe('grid', () => {
             });
 
             it('should support thyOffset is a string', () => {
-                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItemComponent))[0];
+                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItem))[0];
                 const gridItemElement = gridItem.nativeElement;
 
                 testComponent.offset = '2';
@@ -325,7 +325,7 @@ describe('grid', () => {
                 gridInstance.ngOnInit();
                 gridInstance.ngAfterContentInit();
 
-                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItemComponent))[0];
+                const gridItem = gridDebugElement.queryAll(By.directive(ThyGridItem))[0];
                 const gridItemElement = gridItem.nativeElement;
                 assertResponsiveOffset(600, 3);
                 assertResponsiveOffset(800, 2);
@@ -355,7 +355,7 @@ describe('grid', () => {
             it('should show correct grid item added dynamically', () => {
                 testComponent.show = true;
                 fixture.detectChanges();
-                const gridItems = gridDebugElement.queryAll(By.directive(ThyGridItemComponent));
+                const gridItems = gridDebugElement.queryAll(By.directive(ThyGridItem));
                 expect(gridItems.length).toBe(5);
             });
         });

--- a/src/grid/thy-grid-item.component.ts
+++ b/src/grid/thy-grid-item.component.ts
@@ -19,7 +19,7 @@ import { useHostRenderer } from '@tethys/cdk/dom';
     },
     standalone: true
 })
-export class ThyGridItemComponent extends mixinUnsubscribe(MixinBase) implements OnInit, OnDestroy {
+export class ThyGridItem extends mixinUnsubscribe(MixinBase) implements OnInit, OnDestroy {
     /**
      * 栅格项的占位列数，为 0 时会隐藏该栅格项
      * @default 1

--- a/src/grid/thy-grid.component.ts
+++ b/src/grid/thy-grid.component.ts
@@ -18,7 +18,7 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { Observable, Subject } from 'rxjs';
 import { throttleTime } from 'rxjs/operators';
 import { ThyGridToken, THY_GRID_COMPONENT } from './grid.token';
-import { ThyGridItemComponent } from './thy-grid-item.component';
+import { ThyGridItem } from './thy-grid-item.component';
 import { useHostRenderer } from '@tethys/cdk/dom';
 import { hasLaterChange } from 'ngx-tethys/util';
 
@@ -61,7 +61,7 @@ export class ThyGrid implements ThyGridToken, OnInit, OnChanges, AfterContentIni
     /**
      * @internal
      */
-    @ContentChildren(ThyGridItemComponent) gridItems!: QueryList<ThyGridItemComponent>;
+    @ContentChildren(ThyGridItem) gridItems!: QueryList<ThyGridItem>;
 
     /**
      * 栅格的列数
@@ -169,7 +169,7 @@ export class ThyGrid implements ThyGridToken, OnInit, OnChanges, AfterContentIni
     }
 
     private handleGridItems() {
-        this.gridItems.forEach((gridItem: ThyGridItemComponent) => {
+        this.gridItems.forEach((gridItem: ThyGridItem) => {
             const rawSpan = getRawSpan(gridItem.thySpan);
             const span = this.calculateActualValue(rawSpan, THY_GRID_ITEM_DEFAULT_SPAN);
             const offset = this.calculateActualValue(gridItem.thyOffset || 0);

--- a/src/guider/guider-hint/guider-hint.component.ts
+++ b/src/guider/guider-hint/guider-hint.component.ts
@@ -14,7 +14,7 @@ import { NgIf, NgTemplateOutlet, NgFor, NgClass } from '@angular/common';
     standalone: true,
     imports: [NgIf, NgTemplateOutlet, NgFor, NgClass]
 })
-export class ThyGuiderHintComponent implements OnInit {
+export class ThyGuiderHint implements OnInit {
     @HostBinding('class.thy-guider-tip-container') guiderHint = true;
 
     public guiderRef: ThyGuiderRef;
@@ -62,4 +62,4 @@ export class ThyGuiderHintComponent implements OnInit {
     }
 }
 
-defaultGuiderPositionConfig.hintComponent = ThyGuiderHintComponent;
+defaultGuiderPositionConfig.hintComponent = ThyGuiderHint;

--- a/src/guider/guider.module.ts
+++ b/src/guider/guider.module.ts
@@ -6,19 +6,11 @@ import { ThySharedModule } from 'ngx-tethys/shared';
 import { ThyButtonModule } from 'ngx-tethys/button';
 import { ThyPopoverModule } from 'ngx-tethys/popover';
 import { ThyGuiderTargetDirective } from './guider.directive';
-import { ThyGuiderHintComponent } from './guider-hint/guider-hint.component';
+import { ThyGuiderHint } from './guider-hint/guider-hint.component';
 
 @NgModule({
-    imports: [
-        CommonModule,
-        ThySharedModule,
-        ThyIconModule,
-        ThyButtonModule,
-        ThyPopoverModule,
-        ThyGuiderHintComponent,
-        ThyGuiderTargetDirective
-    ],
-    exports: [ThyGuiderHintComponent, ThyGuiderTargetDirective],
+    imports: [CommonModule, ThySharedModule, ThyIconModule, ThyButtonModule, ThyPopoverModule, ThyGuiderHint, ThyGuiderTargetDirective],
+    exports: [ThyGuiderHint, ThyGuiderTargetDirective],
     providers: [ThyGuider]
 })
 export class ThyGuiderModule {}

--- a/src/icon/icon.component.ts
+++ b/src/icon/icon.component.ts
@@ -38,7 +38,7 @@ const iconSuffixMap = {
         class: 'thy-icon'
     }
 })
-export class ThyIconComponent implements OnInit, OnChanges {
+export class ThyIcon implements OnInit, OnChanges {
     private initialized = false;
 
     /**

--- a/src/icon/icon.module.ts
+++ b/src/icon/icon.module.ts
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { ThyIconComponent } from './icon.component';
+import { ThyIcon } from './icon.component';
 import { HttpClientModule } from '@angular/common/http';
 
 @NgModule({
     declarations: [],
-    imports: [ThyIconComponent, CommonModule, FormsModule, HttpClientModule],
-    exports: [ThyIconComponent]
+    imports: [ThyIcon, CommonModule, FormsModule, HttpClientModule],
+    exports: [ThyIcon]
 })
 export class ThyIconModule {}

--- a/src/icon/index.ts
+++ b/src/icon/index.ts
@@ -1,4 +1,4 @@
 export { ThyIconModule } from './icon.module';
-export { ThyIconComponent } from './icon.component';
+export { ThyIcon } from './icon.component';
 export { ThyIconRegistry } from './icon-registry';
 export { setPrintErrorWhenIconNotFound } from './config';

--- a/src/icon/test/icon.spec.ts
+++ b/src/icon/test/icon.spec.ts
@@ -10,7 +10,7 @@ import { By, DomSanitizer } from '@angular/platform-browser';
 
 import { getWhetherPrintErrorWhenIconNotFound, setPrintErrorWhenIconNotFound } from '../config';
 import { ThyIconRegistry } from '../icon-registry';
-import { ThyIconComponent } from '../icon.component';
+import { ThyIcon } from '../icon.component';
 import { ThyIconModule } from '../icon.module';
 
 @Component({
@@ -67,7 +67,7 @@ describe('ThyIconComponent', () => {
             fixture = TestBed.createComponent(ThyIconTestBasicComponent);
             componentInstance = fixture.debugElement.componentInstance;
             fixture.detectChanges();
-            iconDebugElement = fixture.debugElement.query(By.directive(ThyIconComponent));
+            iconDebugElement = fixture.debugElement.query(By.directive(ThyIcon));
         });
 
         it('should create icon success', () => {

--- a/src/image/image-group.component.ts
+++ b/src/image/image-group.component.ts
@@ -12,7 +12,7 @@ import { ThyImageDirective } from './image.directive';
     encapsulation: ViewEncapsulation.None,
     standalone: true
 })
-export class ThyImageGroupComponent {
+export class ThyImageGroup {
     constructor(public injector: Injector, public element: ElementRef) {}
 
     images: ThyImageDirective[] = [];

--- a/src/image/image.directive.ts
+++ b/src/image/image.directive.ts
@@ -11,7 +11,7 @@ import {
     AfterViewInit
 } from '@angular/core';
 import { InputBoolean } from 'ngx-tethys/core';
-import { ThyImageGroupComponent } from './image-group.component';
+import { ThyImageGroup } from './image-group.component';
 import { ThyImageMeta } from './image.class';
 import { ThyImageService } from './image.service';
 
@@ -66,7 +66,7 @@ export class ThyImageDirective implements OnInit, OnChanges, AfterViewInit, OnDe
         return !this.thyDisablePreview;
     }
 
-    private parentGroup: ThyImageGroupComponent;
+    private parentGroup: ThyImageGroup;
 
     constructor(private thyImageService: ThyImageService, private injector: Injector, private elementRef: ElementRef) {}
 
@@ -84,7 +84,7 @@ export class ThyImageDirective implements OnInit, OnChanges, AfterViewInit, OnDe
         while (true) {
             // 多层 thy-image-group 嵌套时，获取最外层 thy-image-group 下的所有图片
             const injector = this.parentGroup?.injector || this.injector;
-            const parentGroup = injector.get(ThyImageGroupComponent, null, InjectFlags.SkipSelf);
+            const parentGroup = injector.get(ThyImageGroup, null, InjectFlags.SkipSelf);
             if (!parentGroup) {
                 break;
             }

--- a/src/image/image.service.ts
+++ b/src/image/image.service.ts
@@ -1,7 +1,7 @@
 import { Inject, Injectable, OnDestroy, Optional } from '@angular/core';
 import { ThyImagePreviewConfig, THY_IMAGE_DEFAULT_PREVIEW_OPTIONS } from './image.config';
 import { ThyImageInfo, ThyImagePreviewOptions } from './image.class';
-import { ThyImagePreviewComponent } from './preview/image-preview.component';
+import { ThyImagePreview } from './preview/image-preview.component';
 import { ThyDialog, ThyDialogSizes } from 'ngx-tethys/dialog';
 import { ThyImagePreviewRef } from './preview/image-preview-ref';
 import { Observable, Subject } from 'rxjs';
@@ -35,7 +35,7 @@ export class ThyImageService implements OnDestroy {
      */
     preview(images: ThyImageInfo[], options?: ThyImagePreviewOptions & { startIndex?: number }): ThyImagePreviewRef {
         const config = { ...this.defaultConfig, ...options };
-        const dialogRef = this.thyDialog.open(ThyImagePreviewComponent, {
+        const dialogRef = this.thyDialog.open(ThyImagePreview, {
             initialState: {
                 images,
                 previewIndex: options?.startIndex >= 0 && options?.startIndex < images.length ? options.startIndex : 0,

--- a/src/image/module.ts
+++ b/src/image/module.ts
@@ -2,8 +2,8 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ThyImageDirective } from './image.directive';
 import { DragDropModule } from '@angular/cdk/drag-drop';
-import { ThyImageGroupComponent } from './image-group.component';
-import { ThyImagePreviewComponent } from './preview/image-preview.component';
+import { ThyImageGroup } from './image-group.component';
+import { ThyImagePreview } from './preview/image-preview.component';
 import { ThyImageService } from './image.service';
 import { PortalModule } from '@angular/cdk/portal';
 import { THY_IMAGE_DEFAULT_PREVIEW_OPTIONS_PROVIDER } from './image.config';
@@ -16,7 +16,7 @@ import { ThyDialogModule } from 'ngx-tethys/dialog';
 import { ThyActionModule } from 'ngx-tethys/action';
 
 @NgModule({
-    exports: [ThyImageDirective, ThyImageGroupComponent, ThyImagePreviewComponent],
+    exports: [ThyImageDirective, ThyImageGroup, ThyImagePreview],
     imports: [
         CommonModule,
         PortalModule,
@@ -29,8 +29,8 @@ import { ThyActionModule } from 'ngx-tethys/action';
         ThyLoadingModule,
         ThyActionModule,
         ThyImageDirective,
-        ThyImageGroupComponent,
-        ThyImagePreviewComponent
+        ThyImageGroup,
+        ThyImagePreview
     ],
     providers: [ThyImageService, THY_IMAGE_DEFAULT_PREVIEW_OPTIONS_PROVIDER]
 })

--- a/src/image/preview/image-preview-ref.ts
+++ b/src/image/preview/image-preview-ref.ts
@@ -1,4 +1,4 @@
-import { ThyImagePreviewComponent } from './image-preview.component';
+import { ThyImagePreview } from './image-preview.component';
 import { ThyDialogRef } from 'ngx-tethys/dialog';
 import { LEFT_ARROW, RIGHT_ARROW } from '@angular/cdk/keycodes';
 import { ThyImageInfo, ThyImagePreviewOptions } from '../image.class';
@@ -10,9 +10,9 @@ export class ThyImagePreviewRef {
     }
 
     constructor(
-        public previewInstance: ThyImagePreviewComponent,
+        public previewInstance: ThyImagePreview,
         private config: ThyImagePreviewOptions,
-        private dialogRef: ThyDialogRef<ThyImagePreviewComponent>
+        private dialogRef: ThyDialogRef<ThyImagePreview>
     ) {
         dialogRef
             .keydownEvents()

--- a/src/image/preview/image-preview.component.ts
+++ b/src/image/preview/image-preview.component.ts
@@ -22,11 +22,11 @@ import { ThyCopyEvent, ThyCopyDirective } from 'ngx-tethys/copy';
 import { ThyNotifyService } from 'ngx-tethys/notify';
 import { DomSanitizer } from '@angular/platform-browser';
 import { fetchImageBlob } from '../utils';
-import { ThyDividerComponent } from 'ngx-tethys/divider';
-import { ThyIconComponent } from 'ngx-tethys/icon';
-import { ThyLoadingComponent } from 'ngx-tethys/loading';
+import { ThyDivider } from 'ngx-tethys/divider';
+import { ThyIcon } from 'ngx-tethys/icon';
+import { ThyLoading } from 'ngx-tethys/loading';
 import { CdkDrag } from '@angular/cdk/drag-drop';
-import { ThyActionComponent, ThyActionsComponent } from 'ngx-tethys/action';
+import { ThyAction, ThyActions } from 'ngx-tethys/action';
 import { ThyTooltipDirective } from 'ngx-tethys/tooltip';
 import { NgIf, NgFor } from '@angular/common';
 
@@ -55,20 +55,9 @@ const VERTICAL_SPACE = 96 + 106; // top: 96px; bottom: 106px
         '[class.thy-image-preview-moving]': 'isDragging'
     },
     standalone: true,
-    imports: [
-        NgIf,
-        ThyTooltipDirective,
-        ThyActionComponent,
-        CdkDrag,
-        NgFor,
-        ThyLoadingComponent,
-        ThyIconComponent,
-        ThyActionsComponent,
-        ThyDividerComponent,
-        ThyCopyDirective
-    ]
+    imports: [NgIf, ThyTooltipDirective, ThyAction, CdkDrag, NgFor, ThyLoading, ThyIcon, ThyActions, ThyDivider, ThyCopyDirective]
 })
-export class ThyImagePreviewComponent extends mixinUnsubscribe(MixinBase) implements OnInit, OnDestroy {
+export class ThyImagePreview extends mixinUnsubscribe(MixinBase) implements OnInit, OnDestroy {
     @Output() downloadClicked: EventEmitter<ThyImageInfo> = new EventEmitter();
     images: InternalImageInfo[] = [];
     previewIndex: number = 0;

--- a/src/input-number/input-number.component.ts
+++ b/src/input-number/input-number.component.ts
@@ -1,6 +1,6 @@
 import { InputBoolean, InputNumber, TabIndexDisabledControlValueAccessorMixin, useHostFocusControl } from 'ngx-tethys/core';
 import { ThyMaxDirective, ThyMinDirective } from 'ngx-tethys/form';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { ThyInputDirective } from 'ngx-tethys/input';
 import { ThyAutofocusDirective } from 'ngx-tethys/shared';
 import { DOWN_ARROW, ENTER, isFloat, isNumber, isUndefinedOrNull, UP_ARROW } from 'ngx-tethys/util';
@@ -40,18 +40,18 @@ enum Type {
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThyInputNumberComponent),
+            useExisting: forwardRef(() => ThyInputNumber),
             multi: true
         }
     ],
     standalone: true,
-    imports: [ThyIconComponent, ThyInputDirective, ThyAutofocusDirective, FormsModule, ThyMinDirective, ThyMaxDirective],
+    imports: [ThyIcon, ThyInputDirective, ThyAutofocusDirective, FormsModule, ThyMinDirective, ThyMaxDirective],
     host: {
         class: 'thy-input-number',
         '[attr.tabindex]': 'tabIndex'
     }
 })
-export class ThyInputNumberComponent
+export class ThyInputNumber
     extends TabIndexDisabledControlValueAccessorMixin
     implements ControlValueAccessor, OnChanges, OnInit, OnDestroy
 {

--- a/src/input-number/module.ts
+++ b/src/input-number/module.ts
@@ -3,12 +3,12 @@ import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
 import { ThySharedModule } from 'ngx-tethys/shared';
 import { ThyIconModule } from 'ngx-tethys/icon';
-import { ThyInputNumberComponent } from './input-number.component';
+import { ThyInputNumber } from './input-number.component';
 import { ThyInputModule } from 'ngx-tethys/input';
 import { ThyFormModule } from 'ngx-tethys/form';
 
 @NgModule({
-    imports: [CommonModule, FormsModule, ThySharedModule, ThyIconModule, ThyInputModule, ThyFormModule, ThyInputNumberComponent],
-    exports: [ThyInputNumberComponent]
+    imports: [CommonModule, FormsModule, ThySharedModule, ThyIconModule, ThyInputModule, ThyFormModule, ThyInputNumber],
+    exports: [ThyInputNumber]
 })
 export class ThyInputNumberModule {}

--- a/src/input-number/test/input-number.spec.ts
+++ b/src/input-number/test/input-number.spec.ts
@@ -7,7 +7,7 @@ import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
-import { ThyInputNumberComponent } from '../input-number.component';
+import { ThyInputNumber } from '../input-number.component';
 import { ThyInputNumberModule } from '../module';
 
 @Component({
@@ -46,9 +46,9 @@ import { ThyInputNumberModule } from '../module';
     `
 })
 class TestInputNumberComponent {
-    @ViewChild(ThyInputNumberComponent, { static: false }) inputNumberComponent: ThyInputNumberComponent;
+    @ViewChild(ThyInputNumber, { static: false }) inputNumberComponent: ThyInputNumber;
 
-    @ViewChild('second', { static: false }) secondInputNumberComponent: ThyInputNumberComponent;
+    @ViewChild('second', { static: false }) secondInputNumberComponent: ThyInputNumber;
 
     thySize = ``;
 
@@ -108,7 +108,7 @@ describe('input-number component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(TestInputNumberComponent);
         inputNumberComponentInstance = fixture.debugElement.componentInstance;
-        inputNumberDebugElement = fixture.debugElement.query(By.directive(ThyInputNumberComponent));
+        inputNumberDebugElement = fixture.debugElement.query(By.directive(ThyInputNumber));
         inputElement = inputNumberDebugElement.nativeElement.querySelector('input');
     });
 

--- a/src/input/input-count.component.ts
+++ b/src/input/input-count.component.ts
@@ -3,7 +3,7 @@ import { ThyInputDirective } from './input.directive';
 import { mixinUnsubscribe, MixinBase } from 'ngx-tethys/core';
 import { takeUntil, switchMap, filter, tap } from 'rxjs/operators';
 import { Subject } from 'rxjs';
-import { ThyInputGroupComponent } from './input-group.component';
+import { ThyInputGroup } from './input-group.component';
 
 const _Base = mixinUnsubscribe(MixinBase);
 
@@ -21,7 +21,7 @@ const _Base = mixinUnsubscribe(MixinBase);
     },
     standalone: true
 })
-export class ThyInputCountComponent extends _Base implements OnInit {
+export class ThyInputCount extends _Base implements OnInit {
     private hasInput = false;
 
     /**
@@ -39,7 +39,7 @@ export class ThyInputCountComponent extends _Base implements OnInit {
 
     thyInput$ = new Subject<ThyInputDirective>();
 
-    constructor(private changeDetectorRef: ChangeDetectorRef, @Optional() private inputGroup: ThyInputGroupComponent) {
+    constructor(private changeDetectorRef: ChangeDetectorRef, @Optional() private inputGroup: ThyInputGroup) {
         super();
         this.setup();
     }

--- a/src/input/input-group.component.ts
+++ b/src/input/input-group.component.ts
@@ -49,7 +49,7 @@ const inputGroupSizeMap = {
     standalone: true,
     imports: [NgIf, NgTemplateOutlet]
 })
-export class ThyInputGroupComponent extends mixinUnsubscribe(MixinBase) implements OnInit, AfterContentChecked, OnDestroy {
+export class ThyInputGroup extends mixinUnsubscribe(MixinBase) implements OnInit, AfterContentChecked, OnDestroy {
     private hostRenderer = useHostRenderer();
 
     private hostFocusControl = useHostFocusControl();

--- a/src/input/input-search.component.ts
+++ b/src/input/input-search.component.ts
@@ -28,7 +28,7 @@ import {
 } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { useHostRenderer } from '@tethys/cdk/dom';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { ThyAutofocusDirective } from 'ngx-tethys/shared';
 import { ThyInputDirective, ThyInputSize } from './input.directive';
 
@@ -39,7 +39,7 @@ export type ThyInputSearchIconPosition = 'before' | 'after';
 
 export const CUSTOM_INPUT_SEARCH_CONTROL_VALUE_ACCESSOR: any = {
     provide: NG_VALUE_ACCESSOR,
-    useExisting: forwardRef(() => ThyInputSearchComponent),
+    useExisting: forwardRef(() => ThyInputSearch),
     multi: true
 };
 
@@ -70,9 +70,9 @@ const _MixinBase: Constructor<ThyHasTabIndex> &
         '[attr.tabindex]': 'tabIndex'
     },
     standalone: true,
-    imports: [NgIf, ThyIconComponent, ThyInputDirective, ThyAutofocusDirective, FormsModule]
+    imports: [NgIf, ThyIcon, ThyInputDirective, ThyAutofocusDirective, FormsModule]
 })
-export class ThyInputSearchComponent extends _MixinBase implements ControlValueAccessor, OnInit, OnDestroy {
+export class ThyInputSearch extends _MixinBase implements ControlValueAccessor, OnInit, OnDestroy {
     @ViewChild('input', { static: true }) inputElement: ElementRef<any>;
 
     private hostRenderer = useHostRenderer();

--- a/src/input/input.component.ts
+++ b/src/input/input.component.ts
@@ -16,14 +16,14 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { ControlValueAccessor, FormsModule, NG_VALUE_ACCESSOR } from '@angular/forms';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { ThyAutofocusDirective } from 'ngx-tethys/shared';
 import { ThyInputDirective, ThyInputSize } from './input.directive';
 import { InputBoolean } from 'ngx-tethys/core';
 
 export const CUSTOM_INPUT_CONTROL_VALUE_ACCESSOR: any = {
     provide: NG_VALUE_ACCESSOR,
-    useExisting: forwardRef(() => ThyInputComponent),
+    useExisting: forwardRef(() => ThyInput),
     multi: true
 };
 
@@ -47,9 +47,9 @@ const password = 'password';
         '[class.disabled]': 'disabled'
     },
     standalone: true,
-    imports: [NgIf, NgTemplateOutlet, ThyInputDirective, ThyAutofocusDirective, FormsModule, ThyIconComponent]
+    imports: [NgIf, NgTemplateOutlet, ThyInputDirective, ThyAutofocusDirective, FormsModule, ThyIcon]
 })
-export class ThyInputComponent implements ControlValueAccessor, OnInit {
+export class ThyInput implements ControlValueAccessor, OnInit {
     /**
      * Placeholder
      */

--- a/src/input/module.ts
+++ b/src/input/module.ts
@@ -1,14 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ThyInputDirective } from './input.directive';
-import { ThyInputComponent } from './input.component';
-import { ThyInputGroupComponent } from './input-group.component';
-import { ThyInputSearchComponent } from './input-search.component';
+import { ThyInput } from './input.component';
+import { ThyInputGroup } from './input-group.component';
+import { ThyInputSearch } from './input-search.component';
 import { FormsModule } from '@angular/forms';
 import { ThySharedModule } from 'ngx-tethys/shared';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyDividerModule } from 'ngx-tethys/divider';
-import { ThyInputCountComponent } from './input-count.component';
+import { ThyInputCount } from './input-count.component';
 
 @NgModule({
     imports: [
@@ -18,11 +18,11 @@ import { ThyInputCountComponent } from './input-count.component';
         ThyIconModule,
         ThyDividerModule,
         ThyInputDirective,
-        ThyInputComponent,
-        ThyInputGroupComponent,
-        ThyInputSearchComponent,
-        ThyInputCountComponent
+        ThyInput,
+        ThyInputGroup,
+        ThyInputSearch,
+        ThyInputCount
     ],
-    exports: [ThyInputDirective, ThyInputComponent, ThyInputGroupComponent, ThyInputSearchComponent, ThyInputCountComponent]
+    exports: [ThyInputDirective, ThyInput, ThyInputGroup, ThyInputSearch, ThyInputCount]
 })
 export class ThyInputModule {}

--- a/src/input/test/input-component.spec.ts
+++ b/src/input/test/input-component.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
-import { ThyInputComponent } from '../input.component';
+import { ThyInput } from '../input.component';
 import { ThyInputDirective } from '../input.directive';
 import { ThyInputModule } from '../module';
 
@@ -75,7 +75,7 @@ describe('input component', () => {
         fixture = TestBed.createComponent(TestBedComponent);
         basicTestComponent = fixture.debugElement.componentInstance;
         debugElement = fixture.debugElement.query(By.directive(ThyInputDirective));
-        debugContainerElement = fixture.debugElement.query(By.directive(ThyInputComponent));
+        debugContainerElement = fixture.debugElement.query(By.directive(ThyInput));
     });
 
     it('thySize empty string', () => {
@@ -174,7 +174,7 @@ describe('input component', () => {
     it('focus and blur ', fakeAsync(() => {
         fixture.detectChanges();
         tick();
-        const debugInputInstance = fixture.debugElement.query(By.directive(ThyInputComponent)).componentInstance;
+        const debugInputInstance = fixture.debugElement.query(By.directive(ThyInput)).componentInstance;
 
         debugInputInstance.onInputFocus();
         fixture.detectChanges();

--- a/src/input/test/input-count.spec.ts
+++ b/src/input/test/input-count.spec.ts
@@ -2,7 +2,7 @@ import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { ThyInputCountComponent } from '../input-count.component';
+import { ThyInputCount } from '../input-count.component';
 import { ThyInputModule } from '../module';
 
 @Component({
@@ -55,7 +55,7 @@ describe('input count', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(TestInputCountBasicComponent);
         fixture.detectChanges();
-        countDebugElement = fixture.debugElement.query(By.directive(ThyInputCountComponent));
+        countDebugElement = fixture.debugElement.query(By.directive(ThyInputCount));
     });
 
     it('should create input count', () => {
@@ -80,7 +80,7 @@ describe('input count', () => {
     it('should create with specify input', () => {
         fixture = TestBed.createComponent(TestInputCountSpecifyInputBasicComponent);
         fixture.detectChanges();
-        countDebugElement = fixture.debugElement.query(By.directive(ThyInputCountComponent));
+        countDebugElement = fixture.debugElement.query(By.directive(ThyInputCount));
         expect(countDebugElement).toBeTruthy();
         const countElement = countDebugElement.nativeElement as HTMLElement;
         expect(countElement.classList.contains('text-muted')).toBeTruthy();

--- a/src/input/test/input-group.spec.ts
+++ b/src/input/test/input-group.spec.ts
@@ -1,7 +1,7 @@
 import { Component, DebugElement, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ThyInputGroupComponent } from '../input-group.component';
+import { ThyInputGroup } from '../input-group.component';
 import { ThyInputModule } from './../module';
 import { ThyTranslate } from '../../core';
 import { dispatchFakeEvent } from 'ngx-tethys/testing';
@@ -110,7 +110,7 @@ describe('input group', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(TestInputGroupBasicComponent);
             basicTestComponent = fixture.debugElement.componentInstance;
-            debugElement = fixture.debugElement.query(By.directive(ThyInputGroupComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyInputGroup));
         });
 
         it('thyPrependText', () => {

--- a/src/input/test/input-search.spec.ts
+++ b/src/input/test/input-search.spec.ts
@@ -5,7 +5,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
-import { ThyInputSearchComponent, ThyInputSearchIconPosition } from '../input-search.component';
+import { ThyInputSearch, ThyInputSearchIconPosition } from '../input-search.component';
 import { ThyInputDirective } from '../input.directive';
 import { ThyInputModule } from '../module';
 
@@ -26,7 +26,7 @@ import { ThyInputModule } from '../module';
     `
 })
 class TestInputSearchBasicComponent {
-    @ViewChild(ThyInputSearchComponent, { static: false }) inputSearchComponent: ThyInputSearchComponent;
+    @ViewChild(ThyInputSearch, { static: false }) inputSearchComponent: ThyInputSearch;
 
     searchFocus = true;
     searchText = '';
@@ -66,7 +66,7 @@ describe('input search', () => {
         fixture = TestBed.createComponent(TestInputSearchBasicComponent);
         basicTestComponent = fixture.debugElement.componentInstance;
         debugInputElement = fixture.debugElement.query(By.directive(ThyInputDirective));
-        debugSearchElement = fixture.debugElement.query(By.directive(ThyInputSearchComponent));
+        debugSearchElement = fixture.debugElement.query(By.directive(ThyInputSearch));
         searchElement = debugSearchElement.nativeElement;
         injectDefaultSvgIconSet();
     });
@@ -165,7 +165,7 @@ describe('input search', () => {
         fixture.detectChanges();
         expect(searchElement.classList.contains('form-control-active')).toBe(true);
 
-        const debugInputInstance = fixture.debugElement.query(By.directive(ThyInputSearchComponent)).componentInstance;
+        const debugInputInstance = fixture.debugElement.query(By.directive(ThyInputSearch)).componentInstance;
         debugInputInstance.focused = false;
         fixture.detectChanges();
         expect(searchElement.classList.contains('form-control-active')).toBe(false);

--- a/src/layout/content-main.component.ts
+++ b/src/layout/content-main.component.ts
@@ -27,4 +27,4 @@ export class ThyContentMainDirective {}
     hostDirectives: [ThyContentMainDirective],
     standalone: true
 })
-export class ThyContentMainComponent {}
+export class ThyContentMain {}

--- a/src/layout/content-section.component.ts
+++ b/src/layout/content-section.component.ts
@@ -27,4 +27,4 @@ export class ThyContentSectionDirective {}
     hostDirectives: [ThyContentSectionDirective],
     standalone: true
 })
-export class ThyContentSectionComponent {}
+export class ThyContentSection {}

--- a/src/layout/content.component.ts
+++ b/src/layout/content.component.ts
@@ -27,4 +27,4 @@ export class ThyContentDirective {}
     hostDirectives: [ThyContentDirective],
     standalone: true
 })
-export class ThyContentComponent {}
+export class ThyContent {}

--- a/src/layout/header.component.ts
+++ b/src/layout/header.component.ts
@@ -1,7 +1,7 @@
 import { NgClass, NgIf, NgTemplateOutlet } from '@angular/common';
 import { ChangeDetectionStrategy, Component, ContentChild, Directive, Input, OnInit, TemplateRef } from '@angular/core';
 import { InputBoolean } from 'ngx-tethys/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { coerceBooleanProperty } from 'ngx-tethys/util';
 
 /**
@@ -72,9 +72,9 @@ export class ThyHeaderDirective {
         }
     ],
     standalone: true,
-    imports: [NgTemplateOutlet, NgIf, ThyIconComponent, NgClass, ThyHeaderDirective]
+    imports: [NgTemplateOutlet, NgIf, ThyIcon, NgClass, ThyHeaderDirective]
 })
-export class ThyHeaderComponent {
+export class ThyHeader {
     public iconClass: string;
 
     public svgIconName: string;

--- a/src/layout/layout.component.ts
+++ b/src/layout/layout.component.ts
@@ -32,4 +32,4 @@ export class ThyLayoutDirective {
     hostDirectives: [ThyLayoutDirective],
     standalone: true
 })
-export class ThyLayoutComponent {}
+export class ThyLayout {}

--- a/src/layout/layout.module.ts
+++ b/src/layout/layout.module.ts
@@ -1,18 +1,18 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyLayoutComponent, ThyLayoutDirective } from './layout.component';
-import { ThyHeaderComponent, ThyHeaderDirective } from './header.component';
-import { ThyContentComponent, ThyContentDirective } from './content.component';
-import { ThySidebarComponent, ThySidebarDirective } from './sidebar.component';
-import { ThyContentSectionComponent, ThyContentSectionDirective } from './content-section.component';
-import { ThyContentMainComponent, ThyContentMainDirective } from './content-main.component';
+import { ThyLayout, ThyLayoutDirective } from './layout.component';
+import { ThyHeader, ThyHeaderDirective } from './header.component';
+import { ThyContent, ThyContentDirective } from './content.component';
+import { ThySidebar, ThySidebarDirective } from './sidebar.component';
+import { ThyContentSection, ThyContentSectionDirective } from './content-section.component';
+import { ThyContentMain, ThyContentMainDirective } from './content-main.component';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { ThyHotkeyModule } from '@tethys/cdk/hotkey';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyTooltipModule } from 'ngx-tethys/tooltip';
-import { ThySidebarHeaderComponent, ThySidebarHeaderDirective } from './sidebar-header.component';
-import { ThySidebarFooterComponent, ThySidebarFooterDirective } from './sidebar-footer.component';
-import { ThySidebarContentComponent, ThySidebarContentDirective } from './sidebar-content.component';
+import { ThySidebarHeader, ThySidebarHeaderDirective } from './sidebar-header.component';
+import { ThySidebarFooter, ThySidebarFooterDirective } from './sidebar-footer.component';
+import { ThySidebarContent, ThySidebarContentDirective } from './sidebar-content.component';
 import { ThyResizableModule } from 'ngx-tethys/resizable';
 
 @NgModule({
@@ -23,15 +23,15 @@ import { ThyResizableModule } from 'ngx-tethys/resizable';
         ThyTooltipModule,
         ThyResizableModule,
         ThyHotkeyModule,
-        ThyLayoutComponent,
-        ThyHeaderComponent,
-        ThyContentComponent,
-        ThySidebarComponent,
-        ThySidebarHeaderComponent,
-        ThySidebarContentComponent,
-        ThySidebarFooterComponent,
-        ThyContentSectionComponent,
-        ThyContentMainComponent,
+        ThyLayout,
+        ThyHeader,
+        ThyContent,
+        ThySidebar,
+        ThySidebarHeader,
+        ThySidebarContent,
+        ThySidebarFooter,
+        ThyContentSection,
+        ThyContentMain,
         ThyLayoutDirective,
         ThyHeaderDirective,
         ThyContentDirective,
@@ -43,15 +43,15 @@ import { ThyResizableModule } from 'ngx-tethys/resizable';
         ThyContentMainDirective
     ],
     exports: [
-        ThyLayoutComponent,
-        ThyHeaderComponent,
-        ThyContentComponent,
-        ThySidebarComponent,
-        ThySidebarHeaderComponent,
-        ThySidebarContentComponent,
-        ThySidebarFooterComponent,
-        ThyContentSectionComponent,
-        ThyContentMainComponent,
+        ThyLayout,
+        ThyHeader,
+        ThyContent,
+        ThySidebar,
+        ThySidebarHeader,
+        ThySidebarContent,
+        ThySidebarFooter,
+        ThyContentSection,
+        ThyContentMain,
         ThyLayoutDirective,
         ThyHeaderDirective,
         ThyContentDirective,

--- a/src/layout/sidebar-content.component.ts
+++ b/src/layout/sidebar-content.component.ts
@@ -26,4 +26,4 @@ export class ThySidebarContentDirective {}
     hostDirectives: [ThySidebarContentDirective],
     standalone: true
 })
-export class ThySidebarContentComponent {}
+export class ThySidebarContent {}

--- a/src/layout/sidebar-footer.component.ts
+++ b/src/layout/sidebar-footer.component.ts
@@ -26,4 +26,4 @@ export class ThySidebarFooterDirective {}
     hostDirectives: [ThySidebarFooterDirective],
     standalone: true
 })
-export class ThySidebarFooterComponent {}
+export class ThySidebarFooter {}

--- a/src/layout/sidebar-header.component.ts
+++ b/src/layout/sidebar-header.component.ts
@@ -41,7 +41,7 @@ export class ThySidebarHeaderDirective {
     standalone: true,
     imports: [NgTemplateOutlet, NgIf]
 })
-export class ThySidebarHeaderComponent {
+export class ThySidebarHeader {
     /**
      * 头部标题
      */

--- a/src/layout/sidebar.component.ts
+++ b/src/layout/sidebar.component.ts
@@ -18,8 +18,8 @@ import {
 import { ThyHotkeyDispatcher } from '@tethys/cdk/hotkey';
 import { isMacPlatform } from '@tethys/cdk/is';
 import { InputBoolean, InputNumber } from 'ngx-tethys/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
-import { ThyResizableDirective, ThyResizeEvent, ThyResizeHandleComponent } from 'ngx-tethys/resizable';
+import { ThyIcon } from 'ngx-tethys/icon';
+import { ThyResizableDirective, ThyResizeEvent, ThyResizeHandle } from 'ngx-tethys/resizable';
 import { ThyTooltipDirective } from 'ngx-tethys/tooltip';
 import { coerceBooleanProperty } from 'ngx-tethys/util';
 import { Subscription } from 'rxjs';
@@ -183,18 +183,9 @@ export class ThySidebarDirective implements OnInit {
         }
     ],
     standalone: true,
-    imports: [
-        NgTemplateOutlet,
-        NgIf,
-        ThyResizeHandleComponent,
-        ThyResizableDirective,
-        ThyIconComponent,
-        ThyTooltipDirective,
-        NgClass,
-        NgStyle
-    ]
+    imports: [NgTemplateOutlet, NgIf, ThyResizeHandle, ThyResizableDirective, ThyIcon, ThyTooltipDirective, NgClass, NgStyle]
 })
-export class ThySidebarComponent implements OnInit, OnDestroy {
+export class ThySidebar implements OnInit, OnDestroy {
     sidebarDirective = inject(ThySidebarDirective);
 
     @HostBinding('style.width.px') get sidebarWidth() {

--- a/src/layout/test/layout.spec.ts
+++ b/src/layout/test/layout.spec.ts
@@ -2,12 +2,12 @@ import { Component, DebugElement } from '@angular/core';
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { ThyLayoutModule } from '../layout.module';
 import { By } from '@angular/platform-browser';
-import { ThyLayoutComponent, ThyLayoutDirective } from '../layout.component';
-import { ThyHeaderComponent, ThyHeaderDirective } from '../header.component';
+import { ThyLayout, ThyLayoutDirective } from '../layout.component';
+import { ThyHeader, ThyHeaderDirective } from '../header.component';
 import { injectDefaultSvgIconSet, bypassSanitizeProvider } from 'ngx-tethys/testing';
-import { ThyContentComponent, ThyContentDirective } from '../content.component';
-import { ThyContentSectionComponent, ThyContentSectionDirective } from '../content-section.component';
-import { ThyContentMainComponent, ThyContentMainDirective } from '../content-main.component';
+import { ThyContent, ThyContentDirective } from '../content.component';
+import { ThyContentSection, ThyContentSectionDirective } from '../content-section.component';
+import { ThyContentMain, ThyContentMainDirective } from '../content-main.component';
 
 @Component({
     selector: 'thy-demo-layout-basic',
@@ -81,7 +81,7 @@ describe(`layout`, () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(ThyDemoLayoutBasicComponent);
             fixture.detectChanges();
-            layoutDebugElement = fixture.debugElement.query(By.directive(ThyLayoutComponent));
+            layoutDebugElement = fixture.debugElement.query(By.directive(ThyLayout));
             layoutElement = layoutDebugElement.nativeElement;
         });
 
@@ -92,7 +92,7 @@ describe(`layout`, () => {
             expect(layoutElement.classList.contains(`thy-layout`)).toBeTruthy();
 
             // header
-            const headerDebugElement = fixture.debugElement.query(By.directive(ThyHeaderComponent));
+            const headerDebugElement = fixture.debugElement.query(By.directive(ThyHeader));
             expect(headerDebugElement).toBeTruthy();
             const headerElement: HTMLElement = headerDebugElement.nativeElement;
             expect(headerElement).toBeTruthy();
@@ -104,21 +104,21 @@ describe(`layout`, () => {
             expect(titleNameElement.innerHTML).toContain('I am header');
 
             // content
-            const contentDebugElement = fixture.debugElement.query(By.directive(ThyContentComponent));
+            const contentDebugElement = fixture.debugElement.query(By.directive(ThyContent));
             expect(contentDebugElement).toBeTruthy();
             const contentElement: HTMLElement = contentDebugElement.nativeElement;
             expect(contentElement).toBeTruthy();
             expect(contentElement.classList.contains(`thy-layout-content`)).toBeTruthy();
 
             // content section
-            const contentSectionDebugElement = fixture.debugElement.query(By.directive(ThyContentSectionComponent));
+            const contentSectionDebugElement = fixture.debugElement.query(By.directive(ThyContentSection));
             expect(contentSectionDebugElement).toBeTruthy();
             const contentSectionElement = contentSectionDebugElement.nativeElement;
             expect(contentSectionElement).toBeTruthy();
             expect(contentSectionElement.classList.contains(`thy-layout-content-section`)).toBeTruthy();
 
             // content main
-            const contentMainDebugElement = fixture.debugElement.query(By.directive(ThyContentMainComponent));
+            const contentMainDebugElement = fixture.debugElement.query(By.directive(ThyContentMain));
             expect(contentMainDebugElement).toBeTruthy();
             const contentMainElement = contentMainDebugElement.nativeElement;
             expect(contentMainElement).toBeTruthy();
@@ -126,7 +126,7 @@ describe(`layout`, () => {
         });
 
         it('should get divided header', () => {
-            const headerDebugElement = fixture.debugElement.query(By.directive(ThyHeaderComponent));
+            const headerDebugElement = fixture.debugElement.query(By.directive(ThyHeader));
             expect(headerDebugElement).toBeTruthy();
             const headerElement: HTMLElement = headerDebugElement.nativeElement;
             expect(headerElement).toBeTruthy();
@@ -138,7 +138,7 @@ describe(`layout`, () => {
         });
 
         it('should get shadow header', () => {
-            const headerDebugElement = fixture.debugElement.query(By.directive(ThyHeaderComponent));
+            const headerDebugElement = fixture.debugElement.query(By.directive(ThyHeader));
             expect(headerDebugElement).toBeTruthy();
             const headerElement: HTMLElement = headerDebugElement.nativeElement;
             expect(headerElement).toBeTruthy();
@@ -150,7 +150,7 @@ describe(`layout`, () => {
         });
 
         it('layout header thyIcon', () => {
-            const headerDebugElement = fixture.debugElement.query(By.directive(ThyHeaderComponent));
+            const headerDebugElement = fixture.debugElement.query(By.directive(ThyHeader));
             expect(headerDebugElement).toBeTruthy();
             expect(headerDebugElement.nativeElement.querySelector('.prefix-icon')).toBeFalsy();
             fixture.debugElement.componentInstance.iconName = 'application-fill';
@@ -159,7 +159,7 @@ describe(`layout`, () => {
         });
 
         it('layout header thySize', () => {
-            const headerDebugElement = fixture.debugElement.query(By.directive(ThyHeaderComponent));
+            const headerDebugElement = fixture.debugElement.query(By.directive(ThyHeader));
             expect(headerDebugElement).toBeTruthy();
             const headerElement: HTMLElement = headerDebugElement.nativeElement;
             expect(headerElement.classList.contains(`thy-layout-header-sm`)).toBeFalsy();
@@ -177,7 +177,7 @@ describe(`layout`, () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(ThyDemoLayoutCustomHeaderComponent);
             fixture.detectChanges();
-            headerDebugElement = fixture.debugElement.query(By.directive(ThyHeaderComponent));
+            headerDebugElement = fixture.debugElement.query(By.directive(ThyHeader));
             headerElement = headerDebugElement.nativeElement;
         });
 

--- a/src/layout/test/sidebar.spec.ts
+++ b/src/layout/test/sidebar.spec.ts
@@ -4,12 +4,12 @@ import { By } from '@angular/platform-browser';
 import { dispatchMouseEvent } from '@tethys/cdk/testing';
 import { ThyResizableDirective, ThyResizeEvent } from 'ngx-tethys/resizable';
 import { bypassSanitizeProvider, createKeyboardEvent, injectDefaultSvgIconSet } from 'ngx-tethys/testing';
-import { ThyLayoutComponent, ThyLayoutDirective } from '../layout.component';
+import { ThyLayout, ThyLayoutDirective } from '../layout.component';
 import { ThyLayoutModule } from '../layout.module';
-import { ThySidebarContentComponent, ThySidebarContentDirective } from '../sidebar-content.component';
-import { ThySidebarFooterComponent, ThySidebarFooterDirective } from '../sidebar-footer.component';
-import { ThySidebarHeaderComponent, ThySidebarHeaderDirective } from '../sidebar-header.component';
-import { ThySidebarComponent, ThySidebarDirection, ThySidebarDirective, ThySidebarTheme } from '../sidebar.component';
+import { ThySidebarContent, ThySidebarContentDirective } from '../sidebar-content.component';
+import { ThySidebarFooter, ThySidebarFooterDirective } from '../sidebar-footer.component';
+import { ThySidebarHeader, ThySidebarHeaderDirective } from '../sidebar-header.component';
+import { ThySidebar, ThySidebarDirection, ThySidebarDirective, ThySidebarTheme } from '../sidebar.component';
 
 const SIDEBAR_ISOLATED_CLASS = 'thy-layout-sidebar-isolated';
 @Component({
@@ -139,7 +139,7 @@ describe(`sidebar`, () => {
         let layoutElement: HTMLElement;
         let sidebarDebugElement: DebugElement;
         let sidebarElement: HTMLElement;
-        let sidebarComponent: ThySidebarComponent;
+        let sidebarComponent: ThySidebar;
         let sidebarHeaderDebugElement: DebugElement;
         let sidebarHeaderElement: HTMLElement;
 
@@ -148,14 +148,14 @@ describe(`sidebar`, () => {
             fixture.detectChanges();
             testInstance = fixture.debugElement.componentInstance;
 
-            layoutDebugElement = fixture.debugElement.query(By.directive(ThyLayoutComponent));
+            layoutDebugElement = fixture.debugElement.query(By.directive(ThyLayout));
             layoutElement = layoutDebugElement.nativeElement;
 
-            sidebarDebugElement = fixture.debugElement.query(By.directive(ThySidebarComponent));
+            sidebarDebugElement = fixture.debugElement.query(By.directive(ThySidebar));
             sidebarElement = sidebarDebugElement.nativeElement;
             sidebarComponent = sidebarDebugElement.componentInstance;
 
-            sidebarHeaderDebugElement = fixture.debugElement.query(By.directive(ThySidebarHeaderComponent));
+            sidebarHeaderDebugElement = fixture.debugElement.query(By.directive(ThySidebarHeader));
             sidebarHeaderElement = sidebarHeaderDebugElement.nativeElement;
         });
 
@@ -198,7 +198,7 @@ describe(`sidebar`, () => {
         });
 
         it(`should get correct class with thy-sidebar-content`, () => {
-            const debugElement = fixture.debugElement.query(By.directive(ThySidebarContentComponent));
+            const debugElement = fixture.debugElement.query(By.directive(ThySidebarContent));
             expect(debugElement).toBeTruthy();
             const element: HTMLElement = debugElement.nativeElement;
             expect(element).toBeTruthy();
@@ -207,7 +207,7 @@ describe(`sidebar`, () => {
         });
 
         it(`should get correct class with thy-sidebar-footer`, () => {
-            const debugElement = fixture.debugElement.query(By.directive(ThySidebarFooterComponent));
+            const debugElement = fixture.debugElement.query(By.directive(ThySidebarFooter));
             expect(debugElement).toBeTruthy();
             const element: HTMLElement = debugElement.nativeElement;
             expect(element).toBeTruthy();
@@ -483,11 +483,11 @@ describe(`sidebar`, () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(ThyDemoLayoutCustomSidebarComponent);
             fixture.detectChanges();
-            layoutDebugElement = fixture.debugElement.query(By.directive(ThyLayoutComponent));
+            layoutDebugElement = fixture.debugElement.query(By.directive(ThyLayout));
             layoutElement = layoutDebugElement.nativeElement;
-            sidebarDebugElement = fixture.debugElement.query(By.directive(ThySidebarComponent));
+            sidebarDebugElement = fixture.debugElement.query(By.directive(ThySidebar));
             sidebarElement = sidebarDebugElement.nativeElement;
-            sidebarHeaderDebugElement = fixture.debugElement.query(By.directive(ThySidebarHeaderComponent));
+            sidebarHeaderDebugElement = fixture.debugElement.query(By.directive(ThySidebarHeader));
             sidebarHeaderElement = sidebarHeaderDebugElement.nativeElement;
         });
 

--- a/src/list/examples/operate/operate.component.ts
+++ b/src/list/examples/operate/operate.component.ts
@@ -1,16 +1,16 @@
 import { Component, OnInit, QueryList, ViewChild, ViewChildren } from '@angular/core';
-import { ThyListOptionComponent } from 'ngx-tethys/shared';
+import { ThyListOption } from 'ngx-tethys/shared';
 import { ThySelectionListChange } from 'ngx-tethys/list';
-import { ThySelectionListComponent } from 'ngx-tethys/list';
+import { ThySelectionList } from 'ngx-tethys/list';
 
 @Component({
     selector: 'app-list-operate-example',
     templateUrl: './operate.component.html'
 })
 export class ThyListOperateExampleComponent implements OnInit {
-    @ViewChild(ThySelectionListComponent, { static: true }) thySelectionListComponent: ThySelectionListComponent;
+    @ViewChild(ThySelectionList, { static: true }) thySelectionListComponent: ThySelectionList;
 
-    @ViewChildren(ThyListOptionComponent) optionQueryList: QueryList<ThyListOptionComponent>;
+    @ViewChildren(ThyListOption) optionQueryList: QueryList<ThyListOption>;
 
     public items = [
         {

--- a/src/list/list-item-meta.component.ts
+++ b/src/list/list-item-meta.component.ts
@@ -1,5 +1,5 @@
 import { Component, Input, HostBinding, ChangeDetectionStrategy, TemplateRef, ContentChild } from '@angular/core';
-import { ThyAvatarComponent } from 'ngx-tethys/avatar';
+import { ThyAvatar } from 'ngx-tethys/avatar';
 import { NgIf } from '@angular/common';
 
 /**
@@ -11,9 +11,9 @@ import { NgIf } from '@angular/common';
     templateUrl: './list-item-meta.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgIf, ThyAvatarComponent]
+    imports: [NgIf, ThyAvatar]
 })
-export class ThyListItemMetaComponent {
+export class ThyListItemMeta {
     /**
      * 列表项的左侧图片
      */

--- a/src/list/list-item.component.ts
+++ b/src/list/list-item.component.ts
@@ -9,7 +9,7 @@ import { Component, HostBinding } from '@angular/core';
     template: '<ng-content></ng-content>',
     standalone: true
 })
-export class ThyListItemComponent {
+export class ThyListItem {
     @HostBinding(`class.thy-list-item`) _isListItem = true;
 
     constructor() {}

--- a/src/list/list.component.ts
+++ b/src/list/list.component.ts
@@ -11,7 +11,7 @@ import { InputBoolean } from 'ngx-tethys/core';
     template: '<ng-content></ng-content>',
     standalone: true
 })
-export class ThyListComponent {
+export class ThyList {
     /**
      * 控制分割线的显示与隐藏
      * @default false

--- a/src/list/list.module.ts
+++ b/src/list/list.module.ts
@@ -1,22 +1,14 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyListComponent } from './list.component';
-import { ThyListItemComponent } from './list-item.component';
-import { ThySelectionListComponent } from './selection/selection-list';
+import { ThyList } from './list.component';
+import { ThyListItem } from './list-item.component';
+import { ThySelectionList } from './selection/selection-list';
 import { ThyOptionModule } from 'ngx-tethys/shared';
-import { ThyListItemMetaComponent } from './list-item-meta.component';
+import { ThyListItemMeta } from './list-item-meta.component';
 import { ThyAvatarModule } from 'ngx-tethys/avatar';
 
 @NgModule({
-    imports: [
-        CommonModule,
-        ThyOptionModule,
-        ThyAvatarModule,
-        ThyListComponent,
-        ThyListItemComponent,
-        ThySelectionListComponent,
-        ThyListItemMetaComponent
-    ],
-    exports: [ThyListComponent, ThyListItemComponent, ThySelectionListComponent, ThyListItemMetaComponent, ThyOptionModule]
+    imports: [CommonModule, ThyOptionModule, ThyAvatarModule, ThyList, ThyListItem, ThySelectionList, ThyListItemMeta],
+    exports: [ThyList, ThyListItem, ThySelectionList, ThyListItemMeta, ThyOptionModule]
 })
 export class ThyListModule {}

--- a/src/list/selection/selection-list.spec.ts
+++ b/src/list/selection/selection-list.spec.ts
@@ -3,8 +3,8 @@ import { ThySelectionListChange } from './selection.interface';
 import { async, ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { ThyListModule } from '../list.module';
 import { By } from '@angular/platform-browser';
-import { ThyListOptionComponent, ThyListLayout } from '../../shared/option';
-import { ThySelectionListComponent } from './selection-list';
+import { ThyListOption, ThyListLayout } from '../../shared/option';
+import { ThySelectionList } from './selection-list';
 import { FormsModule } from '@angular/forms';
 import { dispatchKeyboardEvent, dispatchMouseEvent } from 'ngx-tethys/testing';
 import { DOWN_ARROW, UP_ARROW, SPACE } from 'ngx-tethys/util';
@@ -37,8 +37,8 @@ describe('ThySelectionList without forms', () => {
         beforeEach(async(() => {
             fixture = TestBed.createComponent(SelectionListWithListOptionsComponent);
             fixture.detectChanges();
-            listOptions = fixture.debugElement.queryAll(By.directive(ThyListOptionComponent));
-            selectionList = fixture.debugElement.query(By.directive(ThySelectionListComponent));
+            listOptions = fixture.debugElement.queryAll(By.directive(ThyListOption));
+            selectionList = fixture.debugElement.query(By.directive(ThySelectionList));
         }));
 
         it('should be able to set a value on a list option', () => {
@@ -72,7 +72,7 @@ describe('ThySelectionList without forms', () => {
         it('should not has class "thy-grid-list" when thyLayout is null', () => {
             const defaultFixture = TestBed.createComponent(SelectionListWithListOptionsDefaultComponent);
             fixture.detectChanges();
-            const defaultListOptions = fixture.debugElement.queryAll(By.directive(ThyListOptionComponent));
+            const defaultListOptions = fixture.debugElement.queryAll(By.directive(ThyListOption));
 
             expect(defaultFixture.nativeElement.classList).not.toContain('thy-grid-list');
             expect(defaultListOptions[0].nativeElement.classList).toContain('thy-list-option');
@@ -91,7 +91,7 @@ describe('ThySelectionList without forms', () => {
             const selectionFixture = TestBed.createComponent(SelectionListWithListOptionsComponent);
             selectionFixture.debugElement.componentInstance.autoActiveFirstItem = true;
             selectionFixture.detectChanges();
-            const selectionListOptions = selectionFixture.debugElement.queryAll(By.directive(ThyListOptionComponent));
+            const selectionListOptions = selectionFixture.debugElement.queryAll(By.directive(ThyListOption));
             expect(selectionListOptions[0].nativeElement.classList).toContain('hover');
         });
 
@@ -106,7 +106,7 @@ describe('ThySelectionList without forms', () => {
             const defaultFixture = TestBed.createComponent(SelectionListWithListOptionsDefaultComponent);
             defaultFixture.componentInstance.autoActiveFirstItem = true;
             defaultFixture.detectChanges();
-            const defaultListOptions = defaultFixture.debugElement.queryAll(By.directive(ThyListOptionComponent));
+            const defaultListOptions = defaultFixture.debugElement.queryAll(By.directive(ThyListOption));
             expect(defaultListOptions[0].nativeElement.classList).toContain('hover');
         });
 
@@ -114,7 +114,7 @@ describe('ThySelectionList without forms', () => {
             const defaultFixture = TestBed.createComponent(SelectionListWithListOptionsDefaultComponent);
             defaultFixture.componentInstance.autoActiveFirstItem = false;
             defaultFixture.detectChanges();
-            const defaultListOptions = defaultFixture.debugElement.queryAll(By.directive(ThyListOptionComponent));
+            const defaultListOptions = defaultFixture.debugElement.queryAll(By.directive(ThyListOption));
             expect(defaultListOptions[0].nativeElement.classList).not.toContain('hover');
         });
 
@@ -215,7 +215,7 @@ describe('ThySelectionList without forms', () => {
             const selectionFixture = TestBed.createComponent(SelectionListWithListOptionsComponent);
             selectionFixture.debugElement.componentInstance.autoActiveFirstItem = true;
             selectionFixture.detectChanges();
-            const selectionListOptions = selectionFixture.debugElement.queryAll(By.directive(ThyListOptionComponent));
+            const selectionListOptions = selectionFixture.debugElement.queryAll(By.directive(ThyListOption));
             expect(selectionListOptions[0].nativeElement.classList).toContain('hover');
             selectionFixture.componentInstance.thySelectionListComponent.clearActiveItem();
             selectionFixture.detectChanges();
@@ -272,9 +272,9 @@ describe('ThySelectionList without forms', () => {
     `
 })
 class SelectionListWithListOptionsComponent {
-    @ViewChild(ThySelectionListComponent, { static: true }) thySelectionListComponent: ThySelectionListComponent;
+    @ViewChild(ThySelectionList, { static: true }) thySelectionListComponent: ThySelectionList;
 
-    @ViewChildren(ThyListOptionComponent) optionQueryList: QueryList<ThyListOptionComponent>;
+    @ViewChildren(ThyListOption) optionQueryList: QueryList<ThyListOption>;
 
     public items = [
         {
@@ -375,7 +375,7 @@ class SelectionListWithListOptionsDefaultComponent {
     `
 })
 class SelectionListWithListOptionsByObjectTypeValueComponent {
-    @ViewChild(ThySelectionListComponent, { static: true }) thySelectionListComponent: ThySelectionListComponent;
+    @ViewChild(ThySelectionList, { static: true }) thySelectionListComponent: ThySelectionList;
 
     selectedValue: { displayName: string; id: string };
 

--- a/src/list/selection/selection-list.ts
+++ b/src/list/selection/selection-list.ts
@@ -1,5 +1,5 @@
 import { ScrollToService } from 'ngx-tethys/core';
-import { IThyListOptionParentComponent, THY_LIST_OPTION_PARENT_COMPONENT, ThyListLayout, ThyListOptionComponent } from 'ngx-tethys/shared';
+import { IThyListOptionParentComponent, THY_LIST_OPTION_PARENT_COMPONENT, ThyListLayout, ThyListOption } from 'ngx-tethys/shared';
 import { coerceBooleanProperty, dom, helpers, keycodes } from 'ngx-tethys/util';
 import { Subscription } from 'rxjs';
 import { startWith } from 'rxjs/operators';
@@ -44,19 +44,19 @@ const listSizesMap = {
     providers: [
         {
             provide: THY_LIST_OPTION_PARENT_COMPONENT,
-            useExisting: ThySelectionListComponent
+            useExisting: ThySelectionList
         },
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThySelectionListComponent),
+            useExisting: forwardRef(() => ThySelectionList),
             multi: true
         }
     ],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true
 })
-export class ThySelectionListComponent implements OnInit, OnDestroy, AfterContentInit, IThyListOptionParentComponent, ControlValueAccessor {
-    private _keyManager: ActiveDescendantKeyManager<ThyListOptionComponent>;
+export class ThySelectionList implements OnInit, OnDestroy, AfterContentInit, IThyListOptionParentComponent, ControlValueAccessor {
+    private _keyManager: ActiveDescendantKeyManager<ThyListOption>;
 
     private _selectionChangesUnsubscribe$ = Subscription.EMPTY;
 
@@ -84,7 +84,7 @@ export class ThySelectionListComponent implements OnInit, OnDestroy, AfterConten
     /**
      * @internal
      */
-    @ContentChildren(ThyListOptionComponent, { descendants: true }) options: QueryList<ThyListOptionComponent>;
+    @ContentChildren(ThyListOption, { descendants: true }) options: QueryList<ThyListOption>;
 
     /**
      * 改变 grid item 的选择模式，使其支持多选
@@ -174,7 +174,7 @@ export class ThySelectionListComponent implements OnInit, OnDestroy, AfterConten
 
     private _onChange: (value: any) => void = (_: any) => {};
 
-    private _emitChangeEvent(option: ThyListOptionComponent, event: Event) {
+    private _emitChangeEvent(option: ThyListOption, event: Event) {
         this.thySelectionChange.emit({
             source: this,
             value: option.thyValue,
@@ -219,7 +219,7 @@ export class ThySelectionListComponent implements OnInit, OnDestroy, AfterConten
     }
 
     private _initializeFocusKeyManager() {
-        this._keyManager = new ActiveDescendantKeyManager<ThyListOptionComponent>(this.options)
+        this._keyManager = new ActiveDescendantKeyManager<ThyListOption>(this.options)
             .withWrap()
             // .withTypeAhead()
             // Allow disabled items to be focusable. For accessibility reasons, there must be a way for
@@ -246,7 +246,7 @@ export class ThySelectionListComponent implements OnInit, OnDestroy, AfterConten
         }
     }
 
-    private _getOptionSelectionValue(option: ThyListOptionComponent) {
+    private _getOptionSelectionValue(option: ThyListOption) {
         if (option.thyValue) {
             return this.thyUniqueKey ? option.thyValue[this.thyUniqueKey] : option.thyValue;
         } else {
@@ -386,7 +386,7 @@ export class ThySelectionListComponent implements OnInit, OnDestroy, AfterConten
         }
     }
 
-    toggleOption(option: ThyListOptionComponent, event?: Event) {
+    toggleOption(option: ThyListOption, event?: Event) {
         if (option && !option.disabled) {
             this.selectionModel.toggle(this._getOptionSelectionValue(option));
             // Emit a change event because the focused option changed its state through user
@@ -396,16 +396,16 @@ export class ThySelectionListComponent implements OnInit, OnDestroy, AfterConten
         }
     }
 
-    setActiveOption(option: ThyListOptionComponent) {
+    setActiveOption(option: ThyListOption) {
         this._keyManager.updateActiveItem(option); // .updateActiveItemIndex(this._getOptionIndex(option));
     }
 
-    scrollIntoView(option: ThyListOptionComponent) {
+    scrollIntoView(option: ThyListOption) {
         const scrollContainerElement = dom.getHTMLElementBySelector(this.thyScrollContainer, this.elementRef);
         ScrollToService.scrollToElement(option.element.nativeElement, scrollContainerElement);
     }
 
-    isSelected(option: ThyListOptionComponent) {
+    isSelected(option: ThyListOption) {
         return this.selectionModel.isSelected(this._getOptionSelectionValue(option));
     }
 

--- a/src/list/selection/selection.interface.ts
+++ b/src/list/selection/selection.interface.ts
@@ -1,9 +1,9 @@
-import { ThySelectionListComponent } from './selection-list';
-import { ThyListOptionComponent } from 'ngx-tethys/shared';
+import { ThySelectionList } from './selection-list';
+import { ThyListOption } from 'ngx-tethys/shared';
 
 export interface ThySelectionListChange<TValue = any> {
-    source: ThySelectionListComponent;
-    option: ThyListOptionComponent;
+    source: ThySelectionList;
+    option: ThyListOption;
     value: TValue;
     event: Event;
     selected: boolean;

--- a/src/list/test/list.spec.ts
+++ b/src/list/test/list.spec.ts
@@ -2,7 +2,7 @@ import { Component, DebugElement, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ThyListModule } from '../list.module';
-import { ThyListComponent } from '../list.component';
+import { ThyList } from '../list.component';
 
 describe('list', () => {
     let fixture: ComponentFixture<TestListComponent>;
@@ -14,7 +14,7 @@ describe('list', () => {
             declarations: [TestListComponent]
         }).compileComponents();
         fixture = TestBed.createComponent(TestListComponent);
-        listDebugElement = fixture.debugElement.query(By.directive(ThyListComponent));
+        listDebugElement = fixture.debugElement.query(By.directive(ThyList));
         listElement = listDebugElement.nativeElement;
         fixture.detectChanges();
     });

--- a/src/loading/loading.component.ts
+++ b/src/loading/loading.component.ts
@@ -15,7 +15,7 @@ import { InputBoolean } from 'ngx-tethys/core';
     standalone: true,
     imports: [NgIf]
 })
-export class ThyLoadingComponent {
+export class ThyLoading {
     public isDone: boolean;
 
     public tip: string;

--- a/src/loading/loading.module.ts
+++ b/src/loading/loading.module.ts
@@ -1,9 +1,9 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyLoadingComponent } from './loading.component';
+import { ThyLoading } from './loading.component';
 
 @NgModule({
-    imports: [CommonModule, ThyLoadingComponent],
-    exports: [ThyLoadingComponent]
+    imports: [CommonModule, ThyLoading],
+    exports: [ThyLoading]
 })
 export class ThyLoadingModule {}

--- a/src/loading/test/loading.spec.ts
+++ b/src/loading/test/loading.spec.ts
@@ -1,7 +1,7 @@
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ThyLoadingComponent } from '..';
+import { ThyLoading } from '..';
 import { ThyLoadingModule } from '../loading.module';
 
 @Component({
@@ -33,7 +33,7 @@ describe('test loading', () => {
 
         fixture = TestBed.createComponent(TestLoadingComponent);
         testComponent = fixture.debugElement.componentInstance;
-        loadingComponent = fixture.debugElement.query(By.directive(ThyLoadingComponent));
+        loadingComponent = fixture.debugElement.query(By.directive(ThyLoading));
         loadingElement = loadingComponent.nativeElement;
     });
 

--- a/src/mention/mention.directive.ts
+++ b/src/mention/mention.directive.ts
@@ -8,7 +8,7 @@ import { NgControl } from '@angular/forms';
 import { createMentionAdapter, MatchedMention, MentionAdapter, MentionInputorElement } from './adapter';
 import { CaretPositioner } from './caret-positioner';
 import { Mention, MentionDefaultDataItem, MentionSuggestionSelectEvent } from './interfaces';
-import { ThyMentionSuggestionsComponent } from './suggestions/suggestions.component';
+import { ThyMentionSuggestions } from './suggestions/suggestions.component';
 import { isInputOrTextarea } from 'ngx-tethys/util';
 
 const SUGGESTION_BACKDROP_CLASS = 'thy-mention-suggestions-backdrop';
@@ -39,7 +39,7 @@ const DEFAULT_MENTION_CONFIG: Partial<Mention> = {
 export class ThyMentionDirective implements OnInit, OnDestroy {
     private adapter: MentionAdapter = null;
 
-    public openedSuggestionsRef: ThyPopoverRef<ThyMentionSuggestionsComponent>;
+    public openedSuggestionsRef: ThyPopoverRef<ThyMentionSuggestions>;
 
     private _mentions: Mention<any>[];
     get mentions() {
@@ -78,7 +78,7 @@ export class ThyMentionDirective implements OnInit, OnDestroy {
 
     private destroy$ = new Subject<void>();
 
-    private openedSuggestionsRef$ = new Subject<ThyPopoverRef<ThyMentionSuggestionsComponent> | null>();
+    private openedSuggestionsRef$ = new Subject<ThyPopoverRef<ThyMentionSuggestions> | null>();
 
     constructor(
         private elementRef: ElementRef<HTMLElement>,
@@ -147,7 +147,7 @@ export class ThyMentionDirective implements OnInit, OnDestroy {
             const position = CaretPositioner.getCaretPosition(inputElement, matched.query.start);
             const fontSize = parseInt(getComputedStyle(this.elementRef.nativeElement).fontSize, 10);
             this.openedSuggestionsRef = this.thyPopover.open(
-                ThyMentionSuggestionsComponent,
+                ThyMentionSuggestions,
                 Object.assign({}, POPOVER_DEFAULT_CONFIG, this.popoverConfig, {
                     origin: this.elementRef,
                     originPosition: {

--- a/src/mention/mention.module.ts
+++ b/src/mention/mention.module.ts
@@ -7,18 +7,10 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { ThyMentionDirective } from './mention.directive';
-import { ThyMentionSuggestionsComponent } from './suggestions/suggestions.component';
+import { ThyMentionSuggestions } from './suggestions/suggestions.component';
 
 @NgModule({
-    imports: [
-        CommonModule,
-        FormsModule,
-        ThyPopoverModule,
-        ThyListModule,
-        ThyLoadingModule,
-        ThyMentionDirective,
-        ThyMentionSuggestionsComponent
-    ],
+    imports: [CommonModule, FormsModule, ThyPopoverModule, ThyListModule, ThyLoadingModule, ThyMentionDirective, ThyMentionSuggestions],
     exports: [ThyMentionDirective],
     providers: []
 })

--- a/src/mention/suggestions/suggestions.component.ts
+++ b/src/mention/suggestions/suggestions.component.ts
@@ -1,4 +1,4 @@
-import { ThySelectionListChange, ThySelectionListComponent } from 'ngx-tethys/list';
+import { ThySelectionListChange, ThySelectionList } from 'ngx-tethys/list';
 import { ThyPopoverRef } from 'ngx-tethys/popover';
 import { Observable, of, Subject } from 'rxjs';
 import { catchError, debounceTime, switchMap, take } from 'rxjs/operators';
@@ -7,8 +7,8 @@ import { Component, ElementRef, HostBinding, NgZone, OnDestroy, OnInit } from '@
 
 import { SeekQueryResult } from '../adapter/adapter';
 import { Mention, MentionDefaultDataItem, MentionSuggestionSelectEvent } from '../interfaces';
-import { ThyListOptionComponent } from 'ngx-tethys/shared';
-import { ThyLoadingComponent } from 'ngx-tethys/loading';
+import { ThyListOption } from 'ngx-tethys/shared';
+import { ThyLoading } from 'ngx-tethys/loading';
 import { NgIf, NgTemplateOutlet, NgFor, SlicePipe } from '@angular/common';
 
 /**
@@ -18,9 +18,9 @@ import { NgIf, NgTemplateOutlet, NgFor, SlicePipe } from '@angular/common';
     selector: 'thy-mention-suggestions',
     templateUrl: './suggestions.component.html',
     standalone: true,
-    imports: [NgIf, NgTemplateOutlet, ThyLoadingComponent, ThySelectionListComponent, NgFor, ThyListOptionComponent, SlicePipe]
+    imports: [NgIf, NgTemplateOutlet, ThyLoading, ThySelectionList, NgFor, ThyListOption, SlicePipe]
 })
-export class ThyMentionSuggestionsComponent<TItem = MentionDefaultDataItem> implements OnInit, OnDestroy {
+export class ThyMentionSuggestions<TItem = MentionDefaultDataItem> implements OnInit, OnDestroy {
     data: TItem[];
 
     mention: Mention<TItem>;

--- a/src/menu/divider/menu-divider.component.ts
+++ b/src/menu/divider/menu-divider.component.ts
@@ -8,7 +8,7 @@ import { Component, OnInit, HostBinding } from '@angular/core';
     templateUrl: './menu-divider.component.html',
     standalone: true
 })
-export class ThyMenuDividerComponent implements OnInit {
+export class ThyMenuDivider implements OnInit {
     @HostBinding('class.thy-menu-divider') isThyMenuDivider = true;
 
     constructor() {}

--- a/src/menu/group/menu-group.component.ts
+++ b/src/menu/group/menu-group.component.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 import { InputBoolean } from 'ngx-tethys/core';
 import { ThyPopover } from 'ngx-tethys/popover';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgClass, NgIf, NgTemplateOutlet } from '@angular/common';
 
 /**
@@ -52,9 +52,9 @@ import { NgClass, NgIf, NgTemplateOutlet } from '@angular/common';
     ],
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgClass, NgIf, NgTemplateOutlet, ThyIconComponent]
+    imports: [NgClass, NgIf, NgTemplateOutlet, ThyIcon]
 })
-export class ThyMenuGroupComponent implements OnInit {
+export class ThyMenuGroup implements OnInit {
     public _actionMenu: ComponentType<any> | TemplateRef<any>;
 
     public rightIconClass = 'more';

--- a/src/menu/item/action/menu-item-action.component.ts
+++ b/src/menu/item/action/menu-item-action.component.ts
@@ -16,7 +16,7 @@ import { ThyPopover } from 'ngx-tethys/popover';
     },
     standalone: true
 })
-export class ThyMenuItemActionComponent implements OnDestroy {
+export class ThyMenuItemAction implements OnDestroy {
     _boundEvent = false;
 
     _actionMenu: ComponentType<any> | TemplateRef<any>;

--- a/src/menu/item/icon/menu-item-icon.component.ts
+++ b/src/menu/item/icon/menu-item-icon.component.ts
@@ -15,7 +15,7 @@ import { useHostRenderer } from '@tethys/cdk/dom';
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true
 })
-export class ThyMenuItemIconComponent implements OnInit {
+export class ThyMenuItemIcon implements OnInit {
     /**
      * 设置图标颜色
      */

--- a/src/menu/item/menu-item.component.ts
+++ b/src/menu/item/menu-item.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, AfterViewInit, ChangeDetectionStrategy, Input, Renderer2, ElementRef, ViewChild } from '@angular/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf } from '@angular/common';
 
 /**
@@ -15,9 +15,9 @@ import { NgIf } from '@angular/common';
         class: 'thy-menu-item'
     },
     standalone: true,
-    imports: [NgIf, ThyIconComponent]
+    imports: [NgIf, ThyIcon]
 })
-export class ThyMenuItemComponent implements OnInit, AfterViewInit {
+export class ThyMenuItem implements OnInit, AfterViewInit {
     @ViewChild('content', { read: ElementRef }) content: ElementRef<HTMLElement>;
     /**
      * 菜单项的图标

--- a/src/menu/item/name/menu-item-name.component.ts
+++ b/src/menu/item/name/menu-item-name.component.ts
@@ -14,7 +14,7 @@ import { InputBoolean } from 'ngx-tethys/core';
     },
     standalone: true
 })
-export class ThyMenuItemNameComponent implements OnInit {
+export class ThyMenuItemName implements OnInit {
     /**
      * 是否 ellipsis
      */

--- a/src/menu/menu.component.ts
+++ b/src/menu/menu.component.ts
@@ -19,7 +19,7 @@ export type ThyMenuTheme = 'compact' | 'loose' | 'dark';
     },
     standalone: true
 })
-export class ThyMenuComponent implements OnInit {
+export class ThyMenu implements OnInit {
     theme: ThyMenuTheme = 'compact';
 
     /**

--- a/src/menu/menu.module.ts
+++ b/src/menu/menu.module.ts
@@ -2,35 +2,27 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyPopoverModule } from 'ngx-tethys/popover';
-import { ThyMenuDividerComponent } from './divider/menu-divider.component';
-import { ThyMenuGroupComponent } from './group/menu-group.component';
-import { ThyMenuItemActionComponent } from './item/action/menu-item-action.component';
-import { ThyMenuItemIconComponent } from './item/icon/menu-item-icon.component';
-import { ThyMenuItemComponent } from './item/menu-item.component';
-import { ThyMenuItemNameComponent } from './item/name/menu-item-name.component';
-import { ThyMenuComponent } from './menu.component';
+import { ThyMenuDivider } from './divider/menu-divider.component';
+import { ThyMenuGroup } from './group/menu-group.component';
+import { ThyMenuItemAction } from './item/action/menu-item-action.component';
+import { ThyMenuItemIcon } from './item/icon/menu-item-icon.component';
+import { ThyMenuItem } from './item/menu-item.component';
+import { ThyMenuItemName } from './item/name/menu-item-name.component';
+import { ThyMenu } from './menu.component';
 
 @NgModule({
     imports: [
         CommonModule,
         ThyIconModule,
         ThyPopoverModule,
-        ThyMenuComponent,
-        ThyMenuGroupComponent,
-        ThyMenuItemComponent,
-        ThyMenuItemNameComponent,
-        ThyMenuItemIconComponent,
-        ThyMenuItemActionComponent,
-        ThyMenuDividerComponent
+        ThyMenu,
+        ThyMenuGroup,
+        ThyMenuItem,
+        ThyMenuItemName,
+        ThyMenuItemIcon,
+        ThyMenuItemAction,
+        ThyMenuDivider
     ],
-    exports: [
-        ThyMenuComponent,
-        ThyMenuGroupComponent,
-        ThyMenuItemComponent,
-        ThyMenuItemNameComponent,
-        ThyMenuItemIconComponent,
-        ThyMenuItemActionComponent,
-        ThyMenuDividerComponent
-    ]
+    exports: [ThyMenu, ThyMenuGroup, ThyMenuItem, ThyMenuItemName, ThyMenuItemIcon, ThyMenuItemAction, ThyMenuDivider]
 })
 export class ThyMenuModule {}

--- a/src/menu/test/menu.spec.ts
+++ b/src/menu/test/menu.spec.ts
@@ -7,13 +7,13 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ThyIconModule } from '../../icon/icon.module';
 import { ThyPopover, ThyPopoverModule } from '../../popover';
-import { ThyMenuDividerComponent } from '../divider/menu-divider.component';
-import { ThyMenuGroupComponent } from '../group/menu-group.component';
-import { ThyMenuItemActionComponent } from '../item/action/menu-item-action.component';
-import { ThyMenuItemIconComponent } from '../item/icon/menu-item-icon.component';
-import { ThyMenuItemComponent } from '../item/menu-item.component';
-import { ThyMenuItemNameComponent } from '../item/name/menu-item-name.component';
-import { ThyMenuComponent, ThyMenuTheme } from '../menu.component';
+import { ThyMenuDivider } from '../divider/menu-divider.component';
+import { ThyMenuGroup } from '../group/menu-group.component';
+import { ThyMenuItemAction } from '../item/action/menu-item-action.component';
+import { ThyMenuItemIcon } from '../item/icon/menu-item-icon.component';
+import { ThyMenuItem } from '../item/menu-item.component';
+import { ThyMenuItemName } from '../item/name/menu-item-name.component';
+import { ThyMenu, ThyMenuTheme } from '../menu.component';
 import { ThyMenuModule } from '../menu.module';
 import { ThyDividerModule } from '../../divider';
 
@@ -63,12 +63,12 @@ import { ThyDividerModule } from '../../divider';
     `
 })
 class ThyDemoMenuComponent {
-    @ViewChild(ThyMenuDividerComponent, { static: true }) divider: ThyMenuDividerComponent;
-    @ViewChild(ThyMenuGroupComponent, { static: true }) group: ThyMenuGroupComponent;
-    @ViewChild(ThyMenuItemComponent, { static: true }) item: ThyMenuItemComponent;
-    @ViewChild(ThyMenuItemIconComponent, { static: true }) icon: ThyMenuItemIconComponent;
-    @ViewChild(ThyMenuItemActionComponent, { static: true }) action: ThyMenuItemActionComponent;
-    @ViewChild(ThyMenuItemNameComponent, { static: true }) name: ThyMenuItemNameComponent;
+    @ViewChild(ThyMenuDivider, { static: true }) divider: ThyMenuDivider;
+    @ViewChild(ThyMenuGroup, { static: true }) group: ThyMenuGroup;
+    @ViewChild(ThyMenuItem, { static: true }) item: ThyMenuItem;
+    @ViewChild(ThyMenuItemIcon, { static: true }) icon: ThyMenuItemIcon;
+    @ViewChild(ThyMenuItemAction, { static: true }) action: ThyMenuItemAction;
+    @ViewChild(ThyMenuItemName, { static: true }) name: ThyMenuItemName;
 
     theme = 'default';
     collapsible = true;
@@ -129,7 +129,7 @@ describe('ThyMenu', () => {
             fixture = TestBed.createComponent(ThyMenuTestBasicComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            menuDebugElement = fixture.debugElement.query(By.directive(ThyMenuComponent));
+            menuDebugElement = fixture.debugElement.query(By.directive(ThyMenu));
             menuElement = menuDebugElement.nativeElement;
         });
 
@@ -142,21 +142,21 @@ describe('ThyMenu', () => {
         it('should set theme loose', () => {
             fixture.debugElement.componentInstance.theme = 'loose';
             fixture.detectChanges();
-            const menu = fixture.debugElement.query(By.directive(ThyMenuComponent));
+            const menu = fixture.debugElement.query(By.directive(ThyMenu));
             expect(menu.nativeElement.classList.contains('thy-menu-theme-loose')).toBeTruthy();
         });
 
         it('should set theme dark', () => {
             fixture.debugElement.componentInstance.theme = 'dark';
             fixture.detectChanges();
-            const menu = fixture.debugElement.query(By.directive(ThyMenuComponent));
+            const menu = fixture.debugElement.query(By.directive(ThyMenu));
             expect(menu.nativeElement.classList.contains('thy-menu-theme-dark')).toBeTruthy();
         });
 
         it('should set collapsed success', () => {
             fixture.debugElement.componentInstance.collapsed = true;
             fixture.detectChanges();
-            const menu = fixture.debugElement.query(By.directive(ThyMenuComponent));
+            const menu = fixture.debugElement.query(By.directive(ThyMenu));
             expect(menu.nativeElement.classList.contains('thy-menu-collapsed')).toBeTruthy();
         });
 
@@ -200,7 +200,7 @@ describe('ThyMenu', () => {
         let group: DebugElement;
 
         beforeEach(() => {
-            group = fixture.debugElement.query(By.directive(ThyMenuGroupComponent));
+            group = fixture.debugElement.query(By.directive(ThyMenuGroup));
         });
 
         it('should create thy-menu-group', () => {
@@ -217,7 +217,7 @@ describe('ThyMenu', () => {
             fixture.debugElement.componentInstance.collapsible = false;
             fixture.detectChanges();
             expect(fixture.debugElement.query(By.css('.thy-menu-group-arrow'))).toBeFalsy();
-            const group = fixture.debugElement.query(By.directive(ThyMenuGroupComponent));
+            const group = fixture.debugElement.query(By.directive(ThyMenuGroup));
             const groupHeader = group.nativeElement.querySelector('.thy-menu-group-header');
             groupHeader.click();
             fixture.detectChanges();
@@ -226,7 +226,7 @@ describe('ThyMenu', () => {
 
         it('should toggle worked', () => {
             fixture.detectChanges();
-            const group = fixture.debugElement.query(By.directive(ThyMenuGroupComponent));
+            const group = fixture.debugElement.query(By.directive(ThyMenuGroup));
             const groupHeader = group.nativeElement.querySelector('.thy-menu-group-header');
             const spy = spyOn(fixture.componentInstance, 'toggle');
             groupHeader.click();
@@ -238,7 +238,7 @@ describe('ThyMenu', () => {
         it('should headerContent worked', () => {
             fixture.debugElement.componentInstance.theme = 'loose';
             fixture.detectChanges();
-            const group = fixture.debugElement.query(By.directive(ThyMenuGroupComponent));
+            const group = fixture.debugElement.query(By.directive(ThyMenuGroup));
             expect(group.nativeElement.querySelectorAll('.custom-title')).toBeTruthy();
         });
     });
@@ -247,7 +247,7 @@ describe('ThyMenu', () => {
         let item: DebugElement;
 
         beforeEach(() => {
-            item = fixture.debugElement.query(By.directive(ThyMenuItemComponent));
+            item = fixture.debugElement.query(By.directive(ThyMenuItem));
         });
 
         it('should create thy-menu-item', () => {
@@ -269,7 +269,7 @@ describe('ThyMenu', () => {
         let name: DebugElement;
 
         beforeEach(() => {
-            name = fixture.debugElement.query(By.directive(ThyMenuItemNameComponent));
+            name = fixture.debugElement.query(By.directive(ThyMenuItemName));
         });
 
         it('should create thy-menu-item-name', () => {
@@ -293,18 +293,18 @@ describe('ThyMenu', () => {
 
     describe('thy-menu-item-icon', () => {
         it('should create thy-menu-item-icon', () => {
-            const icon = fixture.debugElement.query(By.directive(ThyMenuItemIconComponent));
+            const icon = fixture.debugElement.query(By.directive(ThyMenuItemIcon));
             expect(icon.componentInstance).toBeTruthy();
             expect(icon.componentInstance === component.icon).toBeTruthy();
         });
 
         it('should have class thy-menu-item-icon', () => {
-            const icon = fixture.debugElement.query(By.directive(ThyMenuItemIconComponent));
+            const icon = fixture.debugElement.query(By.directive(ThyMenuItemIcon));
             expect(icon.nativeElement.classList.contains('thy-menu-item-icon')).toBeTruthy();
         });
 
         it('should not have color when [thyColor] is empty', () => {
-            const icon = fixture.debugElement.query(By.directive(ThyMenuItemIconComponent));
+            const icon = fixture.debugElement.query(By.directive(ThyMenuItemIcon));
             expect(icon.nativeElement.style.color === '').toBeTruthy();
         });
 
@@ -317,7 +317,7 @@ describe('ThyMenu', () => {
     describe('thy-menu-item-action', () => {
         let action: DebugElement;
         beforeEach(() => {
-            action = fixture.debugElement.query(By.directive(ThyMenuItemActionComponent));
+            action = fixture.debugElement.query(By.directive(ThyMenuItemAction));
         });
 
         it('should create thy-menu-item-action', () => {

--- a/src/message/message-container.component.ts
+++ b/src/message/message-container.component.ts
@@ -2,7 +2,7 @@ import { Component, ElementRef, HostBinding, Inject } from '@angular/core';
 import { ThyAbstractMessageContainerComponent } from './abstract';
 import { ThyMessageQueue } from './message-queue.service';
 import { ThyGlobalMessageConfig, THY_MESSAGE_DEFAULT_CONFIG, THY_MESSAGE_DEFAULT_CONFIG_VALUE } from './message.config';
-import { ThyMessageComponent } from './message.component';
+import { ThyMessage } from './message.component';
 import { NgFor, AsyncPipe } from '@angular/common';
 
 /**
@@ -12,9 +12,9 @@ import { NgFor, AsyncPipe } from '@angular/common';
     selector: 'thy-message-container',
     template: ` <thy-message *ngFor="let message of messageQueue.queues$ | async" [thyConfig]="message.config"></thy-message> `,
     standalone: true,
-    imports: [NgFor, ThyMessageComponent, AsyncPipe]
+    imports: [NgFor, ThyMessage, AsyncPipe]
 })
-export class ThyMessageContainerComponent extends ThyAbstractMessageContainerComponent {
+export class ThyMessageContainer extends ThyAbstractMessageContainerComponent {
     @HostBinding('class') className = 'thy-message-container';
 
     constructor(

--- a/src/message/message.component.ts
+++ b/src/message/message.component.ts
@@ -4,7 +4,7 @@ import { ThyMessageConfig } from './message.config';
 import { ThyMessageQueue } from './message-queue.service';
 import { ANIMATION_IN_DURATION, ANIMATION_OUT_DURATION, HIDE_STYLE, ThyAbstractMessageComponent } from './abstract';
 import { ThyStringOrTemplateOutletDirective } from 'ngx-tethys/shared';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf } from '@angular/common';
 import { coerceArray } from 'ngx-tethys/util';
 import { useHostRenderer } from '@tethys/cdk/dom';
@@ -30,9 +30,9 @@ import { useHostRenderer } from '@tethys/cdk/dom';
         ])
     ],
     standalone: true,
-    imports: [NgIf, ThyIconComponent, ThyStringOrTemplateOutletDirective]
+    imports: [NgIf, ThyIcon, ThyStringOrTemplateOutletDirective]
 })
-export class ThyMessageComponent extends ThyAbstractMessageComponent<ThyMessageConfig> {
+export class ThyMessage extends ThyAbstractMessageComponent<ThyMessageConfig> {
     @HostBinding('@flyInOut') animationState = 'flyIn';
 
     config: ThyMessageConfig;

--- a/src/message/message.service.ts
+++ b/src/message/message.service.ts
@@ -1,6 +1,6 @@
 import { Overlay } from '@angular/cdk/overlay';
 import { Inject, Injectable, Injector, TemplateRef } from '@angular/core';
-import { ThyMessageContainerComponent } from './message-container.component';
+import { ThyMessageContainer } from './message-container.component';
 import { ThyMessageRef } from './message-ref';
 import { ThyMessageQueue } from './message-queue.service';
 import { ThyGlobalMessageConfig, ThyMessageConfig, THY_MESSAGE_DEFAULT_CONFIG, THY_MESSAGE_DEFAULT_CONFIG_VALUE } from './message.config';
@@ -9,7 +9,7 @@ import { ThyAbstractMessageService } from './abstract';
 @Injectable({
     providedIn: 'root'
 })
-export class ThyMessageService extends ThyAbstractMessageService<ThyMessageContainerComponent> {
+export class ThyMessageService extends ThyAbstractMessageService<ThyMessageContainer> {
     private _lastMessageId = 0;
 
     private defaultConfig: ThyGlobalMessageConfig;
@@ -83,7 +83,7 @@ export class ThyMessageService extends ThyAbstractMessageService<ThyMessageConta
     }
 
     protected show(config: ThyMessageConfig): ThyMessageRef {
-        this.container = this.createContainer(ThyMessageContainerComponent);
+        this.container = this.createContainer(ThyMessageContainer);
 
         const messageConfig = this.formatOptions(config);
         const messageRef = new ThyMessageRef(messageConfig, this.overlayRef, this.messageQueue);

--- a/src/message/module.ts
+++ b/src/message/module.ts
@@ -4,13 +4,13 @@ import { ThyIconModule } from 'ngx-tethys/icon';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { PortalModule } from '@angular/cdk/portal';
 import { ThySharedModule } from 'ngx-tethys/shared';
-import { ThyMessageComponent } from './message.component';
-import { ThyMessageContainerComponent } from './message-container.component';
+import { ThyMessage } from './message.component';
+import { ThyMessageContainer } from './message-container.component';
 import { THY_MESSAGE_DEFAULT_CONFIG_PROVIDER } from './message.config';
 
 @NgModule({
-    imports: [CommonModule, ThySharedModule, OverlayModule, PortalModule, ThyIconModule, ThyMessageContainerComponent, ThyMessageComponent],
-    exports: [ThyMessageContainerComponent, ThyMessageComponent],
+    imports: [CommonModule, ThySharedModule, OverlayModule, PortalModule, ThyIconModule, ThyMessageContainer, ThyMessage],
+    exports: [ThyMessageContainer, ThyMessage],
     providers: [THY_MESSAGE_DEFAULT_CONFIG_PROVIDER]
 })
 export class ThyMessageModule {}

--- a/src/nav/icon-nav/icon-nav-link.directive.ts
+++ b/src/nav/icon-nav/icon-nav-link.directive.ts
@@ -1,6 +1,6 @@
 import { NgIf } from '@angular/common';
 import { Component, HostBinding, Input } from '@angular/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { coerceBooleanProperty } from 'ngx-tethys/util';
 
 /**
@@ -11,9 +11,9 @@ import { coerceBooleanProperty } from 'ngx-tethys/util';
     selector: '[thyIconNavLink]',
     template: '<ng-content></ng-content><thy-icon *ngIf="icon" [thyIconName]="icon"></thy-icon>',
     standalone: true,
-    imports: [NgIf, ThyIconComponent]
+    imports: [NgIf, ThyIcon]
 })
-export class ThyIconNavLinkComponent {
+export class ThyIconNavLink {
     @HostBinding('class.active') navLinkActive = false;
 
     @HostBinding('class.thy-icon-nav-link') navLinkClass = true;

--- a/src/nav/icon-nav/icon-nav.component.spec.ts
+++ b/src/nav/icon-nav/icon-nav.component.spec.ts
@@ -1,8 +1,8 @@
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { Component, OnInit } from '@angular/core';
 import { ThyNavModule } from '../nav.module';
-import { ThyIconNavComponent } from './icon-nav.component';
-import { ThyIconNavLinkComponent } from './icon-nav-link.directive';
+import { ThyIconNav } from './icon-nav.component';
+import { ThyIconNavLink } from './icon-nav-link.directive';
 import { ThyIconModule } from '../../icon';
 import { injectDefaultSvgIconSet, bypassSanitizeProvider } from 'ngx-tethys/testing';
 import { By } from '@angular/platform-browser';
@@ -47,7 +47,7 @@ describe(`icon-nav`, () => {
         });
 
         it(`should get correct class thy-icon-nav`, () => {
-            const iconNavDebugElement = fixture.debugElement.query(By.directive(ThyIconNavComponent));
+            const iconNavDebugElement = fixture.debugElement.query(By.directive(ThyIconNav));
             const iconNavElement: HTMLElement = iconNavDebugElement.nativeElement;
             expect(iconNavDebugElement).toBeTruthy();
             expect(iconNavElement).toBeTruthy();
@@ -57,7 +57,7 @@ describe(`icon-nav`, () => {
         it(`should get correct class thy-icon-nav-secondary when type is secondary`, async () => {
             fixture.componentInstance.type = 'secondary';
             fixture.detectChanges();
-            const iconNavDebugElement = fixture.debugElement.query(By.directive(ThyIconNavComponent));
+            const iconNavDebugElement = fixture.debugElement.query(By.directive(ThyIconNav));
             const iconNavElement: HTMLElement = iconNavDebugElement.nativeElement;
             expect(iconNavDebugElement).toBeTruthy();
             expect(iconNavElement).toBeTruthy();
@@ -65,7 +65,7 @@ describe(`icon-nav`, () => {
         });
 
         it(`should get correct class 'thy-icon-nav-link' for icon nav link`, async () => {
-            const iconNavLinkDebugElements = fixture.debugElement.queryAll(By.directive(ThyIconNavLinkComponent));
+            const iconNavLinkDebugElements = fixture.debugElement.queryAll(By.directive(ThyIconNavLink));
             expect(iconNavLinkDebugElements).toBeTruthy();
             expect(iconNavLinkDebugElements.length).toEqual(2);
             const inboxIconNavLinkDebugElement = iconNavLinkDebugElements[0];
@@ -76,7 +76,7 @@ describe(`icon-nav`, () => {
         });
 
         it(`should get correct icon for icon nav link when use thyIconNavLinkIcon and custom content`, async () => {
-            const iconNavLinkDebugElements = fixture.debugElement.queryAll(By.directive(ThyIconNavLinkComponent));
+            const iconNavLinkDebugElements = fixture.debugElement.queryAll(By.directive(ThyIconNavLink));
             expect(iconNavLinkDebugElements).toBeTruthy();
             expect(iconNavLinkDebugElements.length).toEqual(2);
             const inboxIconNavLinkDebugElement = iconNavLinkDebugElements[0];

--- a/src/nav/icon-nav/icon-nav.component.ts
+++ b/src/nav/icon-nav/icon-nav.component.ts
@@ -13,7 +13,7 @@ type IconNavTypes = 'primary' | 'secondary' | 'individual' | '';
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true
 })
-export class ThyIconNavComponent implements OnInit {
+export class ThyIconNav implements OnInit {
     private initialized = false;
 
     private hostRenderer = useHostRenderer();

--- a/src/nav/nav.component.ts
+++ b/src/nav/nav.component.ts
@@ -30,7 +30,7 @@ import { ThyNavInkBarDirective } from './nav-ink-bar.directive';
 import { ThyNavItemDirective } from './nav-item.directive';
 import { BypassSecurityTrustHtmlPipe } from './nav.pipe';
 import { ThyDropdownMenuComponent, ThyDropdownMenuItemDirective, ThyDropdownMenuItemActiveDirective } from 'ngx-tethys/dropdown';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgClass, NgTemplateOutlet, NgIf, NgFor } from '@angular/common';
 
 const _MixinBase: Constructor<ThyUnsubscribe> & typeof MixinBase = mixinUnsubscribe(MixinBase);
@@ -77,7 +77,7 @@ const tabItemRight = 20;
         NgTemplateOutlet,
         NgIf,
         ThyNavItemDirective,
-        ThyIconComponent,
+        ThyIcon,
         ThyNavInkBarDirective,
         ThyDropdownMenuComponent,
         NgFor,
@@ -86,10 +86,7 @@ const tabItemRight = 20;
         BypassSecurityTrustHtmlPipe
     ]
 })
-export class ThyNavComponent
-    extends _MixinBase
-    implements OnInit, AfterViewInit, AfterContentInit, AfterContentChecked, OnChanges, OnDestroy
-{
+export class ThyNav extends _MixinBase implements OnInit, AfterViewInit, AfterContentInit, AfterContentChecked, OnChanges, OnDestroy {
     private type: ThyNavType = 'pulled';
     private size: ThyNavSize = 'md';
     public initialized = false;

--- a/src/nav/nav.module.ts
+++ b/src/nav/nav.module.ts
@@ -6,11 +6,11 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
-import { ThyIconNavLinkComponent } from './icon-nav/icon-nav-link.directive';
-import { ThyIconNavComponent } from './icon-nav/icon-nav.component';
+import { ThyIconNavLink } from './icon-nav/icon-nav-link.directive';
+import { ThyIconNav } from './icon-nav/icon-nav.component';
 import { ThyNavInkBarDirective } from './nav-ink-bar.directive';
 import { ThyNavItemDirective } from './nav-item.directive';
-import { ThyNavComponent } from './nav.component';
+import { ThyNav } from './nav.component';
 import { BypassSecurityTrustHtmlPipe } from './nav.pipe';
 
 @NgModule({
@@ -20,13 +20,13 @@ import { BypassSecurityTrustHtmlPipe } from './nav.pipe';
         ThyPopoverModule,
         ThyDropdownModule,
         RouterModule,
-        ThyNavComponent,
+        ThyNav,
         ThyNavItemDirective,
-        ThyIconNavComponent,
-        ThyIconNavLinkComponent,
+        ThyIconNav,
+        ThyIconNavLink,
         BypassSecurityTrustHtmlPipe,
         ThyNavInkBarDirective
     ],
-    exports: [ThyNavComponent, ThyNavItemDirective, ThyIconNavComponent, ThyIconNavLinkComponent, BypassSecurityTrustHtmlPipe]
+    exports: [ThyNav, ThyNavItemDirective, ThyIconNav, ThyIconNavLink, BypassSecurityTrustHtmlPipe]
 })
 export class ThyNavModule {}

--- a/src/nav/test/nav.component.spec.ts
+++ b/src/nav/test/nav.component.spec.ts
@@ -11,7 +11,7 @@ import { RouterTestingModule } from '@angular/router/testing';
 
 import { ThyIconModule } from '../../icon';
 import { ThyNavItemDirective } from '../nav-item.directive';
-import { ThyNavComponent, ThyNavHorizontal, ThyNavSize, ThyNavType } from '../nav.component';
+import { ThyNav, ThyNavHorizontal, ThyNavSize, ThyNavType } from '../nav.component';
 import { ThyNavModule } from '../nav.module';
 
 const NAV_CLASS = `thy-nav`;
@@ -106,7 +106,7 @@ export class NavResponsiveComponent implements OnInit {
 
     @ViewChildren(ThyNavItemDirective, { read: ElementRef }) linksElement: QueryList<ElementRef>;
 
-    @ViewChild(ThyNavComponent) nav: ThyNavComponent;
+    @ViewChild(ThyNav) nav: ThyNav;
 
     constructor() {}
 
@@ -150,7 +150,7 @@ describe(`thy-nav`, () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(NavBasicComponent);
             fixture.detectChanges();
-            navDebugElement = fixture.debugElement.query(By.directive(ThyNavComponent));
+            navDebugElement = fixture.debugElement.query(By.directive(ThyNav));
             navElement = navDebugElement.nativeElement;
         });
 
@@ -384,7 +384,7 @@ describe(`thy-nav`, () => {
         it('should support set thyInsideClosable', fakeAsync(() => {
             fixture.debugElement.componentInstance.insideClosable = false;
             fixture.detectChanges();
-            const navDebugElement = fixture.debugElement.query(By.directive(ThyNavComponent));
+            const navDebugElement = fixture.debugElement.query(By.directive(ThyNav));
             expect(navDebugElement.componentInstance.thyInsideClosable).toBe(false);
         }));
 
@@ -411,7 +411,7 @@ describe(`thy-nav`, () => {
     });
 });
 
-function spyLinksAndNavOffset(links: ThyNavItemDirective[], nav: ThyNavComponent) {
+function spyLinksAndNavOffset(links: ThyNavItemDirective[], nav: ThyNav) {
     (links || []).forEach((link, index) => {
         link.offset = {
             width: 30,

--- a/src/notify/module.ts
+++ b/src/notify/module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyNotifyComponent } from './notify.component';
-import { ThyNotifyContainerComponent } from './notify-container.component';
+import { ThyNotify } from './notify.component';
+import { ThyNotifyContainer } from './notify-container.component';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { PortalModule } from '@angular/cdk/portal';
@@ -9,8 +9,8 @@ import { THY_NOTIFY_DEFAULT_CONFIG_PROVIDER } from './notify.config';
 import { ThySharedModule } from 'ngx-tethys/shared';
 
 @NgModule({
-    imports: [CommonModule, ThySharedModule, OverlayModule, PortalModule, ThyIconModule, ThyNotifyContainerComponent, ThyNotifyComponent],
-    exports: [ThyNotifyContainerComponent, ThyNotifyComponent],
+    imports: [CommonModule, ThySharedModule, OverlayModule, PortalModule, ThyIconModule, ThyNotifyContainer, ThyNotify],
+    exports: [ThyNotifyContainer, ThyNotify],
     providers: [THY_NOTIFY_DEFAULT_CONFIG_PROVIDER]
 })
 export class ThyNotifyModule {}

--- a/src/notify/notify-container.component.ts
+++ b/src/notify/notify-container.component.ts
@@ -2,7 +2,7 @@ import { Component, Inject, ElementRef, HostBinding } from '@angular/core';
 import { ThyAbstractMessageContainerComponent } from 'ngx-tethys/message';
 import { ThyNotifyQueue } from './notify-queue.service';
 import { ThyGlobalNotifyConfig, THY_NOTIFY_DEFAULT_CONFIG, THY_NOTIFY_DEFAULT_CONFIG_VALUE } from './notify.config';
-import { ThyNotifyComponent } from './notify.component';
+import { ThyNotify } from './notify.component';
 import { NgFor, AsyncPipe } from '@angular/common';
 
 /**
@@ -12,9 +12,9 @@ import { NgFor, AsyncPipe } from '@angular/common';
     selector: 'thy-notify-container',
     templateUrl: './notify-container.component.html',
     standalone: true,
-    imports: [NgFor, ThyNotifyComponent, AsyncPipe]
+    imports: [NgFor, ThyNotify, AsyncPipe]
 })
-export class ThyNotifyContainerComponent extends ThyAbstractMessageContainerComponent {
+export class ThyNotifyContainer extends ThyAbstractMessageContainerComponent {
     @HostBinding('class') className = 'thy-notify-container';
 
     constructor(

--- a/src/notify/notify.component.ts
+++ b/src/notify/notify.component.ts
@@ -5,7 +5,7 @@ import { ThyNotifyConfig, ThyNotifyDetail, ThyNotifyPlacement } from './notify.c
 import { ANIMATION_IN_DURATION, ANIMATION_OUT_DURATION, HIDE_STYLE, ThyAbstractMessageComponent } from 'ngx-tethys/message';
 import { ThyNotifyQueue } from './notify-queue.service';
 import { ThyViewOutletDirective } from 'ngx-tethys/shared';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgClass, NgTemplateOutlet } from '@angular/common';
 
 /**
@@ -32,9 +32,9 @@ import { NgIf, NgClass, NgTemplateOutlet } from '@angular/common';
         ])
     ],
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgClass, ThyViewOutletDirective, NgTemplateOutlet]
+    imports: [NgIf, ThyIcon, NgClass, ThyViewOutletDirective, NgTemplateOutlet]
 })
-export class ThyNotifyComponent extends ThyAbstractMessageComponent<ThyNotifyConfig> implements OnInit {
+export class ThyNotify extends ThyAbstractMessageComponent<ThyNotifyConfig> implements OnInit {
     @HostBinding('@flyInOut') animationState: string;
 
     @HostBinding('class') className = '';

--- a/src/notify/notify.service.ts
+++ b/src/notify/notify.service.ts
@@ -3,7 +3,7 @@ import { Inject, Injectable, Injector } from '@angular/core';
 import { ThyGlobalNotifyConfig, ThyNotifyConfig, THY_NOTIFY_DEFAULT_CONFIG, THY_NOTIFY_DEFAULT_CONFIG_VALUE } from './notify.config';
 import { Overlay } from '@angular/cdk/overlay';
 import { ThyNotifyRef } from './notify-ref';
-import { ThyNotifyContainerComponent } from './notify-container.component';
+import { ThyNotifyContainer } from './notify-container.component';
 import { ThyNotifyQueue } from './notify-queue.service';
 import { ThyAbstractMessageService } from 'ngx-tethys/message';
 import { ComponentTypeOrTemplateRef } from 'ngx-tethys/core';
@@ -14,7 +14,7 @@ import { ComponentTypeOrTemplateRef } from 'ngx-tethys/core';
 @Injectable({
     providedIn: 'root'
 })
-export class ThyNotifyService extends ThyAbstractMessageService<ThyNotifyContainerComponent> {
+export class ThyNotifyService extends ThyAbstractMessageService<ThyNotifyContainer> {
     private _lastNotifyId = 0;
 
     private defaultConfig: ThyGlobalNotifyConfig;
@@ -36,7 +36,7 @@ export class ThyNotifyService extends ThyAbstractMessageService<ThyNotifyContain
      * 打开自定义配置的 Notify
      */
     public show(config: ThyNotifyConfig): ThyNotifyRef {
-        this.container = this.createContainer(ThyNotifyContainerComponent);
+        this.container = this.createContainer(ThyNotifyContainer);
 
         const notifyConfig = this.formatOptions(config);
         const notifyRef = new ThyNotifyRef(notifyConfig, this.overlayRef, this.notifyQueue);

--- a/src/pagination/pagination.component.ts
+++ b/src/pagination/pagination.component.ts
@@ -16,10 +16,10 @@ import { PaginationDefaultConfig, DEFAULT_RANGE_COUNT, THY_PAGINATION_CONFIG, Th
 import { useHostRenderer } from '@tethys/cdk/dom';
 import { isTemplateRef } from 'ngx-tethys/util';
 import { PaginationTotalCountFormat } from './pagination.pipe';
-import { ThyIconComponent } from 'ngx-tethys/icon';
-import { ThyOptionComponent, ThyEnterDirective } from 'ngx-tethys/shared';
+import { ThyIcon } from 'ngx-tethys/icon';
+import { ThyOption, ThyEnterDirective } from 'ngx-tethys/shared';
 import { FormsModule } from '@angular/forms';
-import { ThySelectCustomComponent } from 'ngx-tethys/select';
+import { ThySelectCustom } from 'ngx-tethys/select';
 import { NgIf, NgTemplateOutlet, NgFor } from '@angular/common';
 import { InputBoolean, InputNumber } from 'ngx-tethys/core';
 
@@ -36,16 +36,16 @@ import { InputBoolean, InputNumber } from 'ngx-tethys/core';
     imports: [
         NgIf,
         NgTemplateOutlet,
-        ThySelectCustomComponent,
+        ThySelectCustom,
         FormsModule,
         NgFor,
-        ThyOptionComponent,
-        ThyIconComponent,
+        ThyOption,
+        ThyIcon,
         ThyEnterDirective,
         PaginationTotalCountFormat
     ]
 })
-export class ThyPaginationComponent implements OnInit {
+export class ThyPagination implements OnInit {
     isTemplateRef = isTemplateRef;
     public config: ThyPaginationConfigModel = Object.assign({}, PaginationDefaultConfig, this.paginationConfig.main);
 

--- a/src/pagination/pagination.module.ts
+++ b/src/pagination/pagination.module.ts
@@ -1,5 +1,5 @@
 import { NgModule } from '@angular/core';
-import { ThyPaginationComponent } from './pagination.component';
+import { ThyPagination } from './pagination.component';
 import { CommonModule } from '@angular/common';
 import { PaginationTotalCountFormat } from './pagination.pipe';
 import { ThySharedModule } from 'ngx-tethys/shared';
@@ -9,15 +9,7 @@ import { ThySelectModule } from 'ngx-tethys/select';
 import { FormsModule } from '@angular/forms';
 
 @NgModule({
-    imports: [
-        CommonModule,
-        FormsModule,
-        ThySharedModule,
-        ThyIconModule,
-        ThySelectModule,
-        ThyPaginationComponent,
-        PaginationTotalCountFormat
-    ],
-    exports: [ThyPaginationComponent]
+    imports: [CommonModule, FormsModule, ThySharedModule, ThyIconModule, ThySelectModule, ThyPagination, PaginationTotalCountFormat],
+    exports: [ThyPagination]
 })
 export class ThyPaginationModule {}

--- a/src/pagination/test/pagination.spec.ts
+++ b/src/pagination/test/pagination.spec.ts
@@ -1,12 +1,12 @@
 import { TestBed, ComponentFixture, tick, fakeAsync } from '@angular/core/testing';
 import { Component, ViewChild, TemplateRef, DebugElement } from '@angular/core';
 import { ThyPaginationModule } from '../pagination.module';
-import { ThyPaginationComponent } from '../pagination.component';
+import { ThyPagination } from '../pagination.component';
 import { By } from '@angular/platform-browser';
 import { ENTER } from 'ngx-tethys/util';
 import { dispatchFakeEvent, dispatchKeyboardEvent } from 'ngx-tethys/testing';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
-import { ThySelectCustomComponent } from 'ngx-tethys/select';
+import { ThySelectCustom } from 'ngx-tethys/select';
 
 @Component({
     selector: 'thy-test-pagination-basic',
@@ -111,7 +111,7 @@ describe('ThyPagination', () => {
             fixture = TestBed.createComponent(PaginationTestComponent);
             componentInstance = fixture.debugElement.componentInstance;
             fixture.detectChanges();
-            paginationDebugElement = fixture.debugElement.query(By.directive(ThyPaginationComponent));
+            paginationDebugElement = fixture.debugElement.query(By.directive(ThyPagination));
             paginationElement = paginationDebugElement.nativeElement;
             pagination = componentInstance.pagination;
         });
@@ -192,7 +192,7 @@ describe('ThyPagination', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(PaginationBasicComponent);
             basicTestComponent = fixture.debugElement.componentInstance;
-            pageComponent = fixture.debugElement.query(By.directive(ThyPaginationComponent));
+            pageComponent = fixture.debugElement.query(By.directive(ThyPagination));
         });
 
         it('should create', () => {
@@ -422,7 +422,7 @@ describe('ThyPagination', () => {
             fixture = TestBed.createComponent(PaginationTestComponent);
             componentInstance = fixture.debugElement.componentInstance;
             fixture.detectChanges();
-            paginationElement = fixture.debugElement.query(By.directive(ThyPaginationComponent)).nativeElement;
+            paginationElement = fixture.debugElement.query(By.directive(ThyPagination)).nativeElement;
         });
 
         it('should showSizeChanger can works', fakeAsync(() => {

--- a/src/popover/body/popover-body.component.ts
+++ b/src/popover/body/popover-body.component.ts
@@ -15,4 +15,4 @@ import { ChangeDetectionStrategy, Component } from '@angular/core';
     },
     standalone: true
 })
-export class ThyPopoverBodyComponent {}
+export class ThyPopoverBody {}

--- a/src/popover/header/popover-header.component.ts
+++ b/src/popover/header/popover-header.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, ContentChild, EventEmitter, Input, Output, TemplateRef } from '@angular/core';
 import { ThyTranslate } from 'ngx-tethys/core';
 import { ThyPopover } from '../popover.service';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgTemplateOutlet } from '@angular/common';
 
 /**
@@ -18,9 +18,9 @@ import { NgIf, NgTemplateOutlet } from '@angular/common';
         class: 'thy-popover-header'
     },
     standalone: true,
-    imports: [NgIf, NgTemplateOutlet, ThyIconComponent]
+    imports: [NgIf, NgTemplateOutlet, ThyIcon]
 })
-export class ThyPopoverHeaderComponent {
+export class ThyPopoverHeader {
     /**
      * 头部标题
      */

--- a/src/popover/module.ts
+++ b/src/popover/module.ts
@@ -5,9 +5,9 @@ import { PortalModule } from '@angular/cdk/portal';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ThyPopoverBodyComponent } from './body/popover-body.component';
-import { ThyPopoverHeaderComponent } from './header/popover-header.component';
-import { ThyPopoverContainerComponent } from './popover-container.component';
+import { ThyPopoverBody } from './body/popover-body.component';
+import { ThyPopoverHeader } from './header/popover-header.component';
+import { ThyPopoverContainer } from './popover-container.component';
 import { THY_POPOVER_DEFAULT_CONFIG_PROVIDER, THY_POPOVER_SCROLL_STRATEGY_PROVIDER } from './popover.config';
 import { ThyPopoverDirective } from './popover.directive';
 import { ThyPopover } from './popover.service';
@@ -18,12 +18,12 @@ import { ThyPopover } from './popover.service';
         OverlayModule,
         PortalModule,
         ThyIconModule,
-        ThyPopoverContainerComponent,
+        ThyPopoverContainer,
         ThyPopoverDirective,
-        ThyPopoverHeaderComponent,
-        ThyPopoverBodyComponent
+        ThyPopoverHeader,
+        ThyPopoverBody
     ],
-    exports: [ThyPopoverDirective, ThyPopoverHeaderComponent, ThyPopoverBodyComponent],
+    exports: [ThyPopoverDirective, ThyPopoverHeader, ThyPopoverBody],
     providers: [THY_POPOVER_DEFAULT_CONFIG_PROVIDER, THY_POPOVER_SCROLL_STRATEGY_PROVIDER, ThyPopover]
 })
 export class ThyPopoverModule {}

--- a/src/popover/popover-container.component.ts
+++ b/src/popover/popover-container.component.ts
@@ -52,7 +52,7 @@ import { scaleMotion, scaleXMotion, scaleYMotion } from 'ngx-tethys/core';
     standalone: true,
     imports: [PortalModule, ThyPortalOutlet]
 })
-export class ThyPopoverContainerComponent<TData = unknown> extends ThyAbstractOverlayContainer<TData> implements AfterViewInit, OnDestroy {
+export class ThyPopoverContainer<TData = unknown> extends ThyAbstractOverlayContainer<TData> implements AfterViewInit, OnDestroy {
     @ViewChild(ThyPortalOutlet, { static: true })
     portalOutlet: ThyPortalOutlet;
 

--- a/src/popover/popover-ref.ts
+++ b/src/popover/popover-ref.ts
@@ -3,21 +3,21 @@ import { ThyAbstractInternalOverlayRef, ThyAbstractOverlayRef } from 'ngx-tethys
 import { OverlayRef } from '@angular/cdk/overlay';
 import { merge } from 'rxjs';
 
-import { ThyPopoverContainerComponent } from './popover-container.component';
+import { ThyPopoverContainer } from './popover-container.component';
 import { ThyPopoverConfig } from './popover.config';
 import { popoverAbstractOverlayOptions } from './popover.options';
 
 export abstract class ThyPopoverRef<T, TResult = unknown, TData = unknown> extends ThyAbstractOverlayRef<
     T,
-    ThyPopoverContainerComponent<TData>,
+    ThyPopoverContainer<TData>,
     TResult
 > {}
 
 export class ThyInternalPopoverRef<T, TResult = unknown>
-    extends ThyAbstractInternalOverlayRef<T, ThyPopoverContainerComponent, TResult>
+    extends ThyAbstractInternalOverlayRef<T, ThyPopoverContainer, TResult>
     implements ThyPopoverRef<T, TResult>
 {
-    constructor(overlayRef: OverlayRef, containerInstance: ThyPopoverContainerComponent, config: ThyPopoverConfig) {
+    constructor(overlayRef: OverlayRef, containerInstance: ThyPopoverContainer, config: ThyPopoverConfig) {
         super(popoverAbstractOverlayOptions, overlayRef, containerInstance, config);
         // Note: doesn't need to unsubscribe, because `insideClicked` and `outsideClicked`
         // get completed by `ThyPopoverContainerComponent` when the view is destroyed.

--- a/src/popover/popover.service.ts
+++ b/src/popover/popover.service.ts
@@ -21,7 +21,7 @@ import { ComponentPortal } from '@angular/cdk/portal';
 import { DOCUMENT } from '@angular/common';
 import { ElementRef, Inject, Injectable, Injector, NgZone, OnDestroy, Optional, StaticProvider, TemplateRef } from '@angular/core';
 
-import { ThyPopoverContainerComponent } from './popover-container.component';
+import { ThyPopoverContainer } from './popover-container.component';
 import { ThyInternalPopoverRef, ThyPopoverRef } from './popover-ref';
 import {
     THY_POPOVER_DEFAULT_CONFIG,
@@ -37,7 +37,7 @@ import { SafeAny } from 'ngx-tethys/types';
  * @order 10
  */
 @Injectable()
-export class ThyPopover extends ThyAbstractOverlayService<ThyPopoverConfig, ThyPopoverContainerComponent> implements OnDestroy {
+export class ThyPopover extends ThyAbstractOverlayService<ThyPopoverConfig, ThyPopoverContainer> implements OnDestroy {
     private readonly ngUnsubscribe$ = new Subject();
 
     private originInstancesMap = new Map<
@@ -90,34 +90,30 @@ export class ThyPopover extends ThyAbstractOverlayService<ThyPopoverConfig, ThyP
         return overlayConfig;
     }
 
-    protected attachOverlayContainer(overlay: OverlayRef, config: ThyPopoverConfig<any>): ThyPopoverContainerComponent {
+    protected attachOverlayContainer(overlay: OverlayRef, config: ThyPopoverConfig<any>): ThyPopoverContainer {
         const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
         const injector = Injector.create({
             parent: userInjector || this.injector,
             providers: [{ provide: ThyPopoverConfig, useValue: config }]
         });
-        const containerPortal = new ComponentPortal(ThyPopoverContainerComponent, config.viewContainerRef, injector);
-        const containerRef = overlay.attach<ThyPopoverContainerComponent>(containerPortal);
+        const containerPortal = new ComponentPortal(ThyPopoverContainer, config.viewContainerRef, injector);
+        const containerRef = overlay.attach<ThyPopoverContainer>(containerPortal);
         return containerRef.instance;
     }
 
     protected createAbstractOverlayRef<T, TResult = unknown>(
         overlayRef: OverlayRef,
-        containerInstance: ThyPopoverContainerComponent,
+        containerInstance: ThyPopoverContainer,
         config: ThyPopoverConfig
-    ): ThyAbstractOverlayRef<T, ThyPopoverContainerComponent, TResult> {
+    ): ThyAbstractOverlayRef<T, ThyPopoverContainer, TResult> {
         return new ThyInternalPopoverRef(overlayRef, containerInstance, config);
     }
 
-    protected createInjector<T>(
-        config: ThyPopoverConfig,
-        popoverRef: ThyPopoverRef<T>,
-        popoverContainer: ThyPopoverContainerComponent
-    ): Injector {
+    protected createInjector<T>(config: ThyPopoverConfig, popoverRef: ThyPopoverRef<T>, popoverContainer: ThyPopoverContainer): Injector {
         const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
 
         const injectionTokens: StaticProvider[] = [
-            { provide: ThyPopoverContainerComponent, useValue: popoverContainer },
+            { provide: ThyPopoverContainer, useValue: popoverContainer },
             {
                 provide: ThyPopoverRef,
                 useValue: popoverRef

--- a/src/popover/test/popover-layout.spec.ts
+++ b/src/popover/test/popover-layout.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { dispatchMouseEvent } from 'ngx-tethys/testing';
-import { ThyPopoverBodyComponent, ThyPopoverHeaderComponent } from '../index';
+import { ThyPopoverBody, ThyPopoverHeader } from '../index';
 import { ThyPopoverModule } from '../module';
 
 @Component({
@@ -60,7 +60,7 @@ describe('popover-layout', () => {
         beforeEach(() => {
             popoverBasicFixture = TestBed.createComponent(PopoverHeaderBasicComponent);
             popoverBasicFixture.detectChanges();
-            popoverHeaderDebugElement = popoverBasicFixture.debugElement.query(By.directive(ThyPopoverHeaderComponent));
+            popoverHeaderDebugElement = popoverBasicFixture.debugElement.query(By.directive(ThyPopoverHeader));
             popoverHeaderElement = popoverHeaderDebugElement.nativeElement;
         });
 
@@ -125,7 +125,7 @@ describe('popover-layout', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(PopoverHeaderTranslationComponent);
             fixture.detectChanges();
-            popoverHeaderElement = fixture.debugElement.query(By.directive(ThyPopoverHeaderComponent)).nativeElement;
+            popoverHeaderElement = fixture.debugElement.query(By.directive(ThyPopoverHeader)).nativeElement;
         });
 
         it('should create', () => {
@@ -154,7 +154,7 @@ describe('popover-layout', () => {
         beforeEach(() => {
             popoverBasicFixture = TestBed.createComponent(PopoverBodyBasicComponent);
             popoverBasicFixture.detectChanges();
-            popoverBodyDebugElement = popoverBasicFixture.debugElement.query(By.directive(ThyPopoverBodyComponent));
+            popoverBodyDebugElement = popoverBasicFixture.debugElement.query(By.directive(ThyPopoverBody));
             popoverBodyElement = popoverBodyDebugElement.nativeElement;
         });
 
@@ -186,7 +186,7 @@ describe('popover-layout', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(PopoverHeaderTemplateBasicComponent);
             fixture.detectChanges();
-            popoverHeaderDebugElement = fixture.debugElement.query(By.directive(ThyPopoverHeaderComponent));
+            popoverHeaderDebugElement = fixture.debugElement.query(By.directive(ThyPopoverHeader));
             popoverHeaderElement = popoverHeaderDebugElement.nativeElement;
         });
 

--- a/src/progress/progress-circle.component.ts
+++ b/src/progress/progress-circle.component.ts
@@ -28,7 +28,7 @@ import { InputNumber } from 'ngx-tethys/core';
     standalone: true,
     imports: [ThyTooltipDirective, NgClass, NgStyle, NgFor]
 })
-export class ThyProgressCircleComponent implements OnInit, OnChanges {
+export class ThyProgressCircle implements OnInit, OnChanges {
     private hostRenderer = useHostRenderer();
 
     @Input() set thyType(type: ThyProgressType) {

--- a/src/progress/progress-strip.component.ts
+++ b/src/progress/progress-strip.component.ts
@@ -6,7 +6,7 @@ import { InputNumber } from 'ngx-tethys/core';
 
 export interface ThyParentProgress {
     max: number;
-    bars: ThyProgressStripComponent[];
+    bars: ThyProgressStrip[];
 }
 export const THY_PROGRESS_COMPONENT = new InjectionToken<ThyParentProgress>('THY_PROGRESS_COMPONENT');
 
@@ -20,7 +20,7 @@ export const THY_PROGRESS_COMPONENT = new InjectionToken<ThyParentProgress>('THY
     standalone: true,
     imports: [NgStyle]
 })
-export class ThyProgressStripComponent {
+export class ThyProgressStrip {
     private value: number;
 
     private hostRenderer = useHostRenderer();

--- a/src/progress/progress.component.ts
+++ b/src/progress/progress.component.ts
@@ -16,8 +16,8 @@ import {
 import { useHostRenderer } from '@tethys/cdk/dom';
 
 import { ThyProgressGapPositionType, ThyProgressShapeType, ThyProgressStackedValue, ThyProgressType } from './interfaces';
-import { THY_PROGRESS_COMPONENT, ThyParentProgress, ThyProgressStripComponent } from './progress-strip.component';
-import { ThyProgressCircleComponent } from './progress-circle.component';
+import { THY_PROGRESS_COMPONENT, ThyParentProgress, ThyProgressStrip } from './progress-strip.component';
+import { ThyProgressCircle } from './progress-circle.component';
 import { ThyTooltipDirective } from 'ngx-tethys/tooltip';
 import { NgIf, NgFor, NgClass, NgTemplateOutlet } from '@angular/common';
 import { InputNumber } from 'ngx-tethys/core';
@@ -34,7 +34,7 @@ import { InputNumber } from 'ngx-tethys/core';
     providers: [
         {
             provide: THY_PROGRESS_COMPONENT,
-            useExisting: ThyProgressComponent
+            useExisting: ThyProgress
         }
     ],
     host: {
@@ -43,12 +43,12 @@ import { InputNumber } from 'ngx-tethys/core';
         '[class.thy-progress-circle]': `thyShape === 'circle'`
     },
     standalone: true,
-    imports: [NgIf, NgFor, ThyProgressStripComponent, NgClass, ThyTooltipDirective, NgTemplateOutlet, ThyProgressCircleComponent]
+    imports: [NgIf, NgFor, ThyProgressStrip, NgClass, ThyTooltipDirective, NgTemplateOutlet, ThyProgressCircle]
 })
-export class ThyProgressComponent implements ThyParentProgress, OnInit, OnChanges {
+export class ThyProgress implements ThyParentProgress, OnInit, OnChanges {
     value: number | ThyProgressStackedValue[];
 
-    bars: ThyProgressStripComponent[] = [];
+    bars: ThyProgressStrip[] = [];
 
     barsTotalValue: number;
 
@@ -60,8 +60,8 @@ export class ThyProgressComponent implements ThyParentProgress, OnInit, OnChange
 
     @HostBinding(`class.progress-stacked`) isStacked = false;
 
-    @ViewChildren(ThyProgressStripComponent)
-    set barsQueryList(value: QueryList<ThyProgressStripComponent>) {
+    @ViewChildren(ThyProgressStrip)
+    set barsQueryList(value: QueryList<ThyProgressStrip>) {
         this.bars = value.toArray();
     }
 

--- a/src/progress/progress.module.ts
+++ b/src/progress/progress.module.ts
@@ -3,12 +3,12 @@ import { ThyTooltipModule } from 'ngx-tethys/tooltip';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ThyProgressCircleComponent } from './progress-circle.component';
-import { ThyProgressStripComponent } from './progress-strip.component';
-import { ThyProgressComponent } from './progress.component';
+import { ThyProgressCircle } from './progress-circle.component';
+import { ThyProgressStrip } from './progress-strip.component';
+import { ThyProgress } from './progress.component';
 
 @NgModule({
-    imports: [CommonModule, ThyTooltipModule, ThyProgressComponent, ThyProgressStripComponent, ThyProgressCircleComponent],
-    exports: [ThyProgressComponent]
+    imports: [CommonModule, ThyTooltipModule, ThyProgress, ThyProgressStrip, ThyProgressCircle],
+    exports: [ThyProgress]
 })
 export class ThyProgressModule {}

--- a/src/progress/test/progress.component.spec.ts
+++ b/src/progress/test/progress.component.spec.ts
@@ -10,9 +10,9 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ThyTooltipDirective } from '../../tooltip';
 import { hexToRgb } from '../../util/helpers';
 import { ThyProgressStackedValue, ThyProgressType } from '../interfaces';
-import { ThyProgressCircleComponent } from '../progress-circle.component';
-import { ThyProgressStripComponent } from '../progress-strip.component';
-import { ThyProgressComponent } from '../progress.component';
+import { ThyProgressCircle } from '../progress-circle.component';
+import { ThyProgressStrip } from '../progress-strip.component';
+import { ThyProgress } from '../progress.component';
 import { ThyProgressModule } from '../progress.module';
 
 const PROGRESS_CLASS_NAME = 'progress';
@@ -220,9 +220,9 @@ describe(`ThyProgressComponent`, () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(ThyDemoProgressBasicComponent);
             basicTestComponent = fixture.debugElement.componentInstance;
-            progressComponent = fixture.debugElement.query(By.directive(ThyProgressComponent));
+            progressComponent = fixture.debugElement.query(By.directive(ThyProgress));
             progressElement = progressComponent.nativeElement;
-            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStripComponent));
+            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStrip));
         });
 
         function assertProgressAndBarComponentClass(styleWidth: string = '20%') {
@@ -238,14 +238,14 @@ describe(`ThyProgressComponent`, () => {
 
         it('should be correct class by default type', () => {
             fixture.detectChanges();
-            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStripComponent));
+            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStrip));
             assertProgressAndBarComponentClass();
         });
 
         it('should be correct class when input type is success or warning', () => {
             basicTestComponent.type = 'success';
             fixture.detectChanges();
-            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStripComponent));
+            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStrip));
             progressBarElement = progressBarComponent.nativeElement;
             progressBarInnerElement = fixture.debugElement.query(By.css('.progress-bar-inner')).nativeElement;
             assertProgressAndBarComponentClass();
@@ -253,7 +253,7 @@ describe(`ThyProgressComponent`, () => {
 
             basicTestComponent.type = 'warning';
             fixture.detectChanges();
-            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStripComponent));
+            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStrip));
             progressBarElement = progressBarComponent.nativeElement;
             progressBarInnerElement = fixture.debugElement.query(By.css('.progress-bar-inner')).nativeElement;
             assertProgressAndBarComponentClass();
@@ -263,14 +263,14 @@ describe(`ThyProgressComponent`, () => {
         it('should be correct class when input size is sm', () => {
             basicTestComponent.size = 'sm';
             fixture.detectChanges();
-            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStripComponent));
+            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStrip));
             assertProgressAndBarComponentClass();
             expect(progressElement.classList.contains('progress-sm')).toBe(true);
         });
 
         it('should be correct percent with dynamically changed values', () => {
             fixture.detectChanges();
-            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStripComponent));
+            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStrip));
             progressBarElement = progressBarComponent.nativeElement;
             assertProgressAndBarComponentClass();
 
@@ -281,7 +281,7 @@ describe(`ThyProgressComponent`, () => {
 
         it('should be have a tooltip use string', fakeAsync(() => {
             fixture.detectChanges();
-            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStripComponent));
+            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStrip));
             progressBarElement = progressBarComponent.nativeElement;
 
             tooltipDirective = progressBarComponent.injector.get<ThyTooltipDirective>(ThyTooltipDirective);
@@ -317,7 +317,7 @@ describe(`ThyProgressComponent`, () => {
             const buttonElement = buttonDebugElement.nativeElement;
             buttonElement.click();
             fixture.detectChanges();
-            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStripComponent));
+            progressBarComponent = fixture.debugElement.query(By.directive(ThyProgressStrip));
             progressBarElement = progressBarComponent.nativeElement;
 
             tooltipDirective = progressBarComponent.injector.get<ThyTooltipDirective>(ThyTooltipDirective);
@@ -420,8 +420,8 @@ describe(`ThyProgressComponent`, () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(ThyDemoProgressCircleComponent);
             circleTestComponent = fixture.debugElement.componentInstance;
-            progressComponent = fixture.debugElement.query(By.directive(ThyProgressComponent));
-            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircleComponent));
+            progressComponent = fixture.debugElement.query(By.directive(ThyProgress));
+            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircle));
             progressElement = progressComponent.nativeElement;
             fixture.detectChanges();
         });
@@ -434,14 +434,14 @@ describe(`ThyProgressComponent`, () => {
         it('should show correct color when input type is success or warning', () => {
             circleTestComponent.type = 'success';
             fixture.detectChanges();
-            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircleComponent));
+            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircle));
             progressCircleElement = progressCircleComponent.nativeElement;
             progressCircleInnerElement = fixture.debugElement.query(By.css('.progress-circle-inner')).nativeElement;
             expect(progressCircleElement.classList.contains(`progress-circle-${circleTestComponent.type}`)).toBe(true);
 
             circleTestComponent.type = 'warning';
             fixture.detectChanges();
-            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircleComponent));
+            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircle));
             progressCircleElement = progressCircleComponent.nativeElement;
             progressCircleInnerElement = fixture.debugElement.query(By.css('.progress-circle-inner')).nativeElement;
             expect(progressCircleElement.classList.contains(`progress-circle-${circleTestComponent.type}`)).toBe(true);
@@ -452,7 +452,7 @@ describe(`ThyProgressComponent`, () => {
             fixture.detectChanges();
             tick(100);
             progressElement = progressComponent.nativeElement;
-            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircleComponent));
+            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircle));
             expect(progressElement.classList.contains('progress-sm')).toBe(true);
             flush();
         }));
@@ -462,7 +462,7 @@ describe(`ThyProgressComponent`, () => {
             fixture.detectChanges();
             tick(100);
             progressElement = progressComponent.nativeElement;
-            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircleComponent));
+            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircle));
             const circleInner = progressCircleComponent.nativeElement.querySelector('.progress-circle-inner');
             expect(circleInner.style.width).toBe('16px');
             expect(circleInner.style.height).toBe('16px');
@@ -470,7 +470,7 @@ describe(`ThyProgressComponent`, () => {
         }));
 
         it('should be correct percent with dynamically changed values', () => {
-            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircleComponent));
+            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircle));
             progressCircleElement = progressCircleComponent.nativeElement;
             circleTestComponent.size = 'md';
             fixture.detectChanges();
@@ -485,7 +485,7 @@ describe(`ThyProgressComponent`, () => {
         });
 
         it('should be have a tooltip use string', fakeAsync(() => {
-            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircleComponent));
+            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircle));
             progressCircleElement = progressCircleComponent.nativeElement;
 
             tooltipDirective = progressCircleComponent.injector.get<ThyTooltipDirective>(ThyTooltipDirective);
@@ -513,7 +513,7 @@ describe(`ThyProgressComponent`, () => {
         }));
 
         it('should show correct gapDegree when input thyGapDegree', fakeAsync(() => {
-            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircleComponent));
+            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircle));
             progressCircleElement = progressCircleComponent.nativeElement;
             circleTestComponent.gapDegree = 100;
             fixture.detectChanges();
@@ -528,7 +528,7 @@ describe(`ThyProgressComponent`, () => {
         }));
 
         it('should show correct strokeWidth when input thyStrokeWidth', fakeAsync(() => {
-            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircleComponent));
+            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircle));
             progressCircleElement = progressCircleComponent.nativeElement;
             const strokeWidthElement = progressCircleElement.querySelector('path');
             circleTestComponent.strokeWidth = 10;
@@ -543,7 +543,7 @@ describe(`ThyProgressComponent`, () => {
         }));
 
         it('should show correct gapPosition when input thyGapPosition', fakeAsync(() => {
-            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircleComponent));
+            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircle));
             progressCircleElement = progressCircleComponent.nativeElement;
             computedPathString();
 
@@ -563,7 +563,7 @@ describe(`ThyProgressComponent`, () => {
         it('should show correct stakeValue when input value is array', fakeAsync(() => {
             (circleTestComponent.value as any) = circleTestComponent.stackedValue;
             fixture.detectChanges();
-            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircleComponent));
+            progressCircleComponent = fixture.debugElement.query(By.directive(ThyProgressCircle));
             const path = progressCircleComponent.nativeElement.querySelectorAll('.progress-circle-path');
             expect(path.length).toBe(circleTestComponent.stackedValue.length);
         }));
@@ -606,9 +606,9 @@ describe(`ThyProgressComponent`, () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(ThyDemoProgressStackedComponent);
             stackedTestComponent = fixture.debugElement.componentInstance;
-            progressComponent = fixture.debugElement.query(By.directive(ThyProgressComponent));
+            progressComponent = fixture.debugElement.query(By.directive(ThyProgress));
             progressElement = progressComponent.nativeElement;
-            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent));
+            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStrip));
         });
 
         it('should be created progress component', () => {
@@ -617,7 +617,7 @@ describe(`ThyProgressComponent`, () => {
 
         it('should be correct class by stacked value', () => {
             fixture.detectChanges();
-            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent));
+            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStrip));
             progressBarElements = progressBarComponents.map(item => item.nativeElement);
             expect(progressElement.classList.contains(PROGRESS_CLASS_NAME)).toBe(true);
 
@@ -632,7 +632,7 @@ describe(`ThyProgressComponent`, () => {
 
         it('should be have a tooltip in second progress bar', fakeAsync(() => {
             fixture.detectChanges();
-            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent));
+            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStrip));
             progressBarElements = progressBarComponents.map(item => item.nativeElement);
             expect(progressBarElements.length).toBe(3);
 
@@ -694,7 +694,7 @@ describe(`ThyProgressComponent`, () => {
                 }
             ];
             fixture.detectChanges();
-            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent));
+            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStrip));
             progressBarElements = progressBarComponents.map(item => item.nativeElement);
             expect(progressElement.classList.contains(PROGRESS_CLASS_NAME)).toBe(true);
 
@@ -746,9 +746,9 @@ describe(`ThyProgressComponent`, () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(ThyDemoProgressStackedMaxComponent);
             stackedTestComponent = fixture.debugElement.componentInstance;
-            progressComponent = fixture.debugElement.query(By.directive(ThyProgressComponent));
+            progressComponent = fixture.debugElement.query(By.directive(ThyProgress));
             progressElement = progressComponent.nativeElement;
-            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent));
+            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStrip));
         });
 
         it('should be correct value by custom stacked value has max ', () => {
@@ -774,7 +774,7 @@ describe(`ThyProgressComponent`, () => {
             ];
             stackedTestComponent.max = 180;
             fixture.detectChanges();
-            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent));
+            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStrip));
             progressBarElements = progressBarComponents.map(item => item.nativeElement);
             expect(progressElement.classList.contains(PROGRESS_CLASS_NAME)).toBe(true);
 
@@ -809,7 +809,7 @@ describe(`ThyProgressComponent`, () => {
             ];
             stackedTestComponent.max = 40;
             fixture.detectChanges();
-            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent));
+            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStrip));
             progressBarElements = progressBarComponents.map(item => item.nativeElement);
             expect(progressElement.classList.contains(PROGRESS_CLASS_NAME)).toBe(true);
 
@@ -839,7 +839,7 @@ describe(`ThyProgressComponent`, () => {
             ];
             stackedTestComponent.max = 30;
             fixture.detectChanges();
-            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent));
+            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStrip));
             progressBarElements = progressBarComponents.map(item => item.nativeElement);
             expect(progressElement.classList.contains(PROGRESS_CLASS_NAME)).toBe(true);
 
@@ -861,7 +861,7 @@ describe(`ThyProgressComponent`, () => {
             ];
             stackedTestComponent.max = 90;
             fixture.detectChanges();
-            let progressBarComponent = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent))[0].nativeElement;
+            let progressBarComponent = fixture.debugElement.queryAll(By.directive(ThyProgressStrip))[0].nativeElement;
             expect(progressBarComponent.style.width).toEqual('33.33%');
 
             fixture.detectChanges();
@@ -872,7 +872,7 @@ describe(`ThyProgressComponent`, () => {
                 }
             ];
             fixture.detectChanges();
-            progressBarComponent = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent))[0].nativeElement;
+            progressBarComponent = fixture.debugElement.queryAll(By.directive(ThyProgressStrip))[0].nativeElement;
             expect(progressBarComponent.style.width).toEqual('100%');
 
             fixture.detectChanges();
@@ -883,19 +883,19 @@ describe(`ThyProgressComponent`, () => {
                 }
             ];
             fixture.detectChanges();
-            progressBarComponent = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent))[0].nativeElement;
+            progressBarComponent = fixture.debugElement.queryAll(By.directive(ThyProgressStrip))[0].nativeElement;
             expect(progressBarComponent.style.width).toEqual('50%');
 
             fixture.detectChanges();
             stackedTestComponent.max = 180;
             fixture.detectChanges();
-            progressBarComponent = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent))[0].nativeElement;
+            progressBarComponent = fixture.debugElement.queryAll(By.directive(ThyProgressStrip))[0].nativeElement;
             expect(progressBarComponent.style.width).toEqual('25%');
 
             fixture.detectChanges();
             stackedTestComponent.max = 90;
             fixture.detectChanges();
-            progressBarComponent = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent))[0].nativeElement;
+            progressBarComponent = fixture.debugElement.queryAll(By.directive(ThyProgressStrip))[0].nativeElement;
             expect(progressBarComponent.style.width).toEqual('50%');
 
             fixture.detectChanges();
@@ -906,7 +906,7 @@ describe(`ThyProgressComponent`, () => {
                 }
             ];
             fixture.detectChanges();
-            progressBarComponent = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent))[0].nativeElement;
+            progressBarComponent = fixture.debugElement.queryAll(By.directive(ThyProgressStrip))[0].nativeElement;
             expect(progressBarComponent.style.width).toEqual('100%');
         });
 
@@ -914,7 +914,7 @@ describe(`ThyProgressComponent`, () => {
             stackedTestComponent.value = [];
             stackedTestComponent.max = 0;
             fixture.detectChanges();
-            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent));
+            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStrip));
             progressBarElements = progressBarComponents.map(item => item.nativeElement);
             expect(progressElement.classList.contains(PROGRESS_CLASS_NAME)).toBe(true);
 
@@ -963,9 +963,9 @@ describe(`ThyProgressComponent`, () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(ThyDemoProgressTooltipTemplateComponent);
             toolTipTemplateTestComponent = fixture.debugElement.componentInstance;
-            progressComponent = fixture.debugElement.query(By.directive(ThyProgressComponent));
+            progressComponent = fixture.debugElement.query(By.directive(ThyProgress));
             progressElement = progressComponent.nativeElement;
-            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent));
+            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStrip));
         });
 
         it('should be created progress component', () => {
@@ -974,7 +974,7 @@ describe(`ThyProgressComponent`, () => {
 
         it('should be created progress tooltip component width component', fakeAsync(() => {
             fixture.detectChanges();
-            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStripComponent));
+            progressBarComponents = fixture.debugElement.queryAll(By.directive(ThyProgressStrip));
             progressBarElements = progressBarComponents.map(item => item.nativeElement);
             expect(progressBarElements.length).toBe(3);
             progressBarElement = progressBarComponents[0].nativeElement;

--- a/src/property-operation/group/property-operation-group.component.ts
+++ b/src/property-operation/group/property-operation-group.component.ts
@@ -8,7 +8,7 @@ import { Component, HostBinding } from '@angular/core';
     templateUrl: './property-operation-group.component.html',
     standalone: true
 })
-export class ThyPropertyOperationGroupComponent {
+export class ThyPropertyOperationGroup {
     @HostBinding('class.thy-property-operation-group') _isPropertyOperationGroup = true;
 
     constructor() {}

--- a/src/property-operation/module.ts
+++ b/src/property-operation/module.ts
@@ -5,18 +5,11 @@ import { ThyIconModule } from 'ngx-tethys/icon';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ThyPropertyOperationGroupComponent } from './group/property-operation-group.component';
-import { ThyPropertyOperationComponent } from './property-operation.component';
+import { ThyPropertyOperationGroup } from './group/property-operation-group.component';
+import { ThyPropertyOperation } from './property-operation.component';
 
 @NgModule({
-    imports: [
-        CommonModule,
-        ThyButtonModule,
-        ThyIconModule,
-        ThyFlexibleTextModule,
-        ThyPropertyOperationComponent,
-        ThyPropertyOperationGroupComponent
-    ],
-    exports: [ThyPropertyOperationComponent, ThyPropertyOperationGroupComponent]
+    imports: [CommonModule, ThyButtonModule, ThyIconModule, ThyFlexibleTextModule, ThyPropertyOperation, ThyPropertyOperationGroup],
+    exports: [ThyPropertyOperation, ThyPropertyOperationGroup]
 })
 export class ThyPropertyOperationModule {}

--- a/src/property-operation/property-operation.component.ts
+++ b/src/property-operation/property-operation.component.ts
@@ -18,9 +18,9 @@ import { InputBoolean, ThyTranslate } from 'ngx-tethys/core';
 import { htmlElementIsEmpty, coerceBooleanProperty } from 'ngx-tethys/util';
 import { fromEvent, Subject } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { ThyIconComponent } from 'ngx-tethys/icon';
-import { ThyFlexibleTextComponent } from 'ngx-tethys/flexible-text';
-import { ThyButtonIconComponent } from 'ngx-tethys/button';
+import { ThyIcon } from 'ngx-tethys/icon';
+import { ThyFlexibleText } from 'ngx-tethys/flexible-text';
+import { ThyButtonIcon } from 'ngx-tethys/button';
 import { NgTemplateOutlet, NgIf, NgClass } from '@angular/common';
 
 type ThyPropertyOperationTypes = 'primary' | 'success' | 'warning' | 'danger';
@@ -34,9 +34,9 @@ type ThyPropertyOperationTypes = 'primary' | 'success' | 'warning' | 'danger';
     selector: 'thy-property-operation',
     templateUrl: './property-operation.component.html',
     standalone: true,
-    imports: [NgTemplateOutlet, NgIf, NgClass, ThyButtonIconComponent, ThyFlexibleTextComponent, ThyIconComponent]
+    imports: [NgTemplateOutlet, NgIf, NgClass, ThyButtonIcon, ThyFlexibleText, ThyIcon]
 })
-export class ThyPropertyOperationComponent implements OnInit, AfterContentInit, OnDestroy {
+export class ThyPropertyOperation implements OnInit, AfterContentInit, OnDestroy {
     private initialized = false;
 
     private hostRenderer = useHostRenderer();

--- a/src/property-operation/test/property-operation.component.spec.ts
+++ b/src/property-operation/test/property-operation.component.spec.ts
@@ -2,8 +2,8 @@ import { ApplicationRef, Component, DebugElement, ViewChild } from '@angular/cor
 import { TestBed, ComponentFixture } from '@angular/core/testing';
 import { ThyPropertyOperationModule } from '../module';
 import { By } from '@angular/platform-browser';
-import { ThyPropertyOperationComponent } from '../property-operation.component';
-import { ThyButtonIconComponent } from '../../button';
+import { ThyPropertyOperation } from '../property-operation.component';
+import { ThyButtonIcon } from '../../button';
 import { injectDefaultSvgIconSet, bypassSanitizeProvider } from 'ngx-tethys/testing';
 
 //#region test component
@@ -26,7 +26,7 @@ import { injectDefaultSvgIconSet, bypassSanitizeProvider } from 'ngx-tethys/test
     `
 })
 class PropertyOperationBasicComponent {
-    @ViewChild(ThyPropertyOperationComponent, { static: true }) component: ThyPropertyOperationComponent;
+    @ViewChild(ThyPropertyOperation, { static: true }) component: ThyPropertyOperation;
 
     thyIcon = 'calendar-check';
 
@@ -75,7 +75,7 @@ describe('ThyPropertyOperation', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(PropertyOperationBasicComponent);
             componentInstance = fixture.debugElement.componentInstance;
-            propertyOperationDebugElement = fixture.debugElement.query(By.directive(ThyPropertyOperationComponent));
+            propertyOperationDebugElement = fixture.debugElement.query(By.directive(ThyPropertyOperation));
             propertyOperationElement = propertyOperationDebugElement.nativeElement;
             fixture.detectChanges();
         });
@@ -89,7 +89,7 @@ describe('ThyPropertyOperation', () => {
             expect(operationIconElement).toBeTruthy();
             expect(operationContentElement).toBeTruthy();
 
-            const btnIcon = fixture.debugElement.query(By.directive(ThyButtonIconComponent));
+            const btnIcon = fixture.debugElement.query(By.directive(ThyButtonIcon));
             expect(btnIcon).toBeTruthy();
             expect(btnIcon.nativeElement.classList.contains(`btn`)).toBeTruthy();
             expect(btnIcon.nativeElement.classList.contains(`btn-icon`)).toBeTruthy();

--- a/src/property/examples/editable/editable.component.ts
+++ b/src/property/examples/editable/editable.component.ts
@@ -1,5 +1,5 @@
 import { ThyDialog } from 'ngx-tethys/dialog';
-import { ThySelectCustomComponent } from 'ngx-tethys/select';
+import { ThySelectCustom } from 'ngx-tethys/select';
 import { ThyTreeSelectNode } from 'ngx-tethys/tree-select';
 
 import { ChangeDetectorRef, Component, ElementRef, OnInit, TemplateRef, ViewChild } from '@angular/core';
@@ -60,9 +60,9 @@ export class ThyPropertyEditableExampleComponent implements OnInit {
 
     @ViewChild('number', { read: ElementRef }) number: ElementRef;
 
-    @ViewChild('selectSex', { read: ThySelectCustomComponent }) selectSex: ThySelectCustomComponent;
+    @ViewChild('selectSex', { read: ThySelectCustom }) selectSex: ThySelectCustom;
 
-    @ViewChild('selectProfession', { read: ThySelectCustomComponent }) selectProfession: ThySelectCustomComponent;
+    @ViewChild('selectProfession', { read: ThySelectCustom }) selectProfession: ThySelectCustom;
 
     constructor(public thyDialog: ThyDialog, private cdr: ChangeDetectorRef) {}
 

--- a/src/property/examples/operation/operation.component.ts
+++ b/src/property/examples/operation/operation.component.ts
@@ -6,7 +6,7 @@ import { ThyPropertyItemOperationTrigger } from 'ngx-tethys/property';
     templateUrl: './operation.component.html',
     styleUrls: ['./operation.component.scss']
 })
-export class ThyPropertyOperationComponent implements OnInit {
+export class ThyPropertyOperation implements OnInit {
     operationTrigger: ThyPropertyItemOperationTrigger = 'always';
 
     constructor() {}

--- a/src/property/module.ts
+++ b/src/property/module.ts
@@ -1,12 +1,12 @@
 import { ThyFlexibleTextModule } from 'ngx-tethys/flexible-text';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
-import { ThyPropertiesComponent } from './properties.component';
-import { ThyPropertyItemComponent } from './property-item.component';
+import { ThyProperties } from './properties.component';
+import { ThyPropertyItem } from './property-item.component';
 import { ThyTooltipModule } from 'ngx-tethys/tooltip';
 
 @NgModule({
-    imports: [CommonModule, ThyFlexibleTextModule, ThyTooltipModule, ThyPropertiesComponent, ThyPropertyItemComponent],
-    exports: [ThyPropertiesComponent, ThyPropertyItemComponent]
+    imports: [CommonModule, ThyFlexibleTextModule, ThyTooltipModule, ThyProperties, ThyPropertyItem],
+    exports: [ThyProperties, ThyPropertyItem]
 })
 export class ThyPropertyModule {}

--- a/src/property/properties.component.ts
+++ b/src/property/properties.component.ts
@@ -22,7 +22,7 @@ export type ThyPropertiesLayout = 'horizontal' | 'vertical';
     },
     standalone: true
 })
-export class ThyPropertiesComponent implements OnInit {
+export class ThyProperties implements OnInit {
     layout$ = new BehaviorSubject<ThyPropertiesLayout>('horizontal');
 
     layout: ThyPropertiesLayout = 'horizontal';

--- a/src/property/property-item.component.ts
+++ b/src/property/property-item.component.ts
@@ -1,5 +1,5 @@
 import { InputBoolean, InputNumber, ThyClickDispatcher } from 'ngx-tethys/core';
-import { ThyFlexibleTextComponent } from 'ngx-tethys/flexible-text';
+import { ThyFlexibleText } from 'ngx-tethys/flexible-text';
 import { combineLatest, fromEvent, Subject, Subscription, timer } from 'rxjs';
 import { delay, filter, take, takeUntil } from 'rxjs/operators';
 
@@ -24,7 +24,7 @@ import {
     ViewChild
 } from '@angular/core';
 
-import { ThyPropertiesComponent } from './properties.component';
+import { ThyProperties } from './properties.component';
 
 export type ThyPropertyItemOperationTrigger = 'hover' | 'always';
 
@@ -42,9 +42,9 @@ export type ThyPropertyItemOperationTrigger = 'hover' | 'always';
     },
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgIf, ThyFlexibleTextComponent, NgTemplateOutlet]
+    imports: [NgIf, ThyFlexibleText, NgTemplateOutlet]
 })
-export class ThyPropertyItemComponent implements OnInit, OnChanges, OnDestroy {
+export class ThyPropertyItem implements OnInit, OnChanges, OnDestroy {
     /**
      * 属性名称
      * @type sting
@@ -125,7 +125,7 @@ export class ThyPropertyItemComponent implements OnInit, OnChanges, OnDestroy {
         private clickDispatcher: ThyClickDispatcher,
         private ngZone: NgZone,
         private overlayOutsideClickDispatcher: OverlayOutsideClickDispatcher,
-        private parent: ThyPropertiesComponent
+        private parent: ThyProperties
     ) {
         this.originOverlays = [...this.overlayOutsideClickDispatcher._attachedOverlays] as OverlayRef[];
     }

--- a/src/property/test/properties.component.spec.ts
+++ b/src/property/test/properties.component.spec.ts
@@ -12,8 +12,8 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ThyPropertyModule } from '../module';
-import { ThyPropertiesComponent, ThyPropertiesLayout } from '../properties.component';
-import { ThyPropertyItemComponent, ThyPropertyItemOperationTrigger } from '../property-item.component';
+import { ThyProperties, ThyPropertiesLayout } from '../properties.component';
+import { ThyPropertyItem, ThyPropertyItemOperationTrigger } from '../property-item.component';
 
 @Component({
     selector: 'thy-properties-test-basic',
@@ -40,11 +40,11 @@ import { ThyPropertyItemComponent, ThyPropertyItemOperationTrigger } from '../pr
     `
 })
 class ThyPropertiesTestBasicComponent {
-    @ViewChild('properties') propertiesComponent: ThyPropertiesComponent;
+    @ViewChild('properties') propertiesComponent: ThyProperties;
 
-    @ViewChild('ageProperty') agePropertyItemComponent: ThyPropertyItemComponent;
+    @ViewChild('ageProperty') agePropertyItemComponent: ThyPropertyItem;
 
-    @ViewChild('sexProperty') sexPropertyItemComponent: ThyPropertyItemComponent;
+    @ViewChild('sexProperty') sexPropertyItemComponent: ThyPropertyItem;
 
     editable = true;
 
@@ -88,7 +88,7 @@ class ThyPropertiesTestBasicComponent {
     `
 })
 class ThyPropertiesTestColumnComponent {
-    @ViewChild('properties') propertiesComponent: ThyPropertiesComponent;
+    @ViewChild('properties') propertiesComponent: ThyProperties;
 
     column = 3;
 

--- a/src/radio/button/radio-button.component.ts
+++ b/src/radio/button/radio-button.component.ts
@@ -1,8 +1,8 @@
 import { Component, OnInit, HostBinding, HostListener, Input, Optional, ChangeDetectorRef } from '@angular/core';
 import { ThyTranslate } from 'ngx-tethys/core';
-import { ThyRadioGroupComponent } from './../group/radio-group.component';
+import { ThyRadioGroup } from './../group/radio-group.component';
 import { coerceBooleanProperty } from 'ngx-tethys/util';
-import { ThyRadioComponent } from '../radio.component';
+import { ThyRadio } from '../radio.component';
 
 /**
  * @name [thy-radio-button],[thyRadioButton]
@@ -16,7 +16,7 @@ import { ThyRadioComponent } from '../radio.component';
         '[attr.tabindex]': `tabIndex`
     }
 })
-export class ThyRadioButtonComponent extends ThyRadioComponent implements OnInit {
+export class ThyRadioButton extends ThyRadio implements OnInit {
     @HostBinding('class.btn') isButton = true;
     @HostBinding('class.active') isActive = false;
     @HostBinding('class.disabled') get isDisabled() {
@@ -32,11 +32,7 @@ export class ThyRadioButtonComponent extends ThyRadioComponent implements OnInit
         this.writeValue(coerceBooleanProperty(value));
     }
 
-    constructor(
-        thyTranslate: ThyTranslate,
-        @Optional() thyRadioGroupComponent: ThyRadioGroupComponent,
-        changeDetectorRef: ChangeDetectorRef
-    ) {
+    constructor(thyTranslate: ThyTranslate, @Optional() thyRadioGroupComponent: ThyRadioGroup, changeDetectorRef: ChangeDetectorRef) {
         super(thyTranslate, thyRadioGroupComponent, changeDetectorRef);
     }
 

--- a/src/radio/group/radio-group.component.ts
+++ b/src/radio/group/radio-group.component.ts
@@ -14,8 +14,8 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { useHostRenderer } from '@tethys/cdk/dom';
 import { InputBoolean } from 'ngx-tethys/core';
 
-import { ThyRadioButtonComponent } from '../button/radio-button.component';
-import { ThyRadioComponent } from '../radio.component';
+import { ThyRadioButton } from '../button/radio-button.component';
+import { ThyRadio } from '../radio.component';
 import { coerceBooleanProperty } from 'ngx-tethys/util';
 
 const buttonGroupSizeMap = {
@@ -37,7 +37,7 @@ const radioGroupLayoutMap = {
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThyRadioGroupComponent),
+            useExisting: forwardRef(() => ThyRadioGroup),
             multi: true
         }
     ],
@@ -47,7 +47,7 @@ const radioGroupLayoutMap = {
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true
 })
-export class ThyRadioGroupComponent implements ControlValueAccessor, OnInit, OnChanges, AfterContentInit {
+export class ThyRadioGroup implements ControlValueAccessor, OnInit, OnChanges, AfterContentInit {
     @HostBinding('class.thy-radio-group') thyRadioGroup = true;
 
     @HostBinding('class.btn-group') isButtonGroup = false;
@@ -78,7 +78,7 @@ export class ThyRadioGroupComponent implements ControlValueAccessor, OnInit, OnC
 
     _innerValue: string | number;
 
-    radios: Array<ThyRadioComponent | ThyRadioButtonComponent> = [];
+    radios: Array<ThyRadio | ThyRadioButton> = [];
 
     private hostRenderer = useHostRenderer();
 
@@ -97,7 +97,7 @@ export class ThyRadioGroupComponent implements ControlValueAccessor, OnInit, OnC
 
     constructor(private changeDetectorRef: ChangeDetectorRef) {}
 
-    addRadio(radio: ThyRadioComponent | ThyRadioButtonComponent): void {
+    addRadio(radio: ThyRadio | ThyRadioButton): void {
         this.radios.push(radio);
         radio.thyChecked = radio.thyValue === this._innerValue;
     }

--- a/src/radio/module.ts
+++ b/src/radio/module.ts
@@ -1,12 +1,12 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ThyRadioComponent } from './radio.component';
-import { ThyRadioButtonComponent } from './button/radio-button.component';
-import { ThyRadioGroupComponent } from './group/radio-group.component';
+import { ThyRadio } from './radio.component';
+import { ThyRadioButton } from './button/radio-button.component';
+import { ThyRadioGroup } from './group/radio-group.component';
 
 @NgModule({
-    imports: [CommonModule, FormsModule, ThyRadioComponent, ThyRadioGroupComponent, ThyRadioButtonComponent],
-    exports: [ThyRadioComponent, ThyRadioGroupComponent, ThyRadioButtonComponent]
+    imports: [CommonModule, FormsModule, ThyRadio, ThyRadioGroup, ThyRadioButton],
+    exports: [ThyRadio, ThyRadioGroup, ThyRadioButton]
 })
 export class ThyRadioModule {}

--- a/src/radio/radio.component.ts
+++ b/src/radio/radio.component.ts
@@ -2,7 +2,7 @@ import { Component, forwardRef, OnInit, Input, Optional, ChangeDetectionStrategy
 import { NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ThyTranslate } from 'ngx-tethys/core';
 import { ThyFormCheckBaseComponent } from 'ngx-tethys/shared';
-import { ThyRadioGroupComponent } from './group/radio-group.component';
+import { ThyRadioGroup } from './group/radio-group.component';
 import { coerceBooleanProperty } from 'ngx-tethys/util';
 import { NgClass, NgIf } from '@angular/common';
 
@@ -18,7 +18,7 @@ import { NgClass, NgIf } from '@angular/common';
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThyRadioComponent),
+            useExisting: forwardRef(() => ThyRadio),
             multi: true
         }
     ],
@@ -29,7 +29,7 @@ import { NgClass, NgIf } from '@angular/common';
     standalone: true,
     imports: [NgClass, NgIf]
 })
-export class ThyRadioComponent extends ThyFormCheckBaseComponent implements OnInit {
+export class ThyRadio extends ThyFormCheckBaseComponent implements OnInit {
     name: string;
 
     /**
@@ -44,7 +44,7 @@ export class ThyRadioComponent extends ThyFormCheckBaseComponent implements OnIn
 
     constructor(
         public thyTranslate: ThyTranslate,
-        @Optional() public thyRadioGroupComponent: ThyRadioGroupComponent,
+        @Optional() public thyRadioGroupComponent: ThyRadioGroup,
         changeDetectorRef: ChangeDetectorRef
     ) {
         super(thyTranslate, changeDetectorRef);

--- a/src/radio/test/radio.component.spec.ts
+++ b/src/radio/test/radio.component.spec.ts
@@ -3,8 +3,8 @@ import { FormsModule } from '@angular/forms';
 import { ComponentFixture, TestBed, fakeAsync, flush, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ThyRadioModule } from '../module';
-import { ThyRadioComponent } from '../radio.component';
-import { ThyRadioGroupComponent } from '../group/radio-group.component';
+import { ThyRadio } from '../radio.component';
+import { ThyRadioGroup } from '../group/radio-group.component';
 
 @Component({
     selector: 'thy-radio-test',
@@ -34,7 +34,7 @@ describe('radio component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(RadioTestComponent);
         testRadioComponent = fixture.debugElement.componentInstance;
-        radioDebugComponent = fixture.debugElement.query(By.directive(ThyRadioComponent));
+        radioDebugComponent = fixture.debugElement.query(By.directive(ThyRadio));
         radioElement = radioDebugComponent.nativeElement;
         labelNode = radioElement.children[0];
     });
@@ -76,7 +76,7 @@ describe('radio component', () => {
     `
 })
 class RadioGroupTestComponent {
-    @ViewChild('radioGroup', { static: true }) radioGroup: ThyRadioGroupComponent;
+    @ViewChild('radioGroup', { static: true }) radioGroup: ThyRadioGroup;
     checkedValue = 1;
     inlineStatus = false;
     size: string;
@@ -99,7 +99,7 @@ describe('thy-radio-group component', () => {
     beforeEach(() => {
         groupFixture = TestBed.createComponent(RadioGroupTestComponent);
         groupComponent = groupFixture.componentInstance;
-        radioGroupDebugComponent = groupFixture.debugElement.query(By.directive(ThyRadioGroupComponent));
+        radioGroupDebugComponent = groupFixture.debugElement.query(By.directive(ThyRadioGroup));
         labelComponent = radioGroupDebugComponent.nativeElement.children;
         groupFixture.detectChanges();
     });

--- a/src/rate/module.ts
+++ b/src/rate/module.ts
@@ -4,12 +4,12 @@ import { FormsModule } from '@angular/forms';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThySharedModule } from 'ngx-tethys/shared';
 import { ThyTooltipModule } from 'ngx-tethys/tooltip';
-import { ThyRateItemComponent } from './rate-item.component';
-import { ThyRateComponent } from './rate.component';
+import { ThyRateItem } from './rate-item.component';
+import { ThyRate } from './rate.component';
 
 @NgModule({
-    imports: [CommonModule, FormsModule, ThySharedModule, ThyIconModule, ThyTooltipModule, ThyRateComponent, ThyRateItemComponent],
-    exports: [ThyRateComponent],
+    imports: [CommonModule, FormsModule, ThySharedModule, ThyIconModule, ThyTooltipModule, ThyRate, ThyRateItem],
+    exports: [ThyRate],
     providers: []
 })
 export class ThyRateModule {}

--- a/src/rate/rate-item.component.ts
+++ b/src/rate/rate-item.component.ts
@@ -1,5 +1,5 @@
 import { Component, EventEmitter, Input, OnInit, Output, TemplateRef } from '@angular/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgTemplateOutlet } from '@angular/common';
 import { ThyStopPropagationDirective } from 'ngx-tethys/shared';
 import { InputBoolean } from 'ngx-tethys/core';
@@ -26,9 +26,9 @@ import { InputBoolean } from 'ngx-tethys/core';
         </ng-template>
     `,
     standalone: true,
-    imports: [ThyStopPropagationDirective, NgTemplateOutlet, ThyIconComponent]
+    imports: [ThyStopPropagationDirective, NgTemplateOutlet, ThyIcon]
 })
-export class ThyRateItemComponent implements OnInit {
+export class ThyRateItem implements OnInit {
     @Input() @InputBoolean() allowHalf = false;
 
     @Input() iconValue: string;

--- a/src/rate/rate.component.ts
+++ b/src/rate/rate.component.ts
@@ -19,7 +19,7 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { ThyStopPropagationDirective } from 'ngx-tethys/shared';
 import { ThyTooltipDirective } from 'ngx-tethys/tooltip';
-import { ThyRateItemComponent } from './rate-item.component';
+import { ThyRateItem } from './rate-item.component';
 
 const noop = () => {};
 
@@ -34,7 +34,7 @@ const noop = () => {};
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThyRateComponent),
+            useExisting: forwardRef(() => ThyRate),
             multi: true
         }
     ],
@@ -44,9 +44,9 @@ const noop = () => {};
     },
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgFor, ThyStopPropagationDirective, ThyRateItemComponent, NgClass, ThyTooltipDirective]
+    imports: [NgFor, ThyStopPropagationDirective, ThyRateItem, NgClass, ThyTooltipDirective]
 })
-export class ThyRateComponent extends TabIndexDisabledControlValueAccessorMixin implements ControlValueAccessor, OnInit, OnChanges {
+export class ThyRate extends TabIndexDisabledControlValueAccessorMixin implements ControlValueAccessor, OnInit, OnChanges {
     private _value = 0;
 
     private currentValue = 0;

--- a/src/rate/test/rate.spec.ts
+++ b/src/rate/test/rate.spec.ts
@@ -3,7 +3,7 @@ import { FormsModule } from '@angular/forms';
 import { ComponentFixture, TestBed, fakeAsync, tick, flush, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ThyRateModule } from '../module';
-import { ThyRateComponent } from '../rate.component';
+import { ThyRate } from '../rate.component';
 import { ThyTooltipDirective } from 'ngx-tethys/tooltip';
 import { dispatchFakeEvent } from 'ngx-tethys/testing';
 import { ThyRateTemplateExampleComponent } from '../examples/template/template.component';
@@ -36,7 +36,7 @@ describe('Rate basic component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(RateBasicTestComponent);
         testRateBasicComponent = fixture.debugElement.componentInstance;
-        rateBasicDebugComponent = fixture.debugElement.query(By.directive(ThyRateComponent));
+        rateBasicDebugComponent = fixture.debugElement.query(By.directive(ThyRate));
         rateBasicElement = rateBasicDebugComponent.nativeElement;
     });
 
@@ -133,7 +133,7 @@ describe('Rate count component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(RateCountTestComponent);
         testRateCountComponent = fixture.debugElement.componentInstance;
-        rateCountDebugComponent = fixture.debugElement.query(By.directive(ThyRateComponent));
+        rateCountDebugComponent = fixture.debugElement.query(By.directive(ThyRate));
         rateCountElement = rateCountDebugComponent.nativeElement;
     });
 
@@ -180,7 +180,7 @@ describe('Rate half component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(RateHalfTestComponent);
         testRateHalfComponent = fixture.debugElement.componentInstance;
-        rateHalfDebugComponent = fixture.debugElement.query(By.directive(ThyRateComponent));
+        rateHalfDebugComponent = fixture.debugElement.query(By.directive(ThyRate));
         rateHalfElement = rateHalfDebugComponent.nativeElement;
     });
 
@@ -251,7 +251,7 @@ describe('Rate clear component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(RateClearTestComponent);
         testRateClearComponent = fixture.debugElement.componentInstance;
-        rateClearDebugComponent = fixture.debugElement.query(By.directive(ThyRateComponent));
+        rateClearDebugComponent = fixture.debugElement.query(By.directive(ThyRate));
         rateClearElement = rateClearDebugComponent.nativeElement;
     });
 
@@ -321,7 +321,7 @@ describe('Rate disabled component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(RateDisabledTestComponent);
         testRateDisabledComponent = fixture.debugElement.componentInstance;
-        rateDisabledDebugComponent = fixture.debugElement.query(By.directive(ThyRateComponent));
+        rateDisabledDebugComponent = fixture.debugElement.query(By.directive(ThyRate));
         rateDisabledElement = rateDisabledDebugComponent.nativeElement;
     });
 
@@ -388,7 +388,7 @@ describe('Rate tooltip component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(RateTooltipTestComponent);
         testRateTooltipComponent = fixture.debugElement.componentInstance;
-        rateTooltipDebugComponent = fixture.debugElement.query(By.directive(ThyRateComponent));
+        rateTooltipDebugComponent = fixture.debugElement.query(By.directive(ThyRate));
         rateTooltipElement = rateTooltipDebugComponent.nativeElement;
     });
 
@@ -457,7 +457,7 @@ describe('Rate template component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(RateTemplateTestComponent);
         testRateTemplateComponent = fixture.debugElement.componentInstance;
-        rateTemplateDebugComponent = fixture.debugElement.query(By.directive(ThyRateComponent));
+        rateTemplateDebugComponent = fixture.debugElement.query(By.directive(ThyRate));
         rateTemplateElement = rateTemplateDebugComponent.nativeElement;
         templatesComponent = TestBed.createComponent(ThyRateTemplateExampleComponent).componentInstance;
     });

--- a/src/resizable/module.ts
+++ b/src/resizable/module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { ThyResizableDirective } from './resizable.directive';
-import { ThyResizeHandleComponent } from './resize-handle.component';
-import { ThyResizeHandlesComponent } from './resize-handles.component';
+import { ThyResizeHandle } from './resize-handle.component';
+import { ThyResizeHandles } from './resize-handles.component';
 import { CommonModule } from '@angular/common';
 
 @NgModule({
-    imports: [CommonModule, ThyResizableDirective, ThyResizeHandleComponent, ThyResizeHandlesComponent],
-    exports: [ThyResizableDirective, ThyResizeHandleComponent, ThyResizeHandlesComponent]
+    imports: [CommonModule, ThyResizableDirective, ThyResizeHandle, ThyResizeHandles],
+    exports: [ThyResizableDirective, ThyResizeHandle, ThyResizeHandles]
 })
 export class ThyResizableModule {}

--- a/src/resizable/resize-handle.component.ts
+++ b/src/resizable/resize-handle.component.ts
@@ -43,7 +43,7 @@ const passiveEventListenerOptions = <AddEventListenerOptions>normalizePassiveLis
     standalone: true,
     imports: [NgIf]
 })
-export class ThyResizeHandleComponent extends _MixinBase implements OnInit, OnDestroy {
+export class ThyResizeHandle extends _MixinBase implements OnInit, OnDestroy {
     /**
      * 调整方向
      * @type top | right | bottom | left | topRight | bottomRight | bottomLeft | topLeft

--- a/src/resizable/resize-handles.component.ts
+++ b/src/resizable/resize-handles.component.ts
@@ -1,7 +1,7 @@
 import { ChangeDetectionStrategy, Component, Input, OnChanges, SimpleChanges } from '@angular/core';
 import { InputBoolean } from 'ngx-tethys/core';
 import { ThyResizeDirection } from './interface';
-import { ThyResizeHandleComponent } from './resize-handle.component';
+import { ThyResizeHandle } from './resize-handle.component';
 import { NgFor } from '@angular/common';
 
 export const DEFAULT_RESIZE_DIRECTION: ThyResizeDirection[] = [
@@ -25,9 +25,9 @@ export const DEFAULT_RESIZE_DIRECTION: ThyResizeDirection[] = [
     template: ` <thy-resize-handle *ngFor="let dir of directions" [thyLine]="thyLine" [thyDirection]="dir"></thy-resize-handle> `,
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgFor, ThyResizeHandleComponent]
+    imports: [NgFor, ThyResizeHandle]
 })
-export class ThyResizeHandlesComponent implements OnChanges {
+export class ThyResizeHandles implements OnChanges {
     /**
      * 定义调整手柄的方向
      * @type ThyResizeDirection[]

--- a/src/result/result.component.ts
+++ b/src/result/result.component.ts
@@ -13,7 +13,7 @@ type ThyResultStatus = 'success' | 'warning' | 'error';
     standalone: true,
     imports: [NgIf, NgTemplateOutlet]
 })
-export class ThyResultComponent implements OnInit {
+export class ThyResult implements OnInit {
     /**
      * @description 结果的状态，决定显示的图标
      * @type success | warning | error

--- a/src/result/result.module.ts
+++ b/src/result/result.module.ts
@@ -1,9 +1,9 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyResultComponent } from './result.component';
+import { ThyResult } from './result.component';
 
 @NgModule({
-    imports: [CommonModule, ThyResultComponent],
-    exports: [ThyResultComponent]
+    imports: [CommonModule, ThyResult],
+    exports: [ThyResult]
 })
 export class ThyResultModule {}

--- a/src/result/test/result.spec.ts
+++ b/src/result/test/result.spec.ts
@@ -3,7 +3,7 @@ import { Component, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { ThyResultComponent } from '../result.component';
+import { ThyResult } from '../result.component';
 import { ThyResultModule } from '../result.module';
 
 describe('ThyResult', () => {
@@ -22,7 +22,7 @@ describe('ThyResult', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyResultDemoComponent);
         testComponent = fixture.debugElement.componentInstance;
-        thyResultComponent = fixture.debugElement.query(By.directive(ThyResultComponent));
+        thyResultComponent = fixture.debugElement.query(By.directive(ThyResult));
     });
 
     it('should create', () => {

--- a/src/segment/segment-item.component.ts
+++ b/src/segment/segment-item.component.ts
@@ -18,7 +18,7 @@ import { assertIconOnly } from 'ngx-tethys/util';
 import { Subject, fromEvent } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
 import { SafeAny } from 'ngx-tethys/types';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgClass, NgIf } from '@angular/common';
 
 /**
@@ -33,9 +33,9 @@ import { NgClass, NgIf } from '@angular/common';
         class: 'thy-segment-item'
     },
     standalone: true,
-    imports: [NgClass, NgIf, ThyIconComponent]
+    imports: [NgClass, NgIf, ThyIcon]
 })
-export class ThySegmentItemComponent implements AfterViewInit, OnDestroy {
+export class ThySegmentItem implements AfterViewInit, OnDestroy {
     /**
      * 选项的值
      */

--- a/src/segment/segment.component.ts
+++ b/src/segment/segment.component.ts
@@ -13,7 +13,7 @@ import {
 } from '@angular/core';
 import { InputBoolean, InputNumber, ThumbAnimationProps } from 'ngx-tethys/core';
 import { thumbMotion } from 'ngx-tethys/core';
-import { ThySegmentItemComponent } from './segment-item.component';
+import { ThySegmentItem } from './segment-item.component';
 import { IThySegmentComponent, THY_SEGMENTED_COMPONENT } from './segment.token';
 import { ThySegmentEvent } from './types';
 import { AnimationEvent } from '@angular/animations';
@@ -37,7 +37,7 @@ export type ThySegmentMode = 'block' | 'inline';
     providers: [
         {
             provide: THY_SEGMENTED_COMPONENT,
-            useExisting: ThySegmentComponent
+            useExisting: ThySegment
         }
     ],
     host: {
@@ -51,11 +51,11 @@ export type ThySegmentMode = 'block' | 'inline';
     standalone: true,
     imports: [NgIf]
 })
-export class ThySegmentComponent implements IThySegmentComponent, AfterContentInit {
+export class ThySegment implements IThySegmentComponent, AfterContentInit {
     /**
      * @internal
      */
-    @ContentChildren(ThySegmentItemComponent) options!: QueryList<ThySegmentItemComponent>;
+    @ContentChildren(ThySegmentItem) options!: QueryList<ThySegmentItem>;
 
     /**
      * 大小
@@ -100,7 +100,7 @@ export class ThySegmentComponent implements IThySegmentComponent, AfterContentIn
      */
     @Output() readonly thySelectChange = new EventEmitter<ThySegmentEvent>();
 
-    public selectedItem: ThySegmentItemComponent;
+    public selectedItem: ThySegmentItem;
 
     private activeIndex = 0;
 
@@ -115,7 +115,7 @@ export class ThySegmentComponent implements IThySegmentComponent, AfterContentIn
         this.selectedItem?.select();
     }
 
-    public changeSelectedItem(item: ThySegmentItemComponent, event?: Event): void {
+    public changeSelectedItem(item: ThySegmentItem, event?: Event): void {
         this.animationState = {
             value: 'from',
             params: getThumbAnimationProps(this.options?.get(this.activeIndex)?.elementRef.nativeElement!)

--- a/src/segment/segment.module.ts
+++ b/src/segment/segment.module.ts
@@ -2,11 +2,11 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyTooltipModule } from 'ngx-tethys/tooltip';
-import { ThySegmentComponent } from './segment.component';
-import { ThySegmentItemComponent } from './segment-item.component';
+import { ThySegment } from './segment.component';
+import { ThySegmentItem } from './segment-item.component';
 
 @NgModule({
-    imports: [CommonModule, ThyIconModule, ThyTooltipModule, ThySegmentComponent, ThySegmentItemComponent],
-    exports: [ThySegmentComponent, ThySegmentItemComponent]
+    imports: [CommonModule, ThyIconModule, ThyTooltipModule, ThySegment, ThySegmentItem],
+    exports: [ThySegment, ThySegmentItem]
 })
 export class ThySegmentModule {}

--- a/src/segment/segment.token.ts
+++ b/src/segment/segment.token.ts
@@ -1,11 +1,11 @@
 import { InjectionToken } from '@angular/core';
-import { ThySegmentItemComponent } from './segment-item.component';
+import { ThySegmentItem } from './segment-item.component';
 
 export interface IThySegmentComponent {
     thyMode: string;
     thyDisabled: boolean;
-    selectedItem: ThySegmentItemComponent;
-    changeSelectedItem: (item: ThySegmentItemComponent, event?: Event) => void;
+    selectedItem: ThySegmentItem;
+    changeSelectedItem: (item: ThySegmentItem, event?: Event) => void;
 }
 
 export const THY_SEGMENTED_COMPONENT = new InjectionToken<IThySegmentComponent>('THY_SEGMENTED_COMPONENT');

--- a/src/segment/test/segment.spec.ts
+++ b/src/segment/test/segment.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { By } from '@angular/platform-browser';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ThyAvatarModule } from 'ngx-tethys/avatar';
-import { ThySegmentComponent, ThySegmentEvent, ThySegmentItemComponent, ThySegmentModule, ThySegmentSize } from 'ngx-tethys/segment';
+import { ThySegment, ThySegmentEvent, ThySegmentItem, ThySegmentModule, ThySegmentSize } from 'ngx-tethys/segment';
 import { dispatchFakeEvent } from 'ngx-tethys/testing';
 import { ThySegmentMode } from '../segment.component';
 
@@ -155,7 +155,7 @@ describe('segment', () => {
         let fixture: ComponentFixture<TestSegmentBasicComponent>;
         let segmentedDebugElement: DebugElement;
         let segmentedElement: any;
-        let segmentedInstance: ThySegmentComponent;
+        let segmentedInstance: ThySegment;
 
         beforeEach(() => {
             TestBed.configureTestingModule({
@@ -164,7 +164,7 @@ describe('segment', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestSegmentBasicComponent);
-            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegmentComponent));
+            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegment));
             segmentedElement = segmentedDebugElement.nativeElement;
             segmentedInstance = segmentedDebugElement.componentInstance;
             fixture.detectChanges();
@@ -176,7 +176,7 @@ describe('segment', () => {
             expect(segmentedElement).toBeTruthy();
             expect(segmentedElement.classList.contains('thy-segment')).toBeTruthy();
 
-            const items = segmentedDebugElement.queryAll(By.directive(ThySegmentItemComponent));
+            const items = segmentedDebugElement.queryAll(By.directive(ThySegmentItem));
             expect(items).toBeTruthy();
             expect(items.length).toBe(3);
         });
@@ -207,7 +207,7 @@ describe('segment', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestSegmentOnlyTextComponent);
-            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegmentComponent));
+            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegment));
             fixture.detectChanges();
         });
 
@@ -230,7 +230,7 @@ describe('segment', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestSegmentOnlyIconComponent);
-            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegmentComponent));
+            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegment));
             fixture.detectChanges();
         });
 
@@ -253,7 +253,7 @@ describe('segment', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestSegmentIconAndTextComponent);
-            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegmentComponent));
+            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegment));
             fixture.detectChanges();
         });
 
@@ -278,7 +278,7 @@ describe('segment', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestSegmentSizeComponent);
-            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegmentComponent));
+            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegment));
             fixture.detectChanges();
         });
 
@@ -307,7 +307,7 @@ describe('segment', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestSegmentDisabledComponent);
-            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegmentComponent));
+            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegment));
             segmentedElement = segmentedDebugElement.nativeElement;
             testInstance = fixture.debugElement.componentInstance;
             fixture.detectChanges();
@@ -328,7 +328,7 @@ describe('segment', () => {
             const spy = spyOn(testInstance, 'selectedChange');
             testInstance.disableItem = true;
             fixture.detectChanges();
-            const disabledItem = segmentedDebugElement.queryAll(By.directive(ThySegmentItemComponent))[2].nativeElement;
+            const disabledItem = segmentedDebugElement.queryAll(By.directive(ThySegmentItem))[2].nativeElement;
             dispatchFakeEvent(disabledItem, 'click');
             fixture.detectChanges();
             expect(spy).not.toHaveBeenCalled();
@@ -347,7 +347,7 @@ describe('segment', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestSegmentModeComponent);
-            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegmentComponent));
+            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegment));
             fixture.detectChanges();
         });
 
@@ -377,12 +377,12 @@ describe('segment', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestSegmentActiveComponent);
-            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegmentComponent));
+            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegment));
             fixture.detectChanges();
         });
 
         it('should support set default selected item', () => {
-            const items = segmentedDebugElement.queryAll(By.directive(ThySegmentItemComponent));
+            const items = segmentedDebugElement.queryAll(By.directive(ThySegmentItem));
             expect(items[2].nativeElement.classList.contains('active')).toBeTruthy();
         });
 
@@ -419,7 +419,7 @@ describe('segment', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestSegmentCustomTemplateComponent);
-            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegmentComponent));
+            segmentedDebugElement = fixture.debugElement.query(By.directive(ThySegment));
             fixture.detectChanges();
         });
 
@@ -435,6 +435,6 @@ describe('segment', () => {
     });
 
     function getSegmentItemByIndex(index: number, debugElement: any): DebugElement {
-        return debugElement.queryAll(By.directive(ThySegmentItemComponent))[index];
+        return debugElement.queryAll(By.directive(ThySegmentItem))[index];
     }
 });

--- a/src/select/custom-select.spec.ts
+++ b/src/select/custom-select.spec.ts
@@ -19,15 +19,10 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { ThyFormModule } from '../form';
 import { DOWN_ARROW, END, ENTER, ESCAPE, HOME } from '../util/keycodes';
-import {
-    SelectMode,
-    THY_SELECT_PANEL_MIN_WIDTH,
-    ThySelectCustomComponent,
-    ThySelectOptionModel
-} from './custom-select/custom-select.component';
+import { SelectMode, THY_SELECT_PANEL_MIN_WIDTH, ThySelectCustom, ThySelectOptionModel } from './custom-select/custom-select.component';
 import { ThySelectModule } from './module';
 import { THY_SELECT_CONFIG, THY_SELECT_SCROLL_STRATEGY, ThyDropdownWidthMode } from './select.config';
-import { SelectControlSize, ThyOptionComponent, ThyOptionModule } from 'ngx-tethys/shared';
+import { SelectControlSize, ThyOption, ThyOptionModule } from 'ngx-tethys/shared';
 
 interface FoodsInfo {
     value: string | string[];
@@ -85,8 +80,8 @@ class BasicSelectComponent {
     thyAutoActiveFirstItem = true;
     customizeOrigin: ElementRef | HTMLElement;
     borderless = false;
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
 
     @ViewChild('footer', { static: true, read: TemplateRef })
     footerTemplate: TemplateRef<any>;
@@ -123,8 +118,8 @@ class MultipleSelectComponent {
 
     selectedFoods: any[] = [];
 
-    @ViewChild('Foods', { static: true }) foodsComponent: ThySelectCustomComponent;
-    @ViewChild('Vegetables', { static: true }) vegetablesComponent: ThySelectCustomComponent;
+    @ViewChild('Foods', { static: true }) foodsComponent: ThySelectCustom;
+    @ViewChild('Vegetables', { static: true }) vegetablesComponent: ThySelectCustom;
 }
 
 @Component({
@@ -145,8 +140,8 @@ class NgModelSelectComponent {
     ];
     isDisabled: boolean;
 
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
 }
 
 @Component({
@@ -191,8 +186,8 @@ class SingleSelectWithPreselectedArrayValuesComponent {
 
     selectedFoods = this.foods[1].value;
 
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
 }
 
 @Component({
@@ -213,8 +208,8 @@ class SingleSelectNgModelComponent {
 
     selectedValues = this.values[1].value;
 
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
 }
 
 @Component({
@@ -270,8 +265,8 @@ class SelectWithSearchComponent {
     ];
     thyShowSearch = false;
     control = new UntypedFormControl();
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
 }
 
 @Component({
@@ -314,8 +309,8 @@ class SelectWithSearchUseSearchKeyComponent {
     ];
     thyShowSearch = true;
     control = new UntypedFormControl();
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
 }
 
 @Component({
@@ -355,8 +350,8 @@ class SelectWithSearchAndGroupComponent {
         }
     ];
     thyEmptySearchMessageText = 'empty result';
-    @ViewChild(ThySelectCustomComponent, { static: true })
-    select: ThySelectCustomComponent;
+    @ViewChild(ThySelectCustom, { static: true })
+    select: ThySelectCustom;
 }
 
 @Component({
@@ -393,8 +388,8 @@ class SelectWithSearchAndServerSearchComponent {
     selected = this.foods[7];
     thyShowSearch = true;
     control = new UntypedFormControl();
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
     thyOnSearch = jasmine.createSpy('thyServerSearch callback');
 }
 
@@ -437,8 +432,8 @@ class SelectEimtOptionsChangesComponent {
     thyAllowClear = true;
     disabled = false;
     isRequired: boolean;
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
 }
 
 @Component({
@@ -460,7 +455,7 @@ class SelectWithExpandStatusComponent {
     foods: FoodsInfo[] = [{ value: 'pizza-1', viewValue: 'Pizza' }];
     control = new UntypedFormControl();
     thyOnExpandStatusChange = jasmine.createSpy('thyOnExpandStatusChange callback');
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
 }
 
 @Component({
@@ -483,8 +478,8 @@ class SelectWithThyModeComponent {
 
     selectedFoods: string[] = null;
 
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
 }
 
 @Component({
@@ -510,12 +505,12 @@ class SelectWithThySortComparatorComponent {
 
     selectMode: SelectMode = 'multiple';
 
-    thySortComparator: (a: ThyOptionComponent, b: ThyOptionComponent, options: ThyOptionComponent[]) => number;
+    thySortComparator: (a: ThyOption, b: ThyOption, options: ThyOption[]) => number;
 
     selectedFoods: string[] = null;
 
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
 }
 
 @Component({
@@ -531,7 +526,7 @@ class SelectWithThyAutoExpendComponent implements OnInit {
 
     isAutoExpend = true;
 
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
 
     constructor() {}
 
@@ -557,7 +552,7 @@ class SelectWithThyPlacementComponent implements OnInit {
 
     thyPlacement: ThyPlacement = 'top';
 
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
 
     constructor() {}
 
@@ -600,8 +595,8 @@ class SelectWithScrollAndSearchComponent {
     serverSearch = true;
     selected: any = null;
     control = new UntypedFormControl();
-    @ViewChild(ThySelectCustomComponent, { static: true }) select: ThySelectCustomComponent;
-    @ViewChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ViewChild(ThySelectCustom, { static: true }) select: ThySelectCustom;
+    @ViewChildren(ThyOption) options: QueryList<ThyOption>;
     thyOnSearch(value: string) {
         timer(100).subscribe(() => {
             this.foods = this.foods.slice(5);
@@ -619,7 +614,7 @@ class SelectWithScrollAndSearchComponent {
     `
 })
 class SelectWithAsyncLoadComponent implements OnInit {
-    @ViewChild(ThySelectCustomComponent) customSelect: ThySelectCustomComponent;
+    @ViewChild(ThySelectCustom) customSelect: ThySelectCustom;
 
     loadState = true;
 
@@ -769,7 +764,7 @@ describe('ThyCustomSelect', () => {
                 fixture.detectChanges();
                 flush();
 
-                const componentInstance = fixture.debugElement.query(By.directive(ThySelectCustomComponent)).componentInstance;
+                const componentInstance = fixture.debugElement.query(By.directive(ThySelectCustom)).componentInstance;
                 expect(componentInstance.dropDownPositions[0].originY).toEqual('bottom');
             }));
 
@@ -795,7 +790,7 @@ describe('ThyCustomSelect', () => {
             });
 
             it('should auto focus to input element when select focus', fakeAsync(() => {
-                const customSelectDebugElement = fixture.debugElement.query(By.directive(ThySelectCustomComponent));
+                const customSelectDebugElement = fixture.debugElement.query(By.directive(ThySelectCustom));
                 fixture.detectChanges();
                 const focusSpy = spyOn(fixture.componentInstance.select, 'onFocus').and.callThrough();
 
@@ -838,7 +833,7 @@ describe('ThyCustomSelect', () => {
             }));
 
             it('should call onBlur methods when blur', fakeAsync(() => {
-                const customSelectDebugElement = fixture.debugElement.query(By.directive(ThySelectCustomComponent));
+                const customSelectDebugElement = fixture.debugElement.query(By.directive(ThySelectCustom));
                 fixture.detectChanges();
                 const blurSpy = spyOn(fixture.componentInstance.select, 'onBlur').and.callThrough();
 
@@ -1007,7 +1002,7 @@ describe('ThyCustomSelect', () => {
             }));
 
             it('should update the width of the panel on resize', fakeAsync(() => {
-                const selectSelectCustomComponentDebugElement = fixture.debugElement.query(By.directive(ThySelectCustomComponent));
+                const selectSelectCustomComponentDebugElement = fixture.debugElement.query(By.directive(ThySelectCustom));
                 const resizedSpy = spyOn(selectSelectCustomComponentDebugElement.componentInstance, 'getOriginRectWidth');
                 trigger.style.width = '300px';
                 resizedSpy.and.callThrough();
@@ -2279,7 +2274,7 @@ describe('ThyCustomSelect', () => {
             testComponent.thyPlacement = placement;
             fixture.detectChanges();
 
-            const selectComponent = fixture.debugElement.query(By.directive(ThySelectCustomComponent)).componentInstance;
+            const selectComponent = fixture.debugElement.query(By.directive(ThySelectCustom)).componentInstance;
             selectComponent.ngOnInit();
             fixture.detectChanges();
             flush();

--- a/src/select/custom-select/custom-select.component.ts
+++ b/src/select/custom-select/custom-select.component.ts
@@ -10,18 +10,18 @@ import {
     ThyClickDispatcher,
     ThyPlacement
 } from 'ngx-tethys/core';
-import { ThyEmptyComponent } from 'ngx-tethys/empty';
-import { ThyLoadingComponent } from 'ngx-tethys/loading';
+import { ThyEmpty } from 'ngx-tethys/empty';
+import { ThyLoading } from 'ngx-tethys/loading';
 import {
     IThyOptionParentComponent,
     SelectControlSize,
     THY_OPTION_PARENT_COMPONENT,
-    ThyOptionComponent,
-    ThyOptionsContainerComponent,
+    ThyOption,
+    ThyOptionsContainer,
     ThyOptionSelectionChangeEvent,
     ThyScrollDirective,
-    ThySelectControlComponent,
-    ThySelectOptionGroupComponent,
+    ThySelectControl,
+    ThySelectOptionGroup,
     ThyStopPropagationDirective
 } from 'ngx-tethys/shared';
 import {
@@ -133,11 +133,11 @@ const noop = () => {};
     providers: [
         {
             provide: THY_OPTION_PARENT_COMPONENT,
-            useExisting: ThySelectCustomComponent
+            useExisting: ThySelectCustom
         },
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThySelectCustomComponent),
+            useExisting: forwardRef(() => ThySelectCustom),
             multi: true
         }
     ],
@@ -145,17 +145,17 @@ const noop = () => {};
     standalone: true,
     imports: [
         CdkOverlayOrigin,
-        ThySelectControlComponent,
+        ThySelectControl,
         CdkConnectedOverlay,
         ThyStopPropagationDirective,
         NgClass,
         NgIf,
         ThyScrollDirective,
-        ThyLoadingComponent,
-        ThyEmptyComponent,
-        ThyOptionsContainerComponent,
-        ThyOptionComponent,
-        ThySelectOptionGroupComponent,
+        ThyLoading,
+        ThyEmpty,
+        ThyOptionsContainer,
+        ThyOption,
+        ThySelectOptionGroup,
         NgTemplateOutlet,
         NgFor
     ],
@@ -166,7 +166,7 @@ const noop = () => {};
     },
     animations: [scaleXMotion, scaleYMotion, scaleMotion]
 })
-export class ThySelectCustomComponent
+export class ThySelectCustom
     extends TabIndexDisabledControlValueAccessorMixin
     implements ControlValueAccessor, IThyOptionParentComponent, OnInit, AfterViewInit, AfterContentInit, OnDestroy
 {
@@ -198,7 +198,7 @@ export class ThySelectCustomComponent
 
     public dropDownPositions: ConnectionPositionPair[];
 
-    public selectionModel: SelectionModel<ThyOptionComponent>;
+    public selectionModel: SelectionModel<ThyOption>;
 
     public triggerRectWidth: number;
 
@@ -233,7 +233,7 @@ export class ThySelectCustomComponent
 
     @HostBinding('class.thy-select') isSelect = true;
 
-    keyManager: ActiveDescendantKeyManager<ThyOptionComponent>;
+    keyManager: ActiveDescendantKeyManager<ThyOption>;
 
     @HostBinding('class.menu-is-opened')
     panelOpen = false;
@@ -353,7 +353,7 @@ export class ThySelectCustomComponent
     /**
      * 排序比较函数
      */
-    @Input() thySortComparator: (a: ThyOptionComponent, b: ThyOptionComponent, options: ThyOptionComponent[]) => number;
+    @Input() thySortComparator: (a: ThyOption, b: ThyOption, options: ThyOption[]) => number;
 
     /**
      * Footer 模板，默认值为空不显示 Footer
@@ -430,7 +430,7 @@ export class ThySelectCustomComponent
         this.buildReactiveOptions();
     }
 
-    options: QueryList<ThyOptionComponent>;
+    options: QueryList<ThyOption>;
 
     /**
      * 目前只支持多选选中项的展示，默认为空，渲染文字模板，传入tag，渲染展示模板,
@@ -445,16 +445,16 @@ export class ThySelectCustomComponent
     /**
      * @private
      */
-    @ContentChildren(ThyOptionComponent, { descendants: true }) contentOptions: QueryList<ThyOptionComponent>;
+    @ContentChildren(ThyOption, { descendants: true }) contentOptions: QueryList<ThyOption>;
 
-    @ViewChildren(ThyOptionComponent) viewOptions: QueryList<ThyOptionComponent>;
+    @ViewChildren(ThyOption) viewOptions: QueryList<ThyOption>;
 
     /**
      * @private
      */
-    @ContentChildren(ThySelectOptionGroupComponent) contentGroups: QueryList<ThySelectOptionGroupComponent>;
+    @ContentChildren(ThySelectOptionGroup) contentGroups: QueryList<ThySelectOptionGroup>;
 
-    @ViewChildren(ThySelectOptionGroupComponent) viewGroups: QueryList<ThySelectOptionGroupComponent>;
+    @ViewChildren(ThySelectOptionGroup) viewGroups: QueryList<ThySelectOptionGroup>;
 
     @HostListener('keydown', ['$event'])
     handleKeydown(event: KeyboardEvent): void {
@@ -468,7 +468,7 @@ export class ThySelectCustomComponent
 
     get optionsChanges$() {
         this.options = this.isReactiveDriven ? this.viewOptions : this.contentOptions;
-        let previousOptions: ThyOptionComponent[] = this.options.toArray();
+        let previousOptions: ThyOption[] = this.options.toArray();
         return this.options.changes.pipe(
             map(data => {
                 return this.options.toArray();
@@ -717,7 +717,7 @@ export class ThySelectCustomComponent
         this.manualFocusing = false;
     }
 
-    public remove($event: { item: ThyOptionComponent; $eventOrigin: Event }) {
+    public remove($event: { item: ThyOption; $eventOrigin: Event }) {
         $event.$eventOrigin.stopPropagation();
         if (this.disabled) {
             return;
@@ -751,7 +751,7 @@ export class ThySelectCustomComponent
         });
     }
 
-    public get selected(): ThyOptionComponent | ThyOptionComponent[] {
+    public get selected(): ThyOption | ThyOption[] {
         return this.isMultiple ? this.selectionModel.selected : this.selectionModel.selected[0];
     }
 
@@ -802,7 +802,7 @@ export class ThySelectCustomComponent
 
     private emitModelValueChange() {
         const selectedValues = this.selectionModel.selected;
-        const changeValue = selectedValues.map((option: ThyOptionComponent) => {
+        const changeValue = selectedValues.map((option: ThyOption) => {
             return option.thyValue;
         });
         if (this.isMultiple) {
@@ -846,7 +846,7 @@ export class ThySelectCustomComponent
         if (this.keyManager && this.keyManager.activeItem) {
             this.keyManager.activeItem.setInactiveStyles();
         }
-        this.keyManager = new ActiveDescendantKeyManager<ThyOptionComponent>(this.options)
+        this.keyManager = new ActiveDescendantKeyManager<ThyOption>(this.options)
             .withTypeAhead()
             .withWrap()
             .withVerticalOrientation()
@@ -944,7 +944,7 @@ export class ThySelectCustomComponent
         if (this.selectionModel) {
             this.selectionModel.clear();
         }
-        this.selectionModel = new SelectionModel<ThyOptionComponent>(this.isMultiple);
+        this.selectionModel = new SelectionModel<ThyOption>(this.isMultiple);
         if (this.selectionModelSubscription) {
             this.selectionModelSubscription.unsubscribe();
             this.selectionModelSubscription = null;
@@ -1018,7 +1018,7 @@ export class ThySelectCustomComponent
         this.changeDetectorRef.markForCheck();
     }
 
-    private onSelect(option: ThyOptionComponent, isUserInput: boolean) {
+    private onSelect(option: ThyOption, isUserInput: boolean) {
         const wasSelected = this.selectionModel.isSelected(option);
 
         if (option.thyValue == null && !this.isMultiple) {

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -1,4 +1,4 @@
 export * from './module';
-export { ThySelectCustomComponent } from './custom-select/custom-select.component';
-export { ThySelectComponent } from './select.component';
+export { ThySelectCustom } from './custom-select/custom-select.component';
+export { ThySelect } from './select.component';
 export * from './select.config';

--- a/src/select/module.ts
+++ b/src/select/module.ts
@@ -7,8 +7,8 @@ import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyInputModule } from 'ngx-tethys/input';
 import { ThyLoadingModule } from 'ngx-tethys/loading';
 import { ThyOptionModule, ThySelectCommonModule, ThySharedModule } from 'ngx-tethys/shared';
-import { ThySelectCustomComponent } from './custom-select/custom-select.component';
-import { ThySelectComponent } from './select.component';
+import { ThySelectCustom } from './custom-select/custom-select.component';
+import { ThySelect } from './select.component';
 import { THY_SELECT_CONFIG_PROVIDER, THY_SELECT_SCROLL_STRATEGY_PROVIDER } from './select.config';
 
 @NgModule({
@@ -23,10 +23,10 @@ import { THY_SELECT_CONFIG_PROVIDER, THY_SELECT_SCROLL_STRATEGY_PROVIDER } from 
         ThyEmptyModule,
         ThySelectCommonModule,
         ThyOptionModule,
-        ThySelectComponent,
-        ThySelectCustomComponent
+        ThySelect,
+        ThySelectCustom
     ],
-    exports: [ThySelectComponent, ThySelectCustomComponent, ThyOptionModule],
+    exports: [ThySelect, ThySelectCustom, ThyOptionModule],
     providers: [THY_SELECT_SCROLL_STRATEGY_PROVIDER, THY_SELECT_CONFIG_PROVIDER]
 })
 export class ThySelectModule {}

--- a/src/select/select.component.ts
+++ b/src/select/select.component.ts
@@ -6,7 +6,7 @@ import { elementMatchClosest } from 'ngx-tethys/util';
 import { NgIf } from '@angular/common';
 import { ElementRef, ViewChild } from '@angular/core';
 import { useHostRenderer } from '@tethys/cdk/dom';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { ThyInputDirective } from 'ngx-tethys/input';
 
 export type InputSize = 'xs' | 'sm' | 'md' | 'lg' | '';
@@ -24,19 +24,19 @@ const noop = () => {};
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThySelectComponent),
+            useExisting: forwardRef(() => ThySelect),
             multi: true
         }
     ],
     standalone: true,
-    imports: [ThyInputDirective, FormsModule, ThyIconComponent, NgIf],
+    imports: [ThyInputDirective, FormsModule, ThyIcon, NgIf],
     host: {
         '[attr.tabindex]': 'tabIndex',
         '(focus)': 'onFocus($event)',
         '(blur)': 'onBlur($event)'
     }
 })
-export class ThySelectComponent extends TabIndexDisabledControlValueAccessorMixin implements ControlValueAccessor, OnInit {
+export class ThySelect extends TabIndexDisabledControlValueAccessorMixin implements ControlValueAccessor, OnInit {
     @ViewChild('select', { static: true }) selectElement: ElementRef<any>;
 
     // The internal data model

--- a/src/select/select.spec.ts
+++ b/src/select/select.spec.ts
@@ -1,4 +1,4 @@
-import { ThySelectComponent } from 'ngx-tethys/select';
+import { ThySelect } from 'ngx-tethys/select';
 
 import { Component, DebugElement, Sanitizer, SecurityContext, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
@@ -24,7 +24,7 @@ import { ThySelectModule } from './module';
     `
 })
 class BasicSelectComponent {
-    @ViewChild(ThySelectComponent, { static: false }) selectComponent: ThySelectComponent;
+    @ViewChild(ThySelect, { static: false }) selectComponent: ThySelect;
 
     value = '';
     allowClear = false;
@@ -68,7 +68,7 @@ describe(`select`, () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(BasicSelectComponent);
             testComponent = fixture.debugElement.componentInstance;
-            debugComponent = fixture.debugElement.query(By.directive(ThySelectComponent));
+            debugComponent = fixture.debugElement.query(By.directive(ThySelect));
             selectElement = debugComponent.nativeElement;
             selectElementChildren = selectElement.children;
         });

--- a/src/shared/option/group/option-group.component.ts
+++ b/src/shared/option/group/option-group.component.ts
@@ -10,7 +10,7 @@ import {
     ChangeDetectorRef
 } from '@angular/core';
 import { Observable, defer, Subject, merge } from 'rxjs';
-import { ThyOptionVisibleChangeEvent, ThyOptionComponent } from '../option.component';
+import { ThyOptionVisibleChangeEvent, ThyOption } from '../option.component';
 import { take, switchMap, startWith, takeUntil, debounceTime, map } from 'rxjs/operators';
 import { THY_OPTION_GROUP_COMPONENT } from '../option.token';
 import { InputBoolean } from 'ngx-tethys/core';
@@ -24,12 +24,12 @@ import { InputBoolean } from 'ngx-tethys/core';
     providers: [
         {
             provide: THY_OPTION_GROUP_COMPONENT,
-            useExisting: ThySelectOptionGroupComponent
+            useExisting: ThySelectOptionGroup
         }
     ],
     standalone: true
 })
-export class ThySelectOptionGroupComponent implements OnDestroy, AfterContentInit {
+export class ThySelectOptionGroup implements OnDestroy, AfterContentInit {
     _hidden = false;
     @Input()
     @InputBoolean()
@@ -45,7 +45,7 @@ export class ThySelectOptionGroupComponent implements OnDestroy, AfterContentIni
 
     @Input() thyGroupLabel: string;
 
-    @ContentChildren(ThyOptionComponent) options: QueryList<ThyOptionComponent>;
+    @ContentChildren(ThyOption) options: QueryList<ThyOption>;
 
     _destroy$: Subject<void> = new Subject<void>();
 

--- a/src/shared/option/list-option/list-option.component.ts
+++ b/src/shared/option/list-option/list-option.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, HostBinding, ElementRef, ChangeDetectorRef, Inject, H
 import { Highlightable } from '@angular/cdk/a11y';
 import { coerceBooleanProperty } from 'ngx-tethys/util';
 import { IThyListOptionParentComponent, THY_LIST_OPTION_PARENT_COMPONENT } from '../option.token';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf } from '@angular/common';
 import { InputBoolean } from 'ngx-tethys/core';
 
@@ -18,9 +18,9 @@ export type ThyListLayout = 'list' | 'grid';
     selector: 'thy-list-option,[thy-list-option]',
     templateUrl: './list-option.component.html',
     standalone: true,
-    imports: [NgIf, ThyIconComponent]
+    imports: [NgIf, ThyIcon]
 })
-export class ThyListOptionComponent implements Highlightable {
+export class ThyListOption implements Highlightable {
     @HostBinding(`class.thy-list-option`)
     get _isListOption() {
         return this.parentSelectionList.layout === 'list';

--- a/src/shared/option/module.ts
+++ b/src/shared/option/module.ts
@@ -9,29 +9,15 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { ThyListOptionComponent } from './list-option/list-option.component';
-import { ThyOptionGroupComponent } from './option-group.component';
+import { ThyListOption } from './list-option/list-option.component';
+import { ThyOptionGroup } from './option-group.component';
 import { ThyIconModule } from 'ngx-tethys/icon';
-import { ThyOptionComponent } from './option.component';
-import { ThySelectOptionGroupComponent } from './group/option-group.component';
-import { ThyOptionsContainerComponent } from './options-container.component';
+import { ThyOption } from './option.component';
+import { ThySelectOptionGroup } from './group/option-group.component';
+import { ThyOptionsContainer } from './options-container.component';
 
 @NgModule({
-    imports: [
-        CommonModule,
-        ThyIconModule,
-        ThyListOptionComponent,
-        ThyOptionGroupComponent,
-        ThyOptionComponent,
-        ThySelectOptionGroupComponent,
-        ThyOptionsContainerComponent
-    ],
-    exports: [
-        ThyListOptionComponent,
-        ThyOptionGroupComponent,
-        ThyOptionComponent,
-        ThySelectOptionGroupComponent,
-        ThyOptionsContainerComponent
-    ]
+    imports: [CommonModule, ThyIconModule, ThyListOption, ThyOptionGroup, ThyOption, ThySelectOptionGroup, ThyOptionsContainer],
+    exports: [ThyListOption, ThyOptionGroup, ThyOption, ThySelectOptionGroup, ThyOptionsContainer]
 })
 export class ThyOptionModule {}

--- a/src/shared/option/option-group.component.ts
+++ b/src/shared/option/option-group.component.ts
@@ -13,7 +13,7 @@ const _MixinBase: ThyCanDisableCtor & typeof MixinBase = mixinDisabled(MixinBase
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true
 })
-export class ThyOptionGroupComponent extends _MixinBase implements ThyCanDisable {
+export class ThyOptionGroup extends _MixinBase implements ThyCanDisable {
     set thyDisabled(value: any) {
         this.thyDisabled = value;
     }

--- a/src/shared/option/option.component.ts
+++ b/src/shared/option/option.component.ts
@@ -25,14 +25,14 @@ import {
 } from './option.token';
 import { NgIf } from '@angular/common';
 import { InputBoolean } from 'ngx-tethys/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 
 export class ThyOptionSelectionChangeEvent {
-    constructor(public option: ThyOptionComponent, public isUserInput = false) {}
+    constructor(public option: ThyOption, public isUserInput = false) {}
 }
 
 export class ThyOptionVisibleChangeEvent {
-    option: ThyOptionComponent;
+    option: ThyOption;
 }
 
 /**
@@ -44,9 +44,9 @@ export class ThyOptionVisibleChangeEvent {
     templateUrl: './option.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [NgIf, ThyIconComponent]
+    imports: [NgIf, ThyIcon]
 })
-export class ThyOptionComponent extends SelectOptionBase implements OnDestroy, Highlightable {
+export class ThyOption extends SelectOptionBase implements OnDestroy, Highlightable {
     private _selected = false;
     private _hidden = false;
     private _disabled = false;

--- a/src/shared/option/option.token.ts
+++ b/src/shared/option/option.token.ts
@@ -1,6 +1,6 @@
 import { InjectionToken } from '@angular/core';
-import { ThySelectOptionGroupComponent } from './group/option-group.component';
-import { ThyListLayout, ThyListOptionComponent } from './list-option/list-option.component';
+import { ThySelectOptionGroup } from './group/option-group.component';
+import { ThyListLayout, ThyListOption } from './list-option/list-option.component';
 
 export interface IThyOptionParentComponent {
     isMultiple: boolean;
@@ -14,12 +14,12 @@ export interface IThyListOptionParentComponent {
     multiple?: boolean;
     layout?: ThyListLayout;
     // 选择，取消选择 option
-    toggleOption(option: ThyListOptionComponent, event?: Event): void;
+    toggleOption(option: ThyListOption, event?: Event): void;
     // 设置当前选项为激活状态，即 hover 状态
-    setActiveOption(option: ThyListOptionComponent, event?: Event): void;
+    setActiveOption(option: ThyListOption, event?: Event): void;
     // 滚动到当前的选项
-    scrollIntoView(option: ThyListOptionComponent): void;
-    isSelected(option: ThyListOptionComponent): boolean;
+    scrollIntoView(option: ThyListOption): void;
+    isSelected(option: ThyListOption): boolean;
 }
 
 /**
@@ -30,7 +30,7 @@ export const THY_OPTION_PARENT_COMPONENT = new InjectionToken<IThyOptionParentCo
 /**
  * Injection token used to provide the parent component to options.
  */
-export const THY_OPTION_GROUP_COMPONENT = new InjectionToken<ThySelectOptionGroupComponent>('THY_OPTION_GROUP_COMPONENT');
+export const THY_OPTION_GROUP_COMPONENT = new InjectionToken<ThySelectOptionGroup>('THY_OPTION_GROUP_COMPONENT');
 
 /**
  * Injection token used to provide the parent component to options.

--- a/src/shared/option/options-container.component.ts
+++ b/src/shared/option/options-container.component.ts
@@ -10,7 +10,7 @@ import { ChangeDetectionStrategy, Component, OnInit, TemplateRef, ViewChild } fr
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true
 })
-export class ThyOptionsContainerComponent implements OnInit {
+export class ThyOptionsContainer implements OnInit {
     @ViewChild('options') optionsTemplate: TemplateRef<any>;
 
     constructor() {}

--- a/src/shared/select/module.ts
+++ b/src/shared/select/module.ts
@@ -13,10 +13,10 @@ import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
-import { ThySelectControlComponent } from './select-control/select-control.component';
+import { ThySelectControl } from './select-control/select-control.component';
 
 @NgModule({
-    imports: [CommonModule, FormsModule, ThyIconModule, ThyTagModule, ThySelectControlComponent],
-    exports: [ThySelectControlComponent]
+    imports: [CommonModule, FormsModule, ThyIconModule, ThyTagModule, ThySelectControl],
+    exports: [ThySelectControl]
 })
 export class ThySelectCommonModule {}

--- a/src/shared/select/select-control/select-control.component.ts
+++ b/src/shared/select/select-control/select-control.component.ts
@@ -18,8 +18,8 @@ import { useHostRenderer } from '@tethys/cdk/dom';
 
 import { NgClass, NgFor, NgIf, NgStyle, NgTemplateOutlet } from '@angular/common';
 import { FormsModule } from '@angular/forms';
-import { ThyIconComponent } from 'ngx-tethys/icon';
-import { ThyTagComponent } from 'ngx-tethys/tag';
+import { ThyIcon } from 'ngx-tethys/icon';
+import { ThyTag } from 'ngx-tethys/tag';
 import { SelectOptionBase } from '../../option/select-option-base';
 import { ThyGridModule } from 'ngx-tethys/grid';
 
@@ -33,12 +33,12 @@ export type SelectControlSize = 'sm' | 'md' | 'lg' | '';
     templateUrl: './select-control.component.html',
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true,
-    imports: [FormsModule, NgClass, NgIf, NgStyle, NgFor, ThyTagComponent, NgTemplateOutlet, ThyIconComponent, ThyGridModule],
+    imports: [FormsModule, NgClass, NgIf, NgStyle, NgFor, ThyTag, NgTemplateOutlet, ThyIcon, ThyGridModule],
     host: {
         '[class.select-control-borderless]': 'thyBorderless'
     }
 })
-export class ThySelectControlComponent implements OnInit {
+export class ThySelectControl implements OnInit {
     inputValue = '';
 
     isComposing = false;

--- a/src/shared/select/select-control/select-control.spec.ts
+++ b/src/shared/select/select-control/select-control.spec.ts
@@ -5,7 +5,7 @@ import { Component, ViewChild } from '@angular/core';
 import { ThyFormModule } from '../../../form';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { ThyIconModule } from '../../../icon/icon.module';
-import { ThySelectControlComponent, SelectControlSize } from './select-control.component';
+import { ThySelectControl, SelectControlSize } from './select-control.component';
 import { SelectOptionBase } from '../../option';
 
 @Component({
@@ -45,8 +45,8 @@ class BasicSelectControlComponent {
 
     borderless = false;
 
-    @ViewChild(ThySelectControlComponent, { static: true })
-    selectControlComponent: ThySelectControlComponent;
+    @ViewChild(ThySelectControl, { static: true })
+    selectControlComponent: ThySelectControl;
 }
 
 describe('ThySelectControl', () => {

--- a/src/skeleton/module.ts
+++ b/src/skeleton/module.ts
@@ -4,21 +4,14 @@ import { PortalModule } from '@angular/cdk/portal';
 import { ThyGridModule } from 'ngx-tethys/grid';
 import { ThyListModule } from 'ngx-tethys/list';
 
-import { ThySkeletonComponent } from './skeleton.component';
-import { ThySkeletonRectangleComponent } from './skeleton-rectangle.component';
-import { ThySkeletonCircleComponent } from './skeleton-circle.component';
-import { ThySkeletonListComponent } from './stylized/list.component';
-import { ThySkeletonParagraphComponent } from './stylized/paragraph.component';
-import { ThySkeletonBulletListComponent } from './stylized/bullet-list.component';
+import { ThySkeleton } from './skeleton.component';
+import { ThySkeletonRectangle } from './skeleton-rectangle.component';
+import { ThySkeletonCircle } from './skeleton-circle.component';
+import { ThySkeletonList } from './stylized/list.component';
+import { ThySkeletonParagraph } from './stylized/paragraph.component';
+import { ThySkeletonBulletList } from './stylized/bullet-list.component';
 
-const components = [
-    ThySkeletonComponent,
-    ThySkeletonRectangleComponent,
-    ThySkeletonCircleComponent,
-    ThySkeletonListComponent,
-    ThySkeletonParagraphComponent,
-    ThySkeletonBulletListComponent
-];
+const components = [ThySkeleton, ThySkeletonRectangle, ThySkeletonCircle, ThySkeletonList, ThySkeletonParagraph, ThySkeletonBulletList];
 @NgModule({
     imports: [CommonModule, PortalModule, ThyGridModule, ThyListModule, ...components],
     exports: components,

--- a/src/skeleton/skeleton-circle.component.ts
+++ b/src/skeleton/skeleton-circle.component.ts
@@ -9,7 +9,7 @@ import {
     SimpleChanges,
     Inject
 } from '@angular/core';
-import { ThySkeletonComponent } from './skeleton.component';
+import { ThySkeleton } from './skeleton.component';
 import { helpers } from 'ngx-tethys/util';
 import { InputBoolean, InputCssPixel } from 'ngx-tethys/core';
 import { THY_SKELETON_CONFIG, ThySkeletonConfigModel } from './skeleton.config';
@@ -41,7 +41,7 @@ interface Style {
     standalone: true,
     imports: [NgStyle]
 })
-export class ThySkeletonCircleComponent implements OnInit, OnChanges {
+export class ThySkeletonCircle implements OnInit, OnChanges {
     /**
      * 动画速度
      * @default 1.5s
@@ -82,7 +82,7 @@ export class ThySkeletonCircleComponent implements OnInit, OnChanges {
         @Optional()
         @Inject(THY_SKELETON_CONFIG)
         private skeletonConfigModel: ThySkeletonConfigModel,
-        @Optional() private _parent: ThySkeletonComponent
+        @Optional() private _parent: ThySkeleton
     ) {}
 
     ngOnInit() {

--- a/src/skeleton/skeleton-rectangle.component.ts
+++ b/src/skeleton/skeleton-rectangle.component.ts
@@ -9,7 +9,7 @@ import {
     SimpleChanges,
     Inject
 } from '@angular/core';
-import { ThySkeletonComponent } from './skeleton.component';
+import { ThySkeleton } from './skeleton.component';
 import { helpers } from 'ngx-tethys/util';
 import { InputBoolean, InputCssPixel } from 'ngx-tethys/core';
 import { THY_SKELETON_CONFIG, ThySkeletonConfigModel } from './skeleton.config';
@@ -42,7 +42,7 @@ interface Style {
     standalone: true,
     imports: [NgStyle]
 })
-export class ThySkeletonRectangleComponent implements OnInit, OnChanges {
+export class ThySkeletonRectangle implements OnInit, OnChanges {
     /**
      * 是否开启动画
      * @default false
@@ -99,7 +99,7 @@ export class ThySkeletonRectangleComponent implements OnInit, OnChanges {
         @Optional()
         @Inject(THY_SKELETON_CONFIG)
         private skeletonConfigModel: ThySkeletonConfigModel,
-        @Optional() private _parent: ThySkeletonComponent
+        @Optional() private _parent: ThySkeleton
     ) {}
 
     ngOnInit() {

--- a/src/skeleton/skeleton.component.ts
+++ b/src/skeleton/skeleton.component.ts
@@ -13,7 +13,7 @@ import { InputBoolean } from 'ngx-tethys/core';
     encapsulation: ViewEncapsulation.None,
     standalone: true
 })
-export class ThySkeletonComponent {
+export class ThySkeleton {
     /**
      * 是否开启动画
      * @default false

--- a/src/skeleton/stylized/bullet-list.component.ts
+++ b/src/skeleton/stylized/bullet-list.component.ts
@@ -2,8 +2,8 @@ import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@a
 import { InputBoolean, InputCssPixel } from 'ngx-tethys/core';
 
 import { NgFor } from '@angular/common';
-import { ThySkeletonCircleComponent } from '../skeleton-circle.component';
-import { ThySkeletonRectangleComponent } from '../skeleton-rectangle.component';
+import { ThySkeletonCircle } from '../skeleton-circle.component';
+import { ThySkeletonRectangle } from '../skeleton-rectangle.component';
 
 /**
  * 骨架屏无序列表组件
@@ -42,9 +42,9 @@ import { ThySkeletonRectangleComponent } from '../skeleton-rectangle.component';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     standalone: true,
-    imports: [NgFor, ThySkeletonCircleComponent, ThySkeletonRectangleComponent]
+    imports: [NgFor, ThySkeletonCircle, ThySkeletonRectangle]
 })
-export class ThySkeletonBulletListComponent {
+export class ThySkeletonBulletList {
     /**
      * 骨架宽度
      * @default 100%

--- a/src/skeleton/stylized/list.component.ts
+++ b/src/skeleton/stylized/list.component.ts
@@ -1,7 +1,7 @@
 import { NgFor } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { InputBoolean, InputCssPixel } from 'ngx-tethys/core';
-import { ThySkeletonRectangleComponent } from '../skeleton-rectangle.component';
+import { ThySkeletonRectangle } from '../skeleton-rectangle.component';
 
 /**
  * 骨架屏列表组件
@@ -29,9 +29,9 @@ import { ThySkeletonRectangleComponent } from '../skeleton-rectangle.component';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     standalone: true,
-    imports: [NgFor, ThySkeletonRectangleComponent]
+    imports: [NgFor, ThySkeletonRectangle]
 })
-export class ThySkeletonListComponent {
+export class ThySkeletonList {
     /**
      * 骨架宽度
      */

--- a/src/skeleton/stylized/paragraph.component.ts
+++ b/src/skeleton/stylized/paragraph.component.ts
@@ -1,7 +1,7 @@
 import { NgFor } from '@angular/common';
 import { ChangeDetectionStrategy, Component, Input, ViewEncapsulation } from '@angular/core';
 import { InputBoolean, InputCssPixel } from 'ngx-tethys/core';
-import { ThySkeletonRectangleComponent } from '../skeleton-rectangle.component';
+import { ThySkeletonRectangle } from '../skeleton-rectangle.component';
 
 /**
  * 骨架屏段落组件
@@ -29,9 +29,9 @@ import { ThySkeletonRectangleComponent } from '../skeleton-rectangle.component';
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     standalone: true,
-    imports: [NgFor, ThySkeletonRectangleComponent]
+    imports: [NgFor, ThySkeletonRectangle]
 })
-export class ThySkeletonParagraphComponent {
+export class ThySkeletonParagraph {
     /**
      * 首行宽度
      */

--- a/src/skeleton/test/skeleton-circle.spec.ts
+++ b/src/skeleton/test/skeleton-circle.spec.ts
@@ -2,7 +2,7 @@ import { Component, DebugElement, NgModule, OnInit, TemplateRef, ViewChild } fro
 
 import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ThySkeletonCircleComponent } from '../skeleton-circle.component';
+import { ThySkeletonCircle } from '../skeleton-circle.component';
 
 import { ThySkeletonModule } from '../module';
 
@@ -49,7 +49,7 @@ describe('skeleton circle', () => {
         fixture = TestBed.createComponent(ThySkeletonCircleTestComponent);
         skeletonCircleComponent = fixture.debugElement.componentInstance;
 
-        circleDebugComponent = fixture.debugElement.query(By.directive(ThySkeletonCircleComponent));
+        circleDebugComponent = fixture.debugElement.query(By.directive(ThySkeletonCircle));
         circleElement = circleDebugComponent.nativeElement;
     });
 

--- a/src/skeleton/test/skeleton-rectangle.spec.ts
+++ b/src/skeleton/test/skeleton-rectangle.spec.ts
@@ -1,7 +1,7 @@
 import { Component, DebugElement, NgModule, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ThySkeletonRectangleComponent } from '../skeleton-rectangle.component';
+import { ThySkeletonRectangle } from '../skeleton-rectangle.component';
 import { ThySkeletonModule } from '../module';
 
 @Component({
@@ -48,7 +48,7 @@ describe('skeleton rectangle', () => {
         fixture = TestBed.createComponent(ThySkeletonRectangleTestComponent);
         skeletonSkeletonComponent = fixture.debugElement.componentInstance;
 
-        circleDebugComponent = fixture.debugElement.query(By.directive(ThySkeletonRectangleComponent));
+        circleDebugComponent = fixture.debugElement.query(By.directive(ThySkeletonRectangle));
         circleElement = circleDebugComponent.nativeElement;
     });
 

--- a/src/skeleton/test/skeleton.spec.ts
+++ b/src/skeleton/test/skeleton.spec.ts
@@ -1,8 +1,8 @@
 import { Component, DebugElement, NgModule, OnInit, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ThySkeletonCircleComponent } from '../skeleton-circle.component';
-import { ThySkeletonRectangleComponent } from '../skeleton-rectangle.component';
+import { ThySkeletonCircle } from '../skeleton-circle.component';
+import { ThySkeletonRectangle } from '../skeleton-rectangle.component';
 import { ThySkeletonModule } from '../module';
 
 @Component({
@@ -40,8 +40,8 @@ describe('skeleton ', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(thySkeletonTestComponent);
         skeletonComponent = fixture.debugElement.componentInstance;
-        circleDebugComponent = fixture.debugElement.query(By.directive(ThySkeletonCircleComponent));
-        rectangleDebugComponent = fixture.debugElement.query(By.directive(ThySkeletonRectangleComponent));
+        circleDebugComponent = fixture.debugElement.query(By.directive(ThySkeletonCircle));
+        rectangleDebugComponent = fixture.debugElement.query(By.directive(ThySkeletonRectangle));
         circleElement = circleDebugComponent.nativeElement;
         rectangleElement = rectangleDebugComponent.nativeElement;
     });

--- a/src/slide/slide-body/slide-body-section.component.ts
+++ b/src/slide/slide-body/slide-body-section.component.ts
@@ -10,7 +10,7 @@ import { coerceBooleanProperty } from 'ngx-tethys/util';
     template: '<ng-content></ng-content>',
     standalone: true
 })
-export class ThySlideBodySectionComponent implements OnInit {
+export class ThySlideBodySection implements OnInit {
     @HostBinding('class.thy-slide-body-section') thySlideBodyItem = true;
 
     @HostBinding('class.thy-slide-body-section-divider') hasDivider = false;

--- a/src/slide/slide-body/slide-body.component.ts
+++ b/src/slide/slide-body/slide-body.component.ts
@@ -9,6 +9,6 @@ import { Component, HostBinding } from '@angular/core';
     template: ` <ng-content></ng-content> `,
     standalone: true
 })
-export class ThySlideBodyComponent {
+export class ThySlideBody {
     @HostBinding('class.thy-slide-body') slideLayoutBody = true;
 }

--- a/src/slide/slide-container.component.ts
+++ b/src/slide/slide-container.component.ts
@@ -37,7 +37,7 @@ import { slideAbstractOverlayOptions, ThySlideConfig, ThySlideFromTypes } from '
     standalone: true,
     imports: [PortalModule, ThyPortalOutlet]
 })
-export class ThySlideContainerComponent extends ThyAbstractOverlayContainer implements OnDestroy {
+export class ThySlideContainer extends ThyAbstractOverlayContainer implements OnDestroy {
     @ViewChild(ThyPortalOutlet, { static: true })
     portalOutlet: ThyPortalOutlet;
 

--- a/src/slide/slide-footer/slide-footer.component.ts
+++ b/src/slide/slide-footer/slide-footer.component.ts
@@ -9,7 +9,7 @@ import { Component, OnInit, HostBinding } from '@angular/core';
     template: '<ng-content></ng-content>',
     standalone: true
 })
-export class ThySlideFooterComponent implements OnInit {
+export class ThySlideFooter implements OnInit {
     @HostBinding('class.thy-slide-footer') slideLayoutFooter = true;
 
     ngOnInit() {}

--- a/src/slide/slide-header/slide-header.component.ts
+++ b/src/slide/slide-header/slide-header.component.ts
@@ -1,7 +1,7 @@
 import { Component, ContentChild, TemplateRef, Input, OnInit, HostBinding } from '@angular/core';
 import { ThySlideService } from '../slide.service';
-import { ThyActionComponent } from 'ngx-tethys/action';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyAction } from 'ngx-tethys/action';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgTemplateOutlet } from '@angular/common';
 
 /**
@@ -13,9 +13,9 @@ import { NgIf, NgTemplateOutlet } from '@angular/common';
     selector: 'thy-slide-header',
     templateUrl: './slide-header.component.html',
     standalone: true,
-    imports: [NgIf, NgTemplateOutlet, ThyIconComponent, ThyActionComponent]
+    imports: [NgIf, NgTemplateOutlet, ThyIcon, ThyAction]
 })
-export class ThySlideHeaderComponent implements OnInit {
+export class ThySlideHeader implements OnInit {
     isIconFont = false;
 
     private _iconName = '';

--- a/src/slide/slide-layout/slide-layout.component.ts
+++ b/src/slide/slide-layout/slide-layout.component.ts
@@ -10,7 +10,7 @@ import { Component, ViewEncapsulation, OnInit, HostBinding } from '@angular/core
     encapsulation: ViewEncapsulation.None,
     standalone: true
 })
-export class ThySlideLayoutComponent implements OnInit {
+export class ThySlideLayout implements OnInit {
     @HostBinding('class.thy-slide-layout') slideLayout = true;
 
     constructor() {}

--- a/src/slide/slide-ref.service.ts
+++ b/src/slide/slide-ref.service.ts
@@ -3,24 +3,24 @@ import { ThyAbstractInternalOverlayRef, ThyAbstractOverlayPosition, ThyAbstractO
 import { OverlayRef } from '@angular/cdk/overlay';
 import { Injectable } from '@angular/core';
 
-import { ThySlideContainerComponent } from './slide-container.component';
+import { ThySlideContainer } from './slide-container.component';
 import { slideAbstractOverlayOptions, ThySlideConfig } from './slide.config';
 
 /**
  * @public
  * @order 30
  */
-export abstract class ThySlideRef<T, TResult = unknown> extends ThyAbstractOverlayRef<T, ThySlideContainerComponent, TResult> {}
+export abstract class ThySlideRef<T, TResult = unknown> extends ThyAbstractOverlayRef<T, ThySlideContainer, TResult> {}
 
 /**
  * @internal
  */
 @Injectable()
 export class ThyInternalSlideRef<T = unknown, TResult = unknown>
-    extends ThyAbstractInternalOverlayRef<T, ThySlideContainerComponent, TResult>
+    extends ThyAbstractInternalOverlayRef<T, ThySlideContainer, TResult>
     implements ThySlideRef<T>
 {
-    constructor(overlayRef: OverlayRef, containerInstance: ThySlideContainerComponent, config: ThySlideConfig) {
+    constructor(overlayRef: OverlayRef, containerInstance: ThySlideContainer, config: ThySlideConfig) {
         super(slideAbstractOverlayOptions, overlayRef, containerInstance, config);
     }
 

--- a/src/slide/slide.module.ts
+++ b/src/slide/slide.module.ts
@@ -2,13 +2,13 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ThySharedModule } from 'ngx-tethys/shared';
 import { ThySlideService } from './slide.service';
-import { ThySlideContainerComponent } from './slide-container.component';
+import { ThySlideContainer } from './slide-container.component';
 import { ThyInternalSlideRef } from './slide-ref.service';
-import { ThySlideLayoutComponent } from './slide-layout/slide-layout.component';
-import { ThySlideHeaderComponent } from './slide-header/slide-header.component';
-import { ThySlideBodyComponent } from './slide-body/slide-body.component';
-import { ThySlideBodySectionComponent } from './slide-body/slide-body-section.component';
-import { ThySlideFooterComponent } from './slide-footer/slide-footer.component';
+import { ThySlideLayout } from './slide-layout/slide-layout.component';
+import { ThySlideHeader } from './slide-header/slide-header.component';
+import { ThySlideBody } from './slide-body/slide-body.component';
+import { ThySlideBodySection } from './slide-body/slide-body-section.component';
+import { ThySlideFooter } from './slide-footer/slide-footer.component';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { PortalModule } from '@angular/cdk/portal';
@@ -24,22 +24,15 @@ import { ThyActionModule } from 'ngx-tethys/action';
         OverlayModule,
         PortalModule,
         ThyActionModule,
-        ThySlideContainerComponent,
-        ThySlideLayoutComponent,
-        ThySlideHeaderComponent,
-        ThySlideBodyComponent,
-        ThySlideBodySectionComponent,
-        ThySlideFooterComponent,
+        ThySlideContainer,
+        ThySlideLayout,
+        ThySlideHeader,
+        ThySlideBody,
+        ThySlideBodySection,
+        ThySlideFooter,
         ThyDrawerContainerDirective
     ],
-    exports: [
-        ThySlideLayoutComponent,
-        ThySlideHeaderComponent,
-        ThySlideBodyComponent,
-        ThySlideBodySectionComponent,
-        ThySlideFooterComponent,
-        ThyDrawerContainerDirective
-    ],
+    exports: [ThySlideLayout, ThySlideHeader, ThySlideBody, ThySlideBodySection, ThySlideFooter, ThyDrawerContainerDirective],
     providers: [ThyInternalSlideRef, ThySlideService, THY_SLIDE_DEFAULT_CONFIG_PROVIDER]
 })
 export class ThySlideModule {}

--- a/src/slide/slide.service.ts
+++ b/src/slide/slide.service.ts
@@ -8,7 +8,7 @@ import { Overlay, OverlayConfig, OverlayRef } from '@angular/cdk/overlay';
 import { ComponentPortal } from '@angular/cdk/portal';
 import { Inject, Injectable, Injector, OnDestroy, Optional, StaticProvider } from '@angular/core';
 
-import { ThySlideContainerComponent } from './slide-container.component';
+import { ThySlideContainer } from './slide-container.component';
 import { ThyInternalSlideRef, ThySlideRef } from './slide-ref.service';
 import { slideAbstractOverlayOptions, slideDefaultConfigValue, THY_SLIDE_DEFAULT_CONFIG, ThySlideConfig } from './slide.config';
 
@@ -17,7 +17,7 @@ import { slideAbstractOverlayOptions, slideDefaultConfigValue, THY_SLIDE_DEFAULT
  * @order 10
  */
 @Injectable()
-export class ThySlideService extends ThyAbstractOverlayService<ThySlideConfig, ThySlideContainerComponent> implements OnDestroy {
+export class ThySlideService extends ThyAbstractOverlayService<ThySlideConfig, ThySlideContainer> implements OnDestroy {
     private originElementAddActiveClass(config: ThySlideConfig) {
         if (config.origin) {
             coerceElement<HTMLElement>(config.origin).classList.add(...coerceArray(config.originActiveClass));
@@ -39,34 +39,34 @@ export class ThySlideService extends ThyAbstractOverlayService<ThySlideConfig, T
         return overlayConfig;
     }
 
-    protected attachOverlayContainer(overlay: OverlayRef, config: ThySlideConfig): ThySlideContainerComponent {
+    protected attachOverlayContainer(overlay: OverlayRef, config: ThySlideConfig): ThySlideContainer {
         const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
         const injector = Injector.create({
             parent: userInjector || this.injector,
             providers: [{ provide: ThySlideConfig, useValue: config }]
         });
-        const containerPortal = new ComponentPortal(ThySlideContainerComponent, config.viewContainerRef, injector);
-        const containerRef = overlay.attach<ThySlideContainerComponent>(containerPortal);
+        const containerPortal = new ComponentPortal(ThySlideContainer, config.viewContainerRef, injector);
+        const containerRef = overlay.attach<ThySlideContainer>(containerPortal);
         return containerRef.instance;
     }
 
     protected createAbstractOverlayRef<T>(
         overlayRef: OverlayRef,
-        containerInstance: ThySlideContainerComponent,
+        containerInstance: ThySlideContainer,
         config: ThySlideConfig
-    ): ThyAbstractOverlayRef<T, ThySlideContainerComponent, any> {
+    ): ThyAbstractOverlayRef<T, ThySlideContainer, any> {
         return new ThyInternalSlideRef(overlayRef, containerInstance, config);
     }
 
     protected createInjector<T>(
         config: ThySlideConfig,
-        overlayRef: ThyAbstractOverlayRef<T, ThySlideContainerComponent, any>,
-        containerInstance: ThySlideContainerComponent
+        overlayRef: ThyAbstractOverlayRef<T, ThySlideContainer, any>,
+        containerInstance: ThySlideContainer
     ): Injector {
         const userInjector = config && config.viewContainerRef && config.viewContainerRef.injector;
 
         const injectionTokens: StaticProvider[] = [
-            { provide: ThySlideContainerComponent, useValue: containerInstance },
+            { provide: ThySlideContainer, useValue: containerInstance },
             { provide: ThySlideRef, useValue: overlayRef }
         ];
 

--- a/src/slide/test/slide-layout.spec.ts
+++ b/src/slide/test/slide-layout.spec.ts
@@ -4,11 +4,11 @@ import { ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angu
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { THY_SLIDE_DEFAULT_CONFIG, ThySlideConfig, ThySlideModule, ThySlideRef, ThySlideService, slideDefaultConfigValue } from '../index';
-import { ThySlideBodySectionComponent } from '../slide-body/slide-body-section.component';
-import { ThySlideBodyComponent } from '../slide-body/slide-body.component';
-import { ThySlideFooterComponent } from '../slide-footer/slide-footer.component';
-import { ThySlideHeaderComponent } from '../slide-header/slide-header.component';
-import { ThySlideLayoutComponent } from '../slide-layout/slide-layout.component';
+import { ThySlideBodySection } from '../slide-body/slide-body-section.component';
+import { ThySlideBody } from '../slide-body/slide-body.component';
+import { ThySlideFooter } from '../slide-footer/slide-footer.component';
+import { ThySlideHeader } from '../slide-header/slide-header.component';
+import { ThySlideLayout } from '../slide-layout/slide-layout.component';
 import { SafeAny } from '../../types';
 
 describe('ThySlide', () => {
@@ -610,11 +610,11 @@ describe('ThySlide', () => {
 
         beforeEach(fakeAsync(() => {
             fixture = TestBed.createComponent(SlideLayoutTestComponent);
-            layouts = fixture.debugElement.queryAll(By.directive(ThySlideLayoutComponent));
-            headers = fixture.debugElement.queryAll(By.directive(ThySlideHeaderComponent));
-            bodys = fixture.debugElement.queryAll(By.directive(ThySlideBodyComponent));
-            bodySections = fixture.debugElement.queryAll(By.directive(ThySlideBodySectionComponent));
-            footers = fixture.debugElement.queryAll(By.directive(ThySlideFooterComponent));
+            layouts = fixture.debugElement.queryAll(By.directive(ThySlideLayout));
+            headers = fixture.debugElement.queryAll(By.directive(ThySlideHeader));
+            bodys = fixture.debugElement.queryAll(By.directive(ThySlideBody));
+            bodySections = fixture.debugElement.queryAll(By.directive(ThySlideBodySection));
+            footers = fixture.debugElement.queryAll(By.directive(ThySlideFooter));
         }));
 
         it('should have correct class', fakeAsync(() => {

--- a/src/slider/slider.component.ts
+++ b/src/slider/slider.component.ts
@@ -38,7 +38,7 @@ export type ThySliderSize = 'sm' | 'md' | 'lg';
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThySliderComponent),
+            useExisting: forwardRef(() => ThySlider),
             multi: true
         }
     ],
@@ -48,7 +48,7 @@ export type ThySliderSize = 'sm' | 'md' | 'lg';
     standalone: true,
     imports: [NgStyle]
 })
-export class ThySliderComponent
+export class ThySlider
     extends TabIndexDisabledControlValueAccessorMixin
     implements OnInit, AfterViewInit, OnDestroy, OnChanges, ControlValueAccessor
 {
@@ -390,13 +390,13 @@ export class ThySliderComponent
 // Note: keep `verifyMinAndMax` and `verifyStepValues` as separate functions (not as class properties)
 // so they're tree-shakable in production mode.
 
-function verifyMinAndMax(ctx: ThySliderComponent): void | never {
+function verifyMinAndMax(ctx: ThySlider): void | never {
     if (ctx.thyMin >= ctx.thyMax) {
         throw new Error('min value must less than max value.');
     }
 }
 
-function verifyStepValues(ctx: ThySliderComponent): void | never {
+function verifyStepValues(ctx: ThySlider): void | never {
     if (ctx.thyStep <= 0 || !ctx.thyStep) {
         throw new Error('step value must be greater than 0.');
     } else if (Number.isInteger(ctx.thyStep) && (ctx.thyMax - ctx.thyMin) % ctx.thyStep) {

--- a/src/slider/slider.module.ts
+++ b/src/slider/slider.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { CommonModule } from '@angular/common';
-import { ThySliderComponent } from './slider.component';
+import { ThySlider } from './slider.component';
 
 @NgModule({
-    imports: [CommonModule, FormsModule, ThySliderComponent],
-    exports: [ThySliderComponent],
+    imports: [CommonModule, FormsModule, ThySlider],
+    exports: [ThySlider],
     providers: []
 })
 export class ThySliderModule {}

--- a/src/space/space.component.spec.ts
+++ b/src/space/space.component.spec.ts
@@ -1,5 +1,5 @@
 import { ThyButtonModule } from 'ngx-tethys/button';
-import { ThySpaceComponent, ThySpaceModule } from 'ngx-tethys/space';
+import { ThySpace, ThySpaceModule } from 'ngx-tethys/space';
 
 import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
@@ -57,7 +57,7 @@ describe('space', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestBasicComponent);
-            spaceDebugElement = fixture.debugElement.query(By.directive(ThySpaceComponent));
+            spaceDebugElement = fixture.debugElement.query(By.directive(ThySpace));
             fixture.detectChanges();
         });
 
@@ -115,7 +115,7 @@ describe('space', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestSizeComponent);
-            spaceDebugElement = fixture.debugElement.query(By.directive(ThySpaceComponent));
+            spaceDebugElement = fixture.debugElement.query(By.directive(ThySpace));
             fixture.detectChanges();
         });
 

--- a/src/space/space.component.ts
+++ b/src/space/space.component.ts
@@ -55,7 +55,7 @@ const _MixinBase: Constructor<ThyUnsubscribe> & typeof MixinBase = mixinUnsubscr
     standalone: true,
     imports: [NgFor, NgTemplateOutlet]
 })
-export class ThySpaceComponent extends _MixinBase implements OnInit, AfterContentInit {
+export class ThySpace extends _MixinBase implements OnInit, AfterContentInit {
     public space: number = getNumericSize(DEFAULT_SIZE);
 
     private hostRenderer = useHostRenderer();

--- a/src/space/space.module.ts
+++ b/src/space/space.module.ts
@@ -1,10 +1,10 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 
-import { ThySpaceComponent, ThySpaceItemDirective } from './space.component';
+import { ThySpace, ThySpaceItemDirective } from './space.component';
 
 @NgModule({
-    imports: [CommonModule, ThySpaceComponent, ThySpaceItemDirective],
-    exports: [ThySpaceComponent, ThySpaceItemDirective]
+    imports: [CommonModule, ThySpace, ThySpaceItemDirective],
+    exports: [ThySpace, ThySpaceItemDirective]
 })
 export class ThySpaceModule {}

--- a/src/statistic/statistic.component.ts
+++ b/src/statistic/statistic.component.ts
@@ -21,7 +21,7 @@ export type ThyStatisticTitlePosition = 'top' | 'bottom';
     standalone: true,
     imports: [NgIf, NgTemplateOutlet, NgStyle]
 })
-export class ThyStatisticComponent implements OnInit {
+export class ThyStatistic implements OnInit {
     _shape: ThyStatisticShape;
 
     _initialized = false;

--- a/src/statistic/statistic.module.ts
+++ b/src/statistic/statistic.module.ts
@@ -1,12 +1,12 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ThySharedModule } from 'ngx-tethys/shared';
-import { ThyStatisticComponent } from './statistic.component';
+import { ThyStatistic } from './statistic.component';
 import { ThyIconModule } from 'ngx-tethys/icon';
 
 @NgModule({
-    imports: [CommonModule, ThySharedModule, ThyIconModule, ThyStatisticComponent],
-    exports: [ThyStatisticComponent],
+    imports: [CommonModule, ThySharedModule, ThyIconModule, ThyStatistic],
+    exports: [ThyStatistic],
     providers: []
 })
 export class ThyStatisticModule {}

--- a/src/statistic/test/statistic.spec.ts
+++ b/src/statistic/test/statistic.spec.ts
@@ -2,7 +2,7 @@ import { fakeAsync, TestBed, ComponentFixture } from '@angular/core/testing';
 import { ThyStatisticModule } from '../statistic.module';
 import { NgModule, Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { ThyStatisticComponent } from '../statistic.component';
+import { ThyStatistic } from '../statistic.component';
 describe('thy-statistic', () => {
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -18,7 +18,7 @@ describe('thy-statistic', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(ThyDemoStatisticBasicComponent);
             basicTestComponent = fixture.debugElement.componentInstance;
-            statisticComponent = fixture.debugElement.query(By.directive(ThyStatisticComponent));
+            statisticComponent = fixture.debugElement.query(By.directive(ThyStatistic));
         });
 
         it('should have correct class', () => {
@@ -98,7 +98,7 @@ describe('thy-statistic', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(ThyDemoStatisticTemplateComponent);
             templateTestComponent = fixture.debugElement.componentInstance;
-            statisticComponent = fixture.debugElement.query(By.directive(ThyStatisticComponent));
+            statisticComponent = fixture.debugElement.query(By.directive(ThyStatistic));
         });
 
         it('prefix template', () => {
@@ -134,7 +134,7 @@ describe('thy-statistic', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(ThyDemoStatisticTemplateOutsideComponent);
             templateTestComponent = fixture.debugElement.componentInstance;
-            statisticComponent = fixture.debugElement.query(By.directive(ThyStatisticComponent));
+            statisticComponent = fixture.debugElement.query(By.directive(ThyStatistic));
         });
 
         it('prefix template', () => {

--- a/src/stepper/step-header.component.ts
+++ b/src/stepper/step-header.component.ts
@@ -11,7 +11,7 @@ import { InputBoolean, InputNumber } from 'ngx-tethys/core';
     templateUrl: './step-header.component.html',
     standalone: true
 })
-export class ThyStepHeaderComponent {
+export class ThyStepHeader {
     @Input() label: string;
 
     @Input() @InputNumber() index: number;

--- a/src/stepper/step.component.ts
+++ b/src/stepper/step.component.ts
@@ -1,7 +1,7 @@
 import { Component, Input, ViewChild, TemplateRef, Inject, InjectionToken, Optional } from '@angular/core';
 
 export interface IThyStepperComponent {
-    selected: ThyStepComponent;
+    selected: ThyStep;
 }
 
 export const THY_STEPPER_COMPONENT = new InjectionToken<IThyStepperComponent>('THY_STEPPER_COMPONENT');
@@ -16,7 +16,7 @@ export const THY_STEPPER_COMPONENT = new InjectionToken<IThyStepperComponent>('T
     templateUrl: './step.component.html',
     standalone: true
 })
-export class ThyStepComponent {
+export class ThyStep {
     @ViewChild(TemplateRef, { static: true }) content: TemplateRef<any>;
 
     @Input() label: string;

--- a/src/stepper/stepper-button.directive.ts
+++ b/src/stepper/stepper-button.directive.ts
@@ -1,5 +1,5 @@
 import { Directive, HostListener } from '@angular/core';
-import { ThyStepperComponent } from './stepper.component';
+import { ThyStepper } from './stepper.component';
 
 /**
  * 在步进工作流中移动到下一个步骤的按钮
@@ -12,7 +12,7 @@ import { ThyStepperComponent } from './stepper.component';
     standalone: true
 })
 export class ThyStepperNextDirective {
-    constructor(private stepper: ThyStepperComponent) {}
+    constructor(private stepper: ThyStepper) {}
 
     @HostListener('click', ['$event'])
     click($event: any) {
@@ -31,7 +31,7 @@ export class ThyStepperNextDirective {
     standalone: true
 })
 export class ThyStepperPreviousDirective {
-    constructor(private stepper: ThyStepperComponent) {}
+    constructor(private stepper: ThyStepper) {}
 
     @HostListener('click', ['$event'])
     click($event: any) {

--- a/src/stepper/stepper.component.ts
+++ b/src/stepper/stepper.component.ts
@@ -1,6 +1,6 @@
 import { Component, ViewChildren, ContentChildren, QueryList, HostBinding, Input, Output, EventEmitter } from '@angular/core';
-import { ThyStepComponent, IThyStepperComponent, THY_STEPPER_COMPONENT } from './step.component';
-import { ThyStepHeaderComponent } from './step-header.component';
+import { ThyStep, IThyStepperComponent, THY_STEPPER_COMPONENT } from './step.component';
+import { ThyStepHeader } from './step-header.component';
 import { NgIf, NgFor, NgTemplateOutlet } from '@angular/common';
 import { InputBoolean, InputNumber } from 'ngx-tethys/core';
 
@@ -15,13 +15,13 @@ import { InputBoolean, InputNumber } from 'ngx-tethys/core';
     providers: [
         {
             provide: THY_STEPPER_COMPONENT,
-            useExisting: ThyStepperComponent
+            useExisting: ThyStepper
         }
     ],
     standalone: true,
-    imports: [NgIf, NgFor, ThyStepHeaderComponent, NgTemplateOutlet]
+    imports: [NgIf, NgFor, ThyStepHeader, NgTemplateOutlet]
 })
-export class ThyStepperComponent implements IThyStepperComponent {
+export class ThyStepper implements IThyStepperComponent {
     /**
      * 当前处于激活状态的步骤index
      * @default 0
@@ -33,7 +33,7 @@ export class ThyStepperComponent implements IThyStepperComponent {
     }
 
     @Input()
-    set thySelected(value: ThyStepComponent) {
+    set thySelected(value: ThyStep) {
         this.selected = value;
     }
 
@@ -44,7 +44,7 @@ export class ThyStepperComponent implements IThyStepperComponent {
 
     private _selectedIndex = 0;
 
-    public set selected(step: ThyStepComponent) {
+    public set selected(step: ThyStep) {
         this.selectedIndex = this.steps ? this.steps.toArray().indexOf(step) : -1;
     }
 
@@ -66,9 +66,9 @@ export class ThyStepperComponent implements IThyStepperComponent {
 
     @Output() selectionChange: EventEmitter<any> = new EventEmitter<any>();
 
-    @ViewChildren(ThyStepHeaderComponent) stepHeaders: QueryList<ThyStepHeaderComponent>;
+    @ViewChildren(ThyStepHeader) stepHeaders: QueryList<ThyStepHeader>;
 
-    @ContentChildren(ThyStepComponent) steps: QueryList<ThyStepComponent>;
+    @ContentChildren(ThyStep) steps: QueryList<ThyStep>;
 
     @HostBinding('class.thy-stepper') thyStepper = true;
 

--- a/src/stepper/stepper.module.ts
+++ b/src/stepper/stepper.module.ts
@@ -1,20 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyStepHeaderComponent } from './step-header.component';
-import { ThyStepComponent } from './step.component';
-import { ThyStepperComponent } from './stepper.component';
+import { ThyStepHeader } from './step-header.component';
+import { ThyStep } from './step.component';
+import { ThyStepper } from './stepper.component';
 import { ThyStepperNextDirective, ThyStepperPreviousDirective } from './stepper-button.directive';
 
 @NgModule({
-    imports: [
-        CommonModule,
-        ThyStepHeaderComponent,
-        ThyStepperComponent,
-        ThyStepComponent,
-        ThyStepperNextDirective,
-        ThyStepperPreviousDirective
-    ],
-    exports: [ThyStepperComponent, ThyStepComponent, ThyStepHeaderComponent, ThyStepperNextDirective, ThyStepperPreviousDirective],
+    imports: [CommonModule, ThyStepHeader, ThyStepper, ThyStep, ThyStepperNextDirective, ThyStepperPreviousDirective],
+    exports: [ThyStepper, ThyStep, ThyStepHeader, ThyStepperNextDirective, ThyStepperPreviousDirective],
     providers: []
 })
 export class ThyStepperModule {}

--- a/src/stepper/test/stepper-button.directive.spec.ts
+++ b/src/stepper/test/stepper-button.directive.spec.ts
@@ -2,7 +2,7 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { ThyStepperNextDirective, ThyStepperPreviousDirective } from '../stepper-button.directive';
-import { ThyStepperComponent } from '../stepper.component';
+import { ThyStepper } from '../stepper.component';
 
 @Component({
     template: `
@@ -26,13 +26,13 @@ describe('ThyStepperNext', () => {
             declarations: [ThyStepperButtonDirectiveComponent],
             providers: [
                 {
-                    provide: ThyStepperComponent,
+                    provide: ThyStepper,
                     useClass: MockThyStepperComponent
                 }
             ]
         }).compileComponents();
         fixture = TestBed.createComponent(ThyStepperButtonDirectiveComponent);
-        thyStepperComponent = TestBed.get(ThyStepperComponent) as any;
+        thyStepperComponent = TestBed.get(ThyStepper) as any;
     });
     describe('nextDirective', () => {
         it('next function should be called', () => {

--- a/src/stepper/test/stepper.spec.ts
+++ b/src/stepper/test/stepper.spec.ts
@@ -2,8 +2,8 @@ import { fakeAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { ThyStepperModule } from '../stepper.module';
 import { NgModule, Component, ViewChild } from '@angular/core';
 import { By } from '@angular/platform-browser';
-import { ThyStepComponent } from '../step.component';
-import { ThyStepperComponent } from '../stepper.component';
+import { ThyStep } from '../step.component';
+import { ThyStepper } from '../stepper.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 @Component({
@@ -33,7 +33,7 @@ import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
     `
 })
 class ThyDemoStepperComponent {
-    @ViewChild('selectedStep', { static: true }) selectedStepperComponent: ThyStepComponent;
+    @ViewChild('selectedStep', { static: true }) selectedStepperComponent: ThyStep;
     showStepHeader = true;
     selectedIndex = 0;
     next() {}
@@ -70,7 +70,7 @@ describe('ThyStepper', () => {
         });
 
         it('should have class thy-stepper', () => {
-            const stepper = fixture.debugElement.query(By.directive(ThyStepperComponent));
+            const stepper = fixture.debugElement.query(By.directive(ThyStepper));
             expect(stepper.nativeElement.classList.contains('thy-stepper')).toBeTruthy();
         });
 
@@ -87,7 +87,7 @@ describe('ThyStepper', () => {
         });
 
         it('toggle step', () => {
-            const stepper = fixture.debugElement.query(By.directive(ThyStepperComponent)).componentInstance;
+            const stepper = fixture.debugElement.query(By.directive(ThyStepper)).componentInstance;
             stepper.next();
             fixture.detectChanges();
             const secondStep = fixture.debugElement.query(By.css('.second-step'));
@@ -109,7 +109,7 @@ describe('ThyStepper', () => {
         });
 
         it('should support thySelected', () => {
-            const stepper = fixture.debugElement.query(By.directive(ThyStepperComponent)).componentInstance;
+            const stepper = fixture.debugElement.query(By.directive(ThyStepper)).componentInstance;
             stepper.thySelected = testComponent.selectedStepperComponent;
             fixture.detectChanges();
             expect(stepper.selected).toEqual(testComponent.selectedStepperComponent);

--- a/src/strength/strength.component.ts
+++ b/src/strength/strength.component.ts
@@ -40,13 +40,13 @@ const strengthMap = {
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThyStrengthComponent),
+            useExisting: forwardRef(() => ThyStrength),
             multi: true
         }
     ],
     standalone: true
 })
-export class ThyStrengthComponent implements OnInit, ControlValueAccessor {
+export class ThyStrength implements OnInit, ControlValueAccessor {
     @HostBinding('class.password-strength-container') styleClass = true;
 
     strengthTitle: string;

--- a/src/strength/strength.module.ts
+++ b/src/strength/strength.module.ts
@@ -1,9 +1,9 @@
 import { NgModule } from '@angular/core';
-import { ThyStrengthComponent } from './strength.component';
+import { ThyStrength } from './strength.component';
 
 @NgModule({
-    imports: [ThyStrengthComponent],
-    exports: [ThyStrengthComponent],
+    imports: [ThyStrength],
+    exports: [ThyStrength],
     providers: []
 })
 export class ThyStrengthModule {}

--- a/src/strength/test/strength.component.spec.ts
+++ b/src/strength/test/strength.component.spec.ts
@@ -5,7 +5,7 @@ import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testin
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
-import { ThyStrengthComponent } from '../strength.component';
+import { ThyStrength } from '../strength.component';
 import { ThyStrengthModule } from '../strength.module';
 
 @Component({
@@ -34,7 +34,7 @@ describe('Strength basic component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(StrengthBasicTestComponent);
         testStrengthBasicComponent = fixture.debugElement.componentInstance;
-        strengthBasicDebugComponent = fixture.debugElement.query(By.directive(ThyStrengthComponent));
+        strengthBasicDebugComponent = fixture.debugElement.query(By.directive(ThyStrength));
         strengthBasicElement = strengthBasicDebugComponent.nativeElement;
     });
 
@@ -104,7 +104,7 @@ describe('Strength component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(StrengthTestComponent);
         testStrengthComponent = fixture.debugElement.componentInstance;
-        strengthDebugComponent = fixture.debugElement.query(By.directive(ThyStrengthComponent));
+        strengthDebugComponent = fixture.debugElement.query(By.directive(ThyStrength));
         strengthElement = strengthDebugComponent.nativeElement;
     });
 

--- a/src/switch/switch.component.ts
+++ b/src/switch/switch.component.ts
@@ -28,7 +28,7 @@ import { InputBoolean, TabIndexDisabledControlValueAccessorMixin } from 'ngx-tet
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThySwitchComponent),
+            useExisting: forwardRef(() => ThySwitch),
             multi: true
         }
     ],
@@ -40,7 +40,7 @@ import { InputBoolean, TabIndexDisabledControlValueAccessorMixin } from 'ngx-tet
         '[class.thy-switch-sm]': 'size === "sm"'
     }
 })
-export class ThySwitchComponent extends TabIndexDisabledControlValueAccessorMixin implements OnInit, ControlValueAccessor {
+export class ThySwitch extends TabIndexDisabledControlValueAccessorMixin implements OnInit, ControlValueAccessor {
     public model: boolean;
 
     public type?: string = 'primary';

--- a/src/switch/switch.module.ts
+++ b/src/switch/switch.module.ts
@@ -1,9 +1,9 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThySwitchComponent } from './switch.component';
+import { ThySwitch } from './switch.component';
 
 @NgModule({
-    imports: [CommonModule, ThySwitchComponent],
-    exports: [ThySwitchComponent]
+    imports: [CommonModule, ThySwitch],
+    exports: [ThySwitch]
 })
 export class ThySwitchModule {}

--- a/src/switch/test/switch.component.spec.ts
+++ b/src/switch/test/switch.component.spec.ts
@@ -2,7 +2,7 @@ import { Component, DebugElement } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ThySwitchComponent } from '../switch.component';
+import { ThySwitch } from '../switch.component';
 import { ThySwitchModule } from '../switch.module';
 
 @Component({
@@ -42,7 +42,7 @@ describe('switch component', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(SwitchTestComponent);
         testComponent = fixture.debugElement.componentInstance;
-        switchDebugComponent = fixture.debugElement.query(By.directive(ThySwitchComponent));
+        switchDebugComponent = fixture.debugElement.query(By.directive(ThySwitch));
         switchElement = switchDebugComponent.nativeElement;
         labelNode = switchElement.children[0];
     });
@@ -119,7 +119,7 @@ describe('switch component', () => {
         fixture.detectChanges();
         tick();
         fixture.detectChanges();
-        const disabledSwitch = fixture.debugElement.queryAll(By.directive(ThySwitchComponent))[1];
+        const disabledSwitch = fixture.debugElement.queryAll(By.directive(ThySwitch))[1];
         const disabledSwitchElement = disabledSwitch.nativeElement;
         labelNode = disabledSwitchElement.children[0];
         expect(labelNode.classList.contains('thy-switch-disabled')).toBeTruthy();

--- a/src/table/table-skeleton.component.ts
+++ b/src/table/table-skeleton.component.ts
@@ -10,7 +10,7 @@ import {
     ViewEncapsulation
 } from '@angular/core';
 import { InputBoolean, InputCssPixel } from 'ngx-tethys/core';
-import { ThySkeletonCircleComponent, ThySkeletonRectangleComponent } from 'ngx-tethys/skeleton';
+import { ThySkeletonCircle, ThySkeletonRectangle } from 'ngx-tethys/skeleton';
 import { ThyTableSkeletonColumn } from './table.interface';
 import { ThyViewOutletDirective } from 'ngx-tethys/shared';
 import { ThyTableColumnSkeletonType } from './enums';
@@ -31,9 +31,9 @@ const COLUMN_COUNT = 5;
     changeDetection: ChangeDetectionStrategy.OnPush,
     encapsulation: ViewEncapsulation.None,
     standalone: true,
-    imports: [NgFor, NgClass, NgIf, NgTemplateOutlet, ThyViewOutletDirective, ThySkeletonRectangleComponent, ThySkeletonCircleComponent]
+    imports: [NgFor, NgClass, NgIf, NgTemplateOutlet, ThyViewOutletDirective, ThySkeletonRectangle, ThySkeletonCircle]
 })
-export class ThyTableSkeletonComponent implements AfterViewInit {
+export class ThyTableSkeleton implements AfterViewInit {
     @ViewChild('titleTemplate') titleTemplate: ElementRef<HTMLElement>;
 
     @ViewChild('memberTemplate') memberTemplate: ElementRef<HTMLElement>;

--- a/src/table/table.component.ts
+++ b/src/table/table.component.ts
@@ -64,13 +64,13 @@ import {
 } from './table.interface';
 import { TableRowDragDisabledPipe } from './pipes/drag.pipe';
 import { TableIsValidModelValuePipe } from './pipes/table.pipe';
-import { ThyPaginationComponent } from 'ngx-tethys/pagination';
-import { ThyTableSkeletonComponent } from './table-skeleton.component';
-import { ThyEmptyComponent } from 'ngx-tethys/empty';
-import { ThySwitchComponent } from 'ngx-tethys/switch';
+import { ThyPagination } from 'ngx-tethys/pagination';
+import { ThyTableSkeleton } from './table-skeleton.component';
+import { ThyEmpty } from 'ngx-tethys/empty';
+import { ThySwitch } from 'ngx-tethys/switch';
 import { FormsModule } from '@angular/forms';
 import { ThyDragDropDirective, ThyContextMenuDirective } from 'ngx-tethys/shared';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { CdkScrollable } from '@angular/cdk/scrolling';
 import { ThyTableColumnSkeletonType } from './enums';
 
@@ -127,7 +127,7 @@ const _MixinBase: Constructor<ThyUnsubscribe> & typeof MixinBase = mixinUnsubscr
     providers: [
         {
             provide: THY_TABLE_COLUMN_PARENT_COMPONENT,
-            useExisting: ThyTableComponent
+            useExisting: ThyTable
         },
         UpdateHostClassService
     ],
@@ -145,22 +145,22 @@ const _MixinBase: Constructor<ThyUnsubscribe> & typeof MixinBase = mixinUnsubscr
         NgFor,
         NgIf,
         NgTemplateOutlet,
-        ThyIconComponent,
+        ThyIcon,
         ThyDragDropDirective,
         CdkDropList,
         CdkDrag,
         ThyContextMenuDirective,
         NgStyle,
         FormsModule,
-        ThySwitchComponent,
-        ThyEmptyComponent,
-        ThyTableSkeletonComponent,
-        ThyPaginationComponent,
+        ThySwitch,
+        ThyEmpty,
+        ThyTableSkeleton,
+        ThyPagination,
         TableIsValidModelValuePipe,
         TableRowDragDisabledPipe
     ]
 })
-export class ThyTableComponent extends _MixinBase implements OnInit, OnChanges, AfterViewInit, OnDestroy, IThyTableColumnParentComponent {
+export class ThyTable extends _MixinBase implements OnInit, OnChanges, AfterViewInit, OnDestroy, IThyTableColumnParentComponent {
     public customType = customType;
 
     public model: object[] = [];

--- a/src/table/table.module.ts
+++ b/src/table/table.module.ts
@@ -15,8 +15,8 @@ import { FormsModule } from '@angular/forms';
 import { TableRowDragDisabledPipe } from './pipes/drag.pipe';
 import { TableIsValidModelValuePipe } from './pipes/table.pipe';
 import { ThyTableColumnComponent } from './table-column.component';
-import { ThyTableComponent } from './table.component';
-import { ThyTableSkeletonComponent } from './table-skeleton.component';
+import { ThyTable } from './table.component';
+import { ThyTableSkeleton } from './table-skeleton.component';
 
 @NgModule({
     imports: [
@@ -31,12 +31,12 @@ import { ThyTableSkeletonComponent } from './table-skeleton.component';
         ThyIconModule,
         DragDropModule,
         ScrollingModule,
-        ThyTableComponent,
+        ThyTable,
         ThyTableColumnComponent,
         TableIsValidModelValuePipe,
         TableRowDragDisabledPipe,
-        ThyTableSkeletonComponent
+        ThyTableSkeleton
     ],
-    exports: [ThyTableComponent, ThyTableColumnComponent, ThyTableSkeletonComponent]
+    exports: [ThyTable, ThyTableColumnComponent, ThyTableSkeleton]
 })
 export class ThyTableModule {}

--- a/src/table/test/table-skeleton.spec.ts
+++ b/src/table/test/table-skeleton.spec.ts
@@ -7,7 +7,7 @@ import {
     ThyTableModule,
     ThyTableSize,
     ThyTableSkeletonColumn,
-    ThyTableSkeletonComponent,
+    ThyTableSkeleton,
     ThyTableTheme
 } from 'ngx-tethys/table';
 import { SafeAny } from 'ngx-tethys/types';
@@ -63,7 +63,7 @@ class TestTableSkeletonBasicComponent {
 describe('thy-table-skeleton', () => {
     let fixture: ComponentFixture<TestTableSkeletonBasicComponent>;
     let tableSkeletonElement: SafeAny;
-    let tableSkeletonInstance: ThyTableSkeletonComponent;
+    let tableSkeletonInstance: ThyTableSkeleton;
     let tableDebugElement: DebugElement;
     let tableElement: SafeAny;
     let testComponent: TestTableSkeletonBasicComponent;
@@ -76,7 +76,7 @@ describe('thy-table-skeleton', () => {
 
         fixture = TestBed.createComponent(TestTableSkeletonBasicComponent);
 
-        const tableSkeletonDebugElement = fixture.debugElement.query(By.directive(ThyTableSkeletonComponent));
+        const tableSkeletonDebugElement = fixture.debugElement.query(By.directive(ThyTableSkeleton));
         tableSkeletonElement = tableSkeletonDebugElement.nativeElement;
         tableSkeletonInstance = tableSkeletonDebugElement.componentInstance;
 

--- a/src/table/test/table-tree.spec.ts
+++ b/src/table/test/table-tree.spec.ts
@@ -4,7 +4,7 @@ import { Component, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { ThyTableComponent } from '../table.component';
+import { ThyTable } from '../table.component';
 import { ThyTableModule } from '../table.module';
 
 @Component({
@@ -136,7 +136,7 @@ describe('ThyTable: tree', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyDemoTableTreeComponent);
         testComponent = fixture.debugElement.componentInstance;
-        tableComponent = fixture.debugElement.query(By.directive(ThyTableComponent));
+        tableComponent = fixture.debugElement.query(By.directive(ThyTable));
         fixture.detectChanges();
         rows = tableComponent.nativeElement.querySelectorAll('tr');
     });
@@ -187,7 +187,7 @@ describe('ThyTable: tree', () => {
         fixture = TestBed.createComponent(ThyDemoTableTreeComponent);
         fixture.componentInstance.showExpand = true;
         testComponent = fixture.debugElement.componentInstance;
-        tableComponent = fixture.debugElement.query(By.directive(ThyTableComponent));
+        tableComponent = fixture.debugElement.query(By.directive(ThyTable));
         fixture.detectChanges();
         rows = tableComponent.nativeElement.querySelectorAll('tr');
 

--- a/src/table/test/table.spec.ts
+++ b/src/table/test/table.spec.ts
@@ -1,11 +1,11 @@
-import { ThySwitchComponent } from 'ngx-tethys/switch';
+import { ThySwitch } from 'ngx-tethys/switch';
 import { createFakeEvent, dispatchFakeEvent, dispatchMouseEvent } from 'ngx-tethys/testing';
 
 import { ApplicationRef, Component, DebugElement, NgModule, TemplateRef, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { ThyTableComponent } from '../table.component';
+import { ThyTable } from '../table.component';
 import { ThyPage, ThyTableDraggableEvent, ThyTableSortDirection } from '../table.interface';
 import { ThyTableModule } from '../table.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -77,7 +77,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
     `
 })
 class ThyDemoDefaultTableComponent {
-    @ViewChild('table') table: ThyTableComponent;
+    @ViewChild('table') table: ThyTable;
 
     isCheckbox = true;
 
@@ -224,7 +224,7 @@ describe('ThyTable: basic', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyDemoDefaultTableComponent);
         testComponent = fixture.debugElement.componentInstance;
-        tableComponent = fixture.debugElement.query(By.directive(ThyTableComponent));
+        tableComponent = fixture.debugElement.query(By.directive(ThyTable));
         table = tableComponent.nativeElement.querySelector('table');
     });
 
@@ -587,10 +587,10 @@ describe('ThyTable: basic', () => {
 
     it('should call onSwitchChange when change switch', fakeAsync(() => {
         fixture.detectChanges();
-        const switchComponent: DebugElement = (tableComponent as DebugElement).query(By.directive(ThySwitchComponent));
+        const switchComponent: DebugElement = (tableComponent as DebugElement).query(By.directive(ThySwitch));
         rows = tableComponent.nativeElement.querySelectorAll('tr');
         const switchChangeSpy = spyOn(testComponent, 'onSwitchChange');
-        (switchComponent.componentInstance as ThySwitchComponent).toggle({} as Event);
+        (switchComponent.componentInstance as ThySwitch).toggle({} as Event);
         fixture.detectChanges();
         tick(1000);
         fixture.detectChanges();
@@ -710,7 +710,7 @@ describe('ThyTable: basic', () => {
     ]
 })
 class ThyDemoGroupTableComponent {
-    @ViewChild('table') innerTable: ThyTableComponent;
+    @ViewChild('table') innerTable: ThyTable;
 
     groups = [
         {
@@ -817,7 +817,7 @@ describe('ThyTable: group', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyDemoGroupTableComponent);
         testComponent = fixture.debugElement.componentInstance;
-        tableComponent = fixture.debugElement.query(By.directive(ThyTableComponent));
+        tableComponent = fixture.debugElement.query(By.directive(ThyTable));
         table = tableComponent.nativeElement.querySelector('table');
         fixture.detectChanges();
         rows = table.querySelectorAll('tr');
@@ -1074,7 +1074,7 @@ describe('ThyTable: empty', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyDemoEmptyTableComponent);
         testComponent = fixture.debugElement.componentInstance;
-        tableComponent = fixture.debugElement.query(By.directive(ThyTableComponent));
+        tableComponent = fixture.debugElement.query(By.directive(ThyTable));
     });
 
     it('should be created table component', () => {
@@ -1124,7 +1124,7 @@ describe('ThyTable: fixed', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyDemoFixedTableComponent);
         testComponent = fixture.debugElement.componentInstance;
-        tableComponent = fixture.debugElement.query(By.directive(ThyTableComponent));
+        tableComponent = fixture.debugElement.query(By.directive(ThyTable));
     });
 
     it('should be created table component', () => {
@@ -1193,7 +1193,7 @@ describe('ThyTable: sort', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyDemoSortTableComponent);
         testComponent = fixture.debugElement.componentInstance;
-        tableComponent = fixture.debugElement.query(By.directive(ThyTableComponent));
+        tableComponent = fixture.debugElement.query(By.directive(ThyTable));
     });
 
     it('should be created table component', () => {

--- a/src/tabs/tab-content.component.ts
+++ b/src/tabs/tab-content.component.ts
@@ -27,7 +27,7 @@ import { NgIf, NgTemplateOutlet } from '@angular/common';
     standalone: true,
     imports: [NgIf, NgTemplateOutlet]
 })
-export class ThyTabContentComponent {
+export class ThyTabContent {
     @Input() content: TemplateRef<void> | null = null;
 
     @Input() active = false;

--- a/src/tabs/tab.component.ts
+++ b/src/tabs/tab.component.ts
@@ -11,7 +11,7 @@ import { InputBoolean } from 'ngx-tethys/core';
     changeDetection: ChangeDetectionStrategy.OnPush,
     standalone: true
 })
-export class ThyTabComponent implements OnInit {
+export class ThyTab implements OnInit {
     /**
      * 自定义选项标题的模板
      * @type TemplateRef

--- a/src/tabs/tabs.component.ts
+++ b/src/tabs/tabs.component.ts
@@ -18,11 +18,11 @@ import { Constructor, InputBoolean, MixinBase, mixinUnsubscribe, ThyUnsubscribe 
 import { isString } from 'ngx-tethys/util';
 import { fromEvent } from 'rxjs';
 import { takeUntil } from 'rxjs/operators';
-import { ThyTabComponent } from './tab.component';
+import { ThyTab } from './tab.component';
 import { ThyActiveTabInfo, ThyTabActiveEvent } from './types';
-import { ThyTabContentComponent } from './tab-content.component';
+import { ThyTabContent } from './tab-content.component';
 import { NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
-import { ThyNavComponent, ThyNavItemDirective } from 'ngx-tethys/nav';
+import { ThyNav, ThyNavItemDirective } from 'ngx-tethys/nav';
 
 export type ThyTabsSize = 'lg' | 'md' | 'sm';
 
@@ -47,10 +47,10 @@ const _MixinBase: Constructor<ThyUnsubscribe> & typeof MixinBase = mixinUnsubscr
         '[style.overflow]': `transitionStarted ? "hidden" : null`
     },
     standalone: true,
-    imports: [ThyNavComponent, NgFor, ThyNavItemDirective, NgIf, NgTemplateOutlet, ThyTabContentComponent]
+    imports: [ThyNav, NgFor, ThyNavItemDirective, NgIf, NgTemplateOutlet, ThyTabContent]
 })
-export class ThyTabsComponent extends _MixinBase implements OnInit, OnChanges, AfterContentInit {
-    @ContentChildren(ThyTabComponent, { descendants: true }) tabs = new QueryList<ThyTabComponent>();
+export class ThyTabs extends _MixinBase implements OnInit, OnChanges, AfterContentInit {
+    @ContentChildren(ThyTab, { descendants: true }) tabs = new QueryList<ThyTab>();
 
     /**
      * 标签类型
@@ -151,7 +151,7 @@ export class ThyTabsComponent extends _MixinBase implements OnInit, OnChanges, A
         return '';
     }
 
-    activeTab(tab: ThyTabComponent, index: number) {
+    activeTab(tab: ThyTab, index: number) {
         if (tab.thyDisabled) {
             return;
         }
@@ -162,7 +162,7 @@ export class ThyTabsComponent extends _MixinBase implements OnInit, OnChanges, A
         this.thyActiveTabChange.emit(activeTab);
     }
 
-    tabTrackBy(index: number, item: ThyTabComponent) {
+    tabTrackBy(index: number, item: ThyTab) {
         return index;
     }
 }

--- a/src/tabs/tabs.module.ts
+++ b/src/tabs/tabs.module.ts
@@ -1,13 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyTabsComponent } from './tabs.component';
-import { ThyTabComponent } from './tab.component';
+import { ThyTabs } from './tabs.component';
+import { ThyTab } from './tab.component';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyNavModule } from 'ngx-tethys/nav';
-import { ThyTabContentComponent } from './tab-content.component';
+import { ThyTabContent } from './tab-content.component';
 
 @NgModule({
-    imports: [CommonModule, ThyIconModule, ThyNavModule, ThyTabsComponent, ThyTabComponent, ThyTabContentComponent],
-    exports: [ThyTabsComponent, ThyTabComponent]
+    imports: [CommonModule, ThyIconModule, ThyNavModule, ThyTabs, ThyTab, ThyTabContent],
+    exports: [ThyTabs, ThyTab]
 })
 export class ThyTabsModule {}

--- a/src/tabs/test/tabs.spec.ts
+++ b/src/tabs/test/tabs.spec.ts
@@ -2,10 +2,10 @@ import { ComponentType } from '@angular/cdk/portal';
 import { Component, DebugElement, ElementRef, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ThyNavComponent } from 'ngx-tethys/nav';
+import { ThyNav } from 'ngx-tethys/nav';
 import { createFakeEvent, dispatchFakeEvent } from 'ngx-tethys/testing';
 import { SafeAny } from 'ngx-tethys/types';
-import { ThyTabsComponent, ThyTabsPosition, ThyTabsSize, ThyTabsType } from '../tabs.component';
+import { ThyTabs, ThyTabsPosition, ThyTabsSize, ThyTabsType } from '../tabs.component';
 import { ThyTabsModule } from '../tabs.module';
 import { ThyActiveTabInfo, ThyTabActiveEvent } from '../types';
 
@@ -166,7 +166,7 @@ class TestTabsDisabledComponent {
     `
 })
 class TestTabsAnimatedComponent {
-    @ViewChild('tabs', { static: true }) tabComponent: ElementRef<ThyTabsComponent>;
+    @ViewChild('tabs', { static: true }) tabComponent: ElementRef<ThyTabs>;
 }
 
 describe('tabs', () => {
@@ -174,7 +174,7 @@ describe('tabs', () => {
         let fixture: ComponentFixture<TestTabsBasicComponent>;
         let tabsDebugElement: DebugElement;
         let tabsElement: HTMLElement;
-        let tabsInstance: ThyTabsComponent;
+        let tabsInstance: ThyTabs;
 
         beforeEach(() => {
             TestBed.configureTestingModule({
@@ -183,7 +183,7 @@ describe('tabs', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestTabsBasicComponent);
-            tabsDebugElement = getDebugElement(fixture, ThyTabsComponent);
+            tabsDebugElement = getDebugElement(fixture, ThyTabs);
             tabsElement = tabsDebugElement.nativeElement;
             tabsInstance = tabsDebugElement.componentInstance;
             fixture.detectChanges();
@@ -224,7 +224,7 @@ describe('tabs', () => {
                 fixture.detectChanges();
                 tick();
                 fixture.detectChanges();
-                const navElement = getDebugElement(fixture, ThyNavComponent).nativeElement;
+                const navElement = getDebugElement(fixture, ThyNav).nativeElement;
                 expect(navElement.classList.contains(`thy-nav-${type}`)).toBeTruthy();
             });
         }));
@@ -249,7 +249,7 @@ describe('tabs', () => {
                 fixture.detectChanges();
                 tick();
                 fixture.detectChanges();
-                const tabsElement = getDebugElement(fixture, ThyNavComponent).nativeElement;
+                const tabsElement = getDebugElement(fixture, ThyNav).nativeElement;
                 expect(tabsElement.classList.contains(`thy-nav-${size}`)).toBeTruthy();
             });
         }));
@@ -323,7 +323,7 @@ describe('tabs', () => {
         }));
 
         function getTabsClassList() {
-            return fixture.debugElement.query(By.directive(ThyTabsComponent)).nativeElement.classList;
+            return fixture.debugElement.query(By.directive(ThyTabs)).nativeElement.classList;
         }
     });
 
@@ -358,7 +358,7 @@ describe('tabs', () => {
         it('should set thyActiveTab successfully when thyActiveTab type is number', () => {
             fixture.debugElement.componentInstance.activeTab = 1;
             fixture.detectChanges();
-            const tabsInstance = getDebugElement(fixture, ThyTabsComponent).componentInstance;
+            const tabsInstance = getDebugElement(fixture, ThyTabs).componentInstance;
             expect(tabsInstance.activeTabIndex).toEqual(1);
         });
 
@@ -385,7 +385,7 @@ describe('tabs', () => {
         });
 
         it('should support add tab dynamically', fakeAsync(() => {
-            const tabsInstance = getDebugElement(fixture, ThyTabsComponent).componentInstance;
+            const tabsInstance = getDebugElement(fixture, ThyTabs).componentInstance;
             expect(tabsInstance.tabs.length).toBe(3);
 
             fixture.debugElement.componentInstance.addTab();
@@ -396,7 +396,7 @@ describe('tabs', () => {
         }));
 
         it('should set thyActiveTab successfully when add tab', fakeAsync(() => {
-            const tabsInstance = getDebugElement(fixture, ThyTabsComponent).componentInstance;
+            const tabsInstance = getDebugElement(fixture, ThyTabs).componentInstance;
             expect(tabsInstance.tabs.length).toBe(3);
 
             fixture.debugElement.componentInstance.addTab();
@@ -412,7 +412,7 @@ describe('tabs', () => {
         }));
 
         it('should set thyActiveTab successfully when add tab and thyAnimated', fakeAsync(() => {
-            const tabsInstance = getDebugElement(fixture, ThyTabsComponent).componentInstance;
+            const tabsInstance = getDebugElement(fixture, ThyTabs).componentInstance;
             expect(tabsInstance.tabs.length).toBe(3);
 
             fixture.debugElement.componentInstance.addTab();
@@ -444,7 +444,7 @@ describe('tabs', () => {
 
         it('should set thyDisabled successfully', fakeAsync(() => {
             const spy = jasmine.createSpy('spy on tab click');
-            const tabsInstance = getDebugElement(fixture, ThyTabsComponent).componentInstance;
+            const tabsInstance = getDebugElement(fixture, ThyTabs).componentInstance;
             tabsInstance.thyActiveTabChange.subscribe((event: ThyTabActiveEvent) => {
                 spy();
             });

--- a/src/tag/tag.component.ts
+++ b/src/tag/tag.component.ts
@@ -29,7 +29,7 @@ export type ThyTagSize = 'sm' | 'md' | 'lg';
     },
     standalone: true
 })
-export class ThyTagComponent implements OnInit, OnChanges {
+export class ThyTag implements OnInit, OnChanges {
     private color: ThyTagColor = 'default';
 
     private hostRenderer = useHostRenderer();

--- a/src/tag/tag.module.ts
+++ b/src/tag/tag.module.ts
@@ -1,11 +1,11 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyTagComponent } from './tag.component';
+import { ThyTag } from './tag.component';
 import { ThyIconModule } from 'ngx-tethys/icon';
-import { ThyTagsComponent } from './tags.component';
+import { ThyTags } from './tags.component';
 
 @NgModule({
-    imports: [CommonModule, ThyIconModule, ThyTagComponent, ThyTagsComponent],
-    exports: [ThyTagComponent, ThyTagsComponent]
+    imports: [CommonModule, ThyIconModule, ThyTag, ThyTags],
+    exports: [ThyTag, ThyTags]
 })
 export class ThyTagModule {}

--- a/src/tag/tags.component.ts
+++ b/src/tag/tags.component.ts
@@ -12,7 +12,7 @@ import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
     },
     standalone: true
 })
-export class ThyTagsComponent implements OnInit {
+export class ThyTags implements OnInit {
     constructor() {}
 
     ngOnInit(): void {}

--- a/src/tag/test/tags.component.spec.ts
+++ b/src/tag/test/tags.component.spec.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit } from '@angular/core';
 import { TestBed, waitForAsync, ComponentFixture } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
-import { ThyTagsComponent } from '../tags.component';
+import { ThyTags } from '../tags.component';
 import { ThyTagModule } from '../tag.module';
 import { ThyIconModule } from 'ngx-tethys/icon';
 
@@ -35,7 +35,7 @@ describe('thy-tags', () => {
     });
 
     it('should create thy-tags', () => {
-        const tagsDebugElement = fixture.debugElement.query(By.directive(ThyTagsComponent));
+        const tagsDebugElement = fixture.debugElement.query(By.directive(ThyTags));
         expect(tagsDebugElement).toBeTruthy();
         const tagsElement: HTMLElement = tagsDebugElement.nativeElement;
         expect(tagsElement.classList.contains('thy-tags')).toBeTruthy();

--- a/src/time-picker/inner/inner-time-picker.component.ts
+++ b/src/time-picker/inner/inner-time-picker.component.ts
@@ -37,7 +37,7 @@ import { ThyTimePickerStore } from './inner-time-picker.store';
 
 export const TIMEPICKER_CONTROL_VALUE_ACCESSOR: StaticProvider = {
     provide: NG_VALUE_ACCESSOR,
-    useExisting: forwardRef(() => ThyInnerTimePickerComponent),
+    useExisting: forwardRef(() => ThyInnerTimePicker),
     multi: true
 };
 
@@ -52,9 +52,7 @@ export const TIMEPICKER_CONTROL_VALUE_ACCESSOR: StaticProvider = {
     standalone: true,
     imports: [NgIf]
 })
-export class ThyInnerTimePickerComponent
-    implements ControlValueAccessor, TimePickerComponentState, TimePickerControls, OnChanges, OnDestroy
-{
+export class ThyInnerTimePicker implements ControlValueAccessor, TimePickerComponentState, TimePickerControls, OnChanges, OnDestroy {
     /** hours change step */
     @Input() hourStep: number;
     /** hours change step */

--- a/src/time-picker/test/inner-time-picker.component.spec.ts
+++ b/src/time-picker/test/inner-time-picker.component.spec.ts
@@ -6,7 +6,7 @@ import { Component, DebugElement, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { ThyInnerTimePickerComponent } from '../inner/inner-time-picker.component';
+import { ThyInnerTimePicker } from '../inner/inner-time-picker.component';
 import { ThyTimePickerModule } from '../time-picker.module';
 
 registerLocaleData(zh);
@@ -480,7 +480,7 @@ describe('ThyInnerTimePickerComponent', () => {
 class ThyTestInnerTimePickerBaseComponent {
     public containerClass = CONTAINER_CLASS;
 
-    @ViewChild('timePicker') timePicker: ThyInnerTimePickerComponent;
+    @ViewChild('timePicker') timePicker: ThyInnerTimePicker;
     // 默认值与 timePicker 的默认值一致，见 ../time-picker.config.ts
     readonly = false;
 

--- a/src/time-picker/test/time-picker-panel.component.spec.ts
+++ b/src/time-picker/test/time-picker-panel.component.spec.ts
@@ -2,7 +2,7 @@ import { Component, DebugElement, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, flush, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
-import { ThyTimePanelComponent } from '../time-picker-panel.component';
+import { ThyTimePanel } from '../time-picker-panel.component';
 import { ThyTimePickerModule } from '../time-picker.module';
 
 describe('ThyTimePanelComponent', () => {
@@ -240,7 +240,7 @@ describe('ThyTimePanelComponent', () => {
     `
 })
 class ThyTestTimePanelComponent {
-    @ViewChild('panel') timePanelRef: ThyTimePanelComponent;
+    @ViewChild('panel') timePanelRef: ThyTimePanel;
 
     value: Date | number;
 

--- a/src/time-picker/test/time-picker.component.spec.ts
+++ b/src/time-picker/test/time-picker.component.spec.ts
@@ -4,7 +4,7 @@ import { ComponentFixture, fakeAsync, flush, inject, TestBed, tick } from '@angu
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { dispatchMouseEvent, dispatchFakeEvent } from 'ngx-tethys/testing';
-import { ThyTimePickerComponent, TimePickerSize } from '../time-picker.component';
+import { ThyTimePicker, TimePickerSize } from '../time-picker.component';
 import { ThyTimePickerModule } from '../time-picker.module';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
@@ -441,7 +441,7 @@ describe('ThyTimePickerComponent', () => {
     `
 })
 class ThyTestTimePickerBaseComponent {
-    @ViewChild('timePicker', { static: false }) timePickerRef: ThyTimePickerComponent;
+    @ViewChild('timePicker', { static: false }) timePickerRef: ThyTimePicker;
 
     value: Date | number;
 

--- a/src/time-picker/time-picker-panel.component.ts
+++ b/src/time-picker/time-picker-panel.component.ts
@@ -16,7 +16,7 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 import { isValid } from 'date-fns';
 import { InputBoolean, reqAnimFrame } from 'ngx-tethys/core';
 import { TinyDate } from 'ngx-tethys/util';
-import { ThyButtonComponent } from 'ngx-tethys/button';
+import { ThyButton } from 'ngx-tethys/button';
 import { NgIf, NgFor, DecimalPipe } from '@angular/common';
 
 /**
@@ -31,7 +31,7 @@ import { NgIf, NgFor, DecimalPipe } from '@angular/common';
         {
             provide: NG_VALUE_ACCESSOR,
             multi: true,
-            useExisting: forwardRef(() => ThyTimePanelComponent)
+            useExisting: forwardRef(() => ThyTimePanel)
         }
     ],
     host: {
@@ -41,9 +41,9 @@ import { NgIf, NgFor, DecimalPipe } from '@angular/common';
         '[class.thy-time-picker-panel-columns-3]': `showColumnCount === 3`
     },
     standalone: true,
-    imports: [NgIf, NgFor, ThyButtonComponent, DecimalPipe]
+    imports: [NgIf, NgFor, ThyButton, DecimalPipe]
 })
-export class ThyTimePanelComponent implements OnInit, OnDestroy, ControlValueAccessor {
+export class ThyTimePanel implements OnInit, OnDestroy, ControlValueAccessor {
     @ViewChild('hourListElement', { static: false }) hourListRef: ElementRef<HTMLElement>;
 
     @ViewChild('minuteListElement', { static: false }) minuteListRef: ElementRef<HTMLElement>;

--- a/src/time-picker/time-picker.component.ts
+++ b/src/time-picker/time-picker.component.ts
@@ -16,8 +16,8 @@ import { ControlValueAccessor, NG_VALUE_ACCESSOR, FormsModule } from '@angular/f
 import { isValid } from 'date-fns';
 import { getFlexiblePositions, InputBoolean, ThyPlacement } from 'ngx-tethys/core';
 import { TinyDate, coerceBooleanProperty } from 'ngx-tethys/util';
-import { ThyTimePanelComponent } from './time-picker-panel.component';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyTimePanel } from './time-picker-panel.component';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgTemplateOutlet, NgIf, NgClass } from '@angular/common';
 import { ThyInputDirective } from 'ngx-tethys/input';
 import { scaleMotion, scaleXMotion, scaleYMotion } from 'ngx-tethys/core';
@@ -36,7 +36,7 @@ export type TimePickerSize = 'xs' | 'sm' | 'md' | 'lg' | 'default';
         {
             provide: NG_VALUE_ACCESSOR,
             multi: true,
-            useExisting: forwardRef(() => ThyTimePickerComponent)
+            useExisting: forwardRef(() => ThyTimePicker)
         }
     ],
     host: {
@@ -51,14 +51,14 @@ export type TimePickerSize = 'xs' | 'sm' | 'md' | 'lg' | 'default';
         FormsModule,
         NgTemplateOutlet,
         NgIf,
-        ThyIconComponent,
+        ThyIcon,
         NgClass,
         CdkConnectedOverlay,
-        ThyTimePanelComponent
+        ThyTimePanel
     ],
     animations: [scaleXMotion, scaleYMotion, scaleMotion]
 })
-export class ThyTimePickerComponent implements OnInit, AfterViewInit, ControlValueAccessor {
+export class ThyTimePicker implements OnInit, AfterViewInit, ControlValueAccessor {
     @ViewChild(CdkConnectedOverlay, { static: true }) cdkConnectedOverlay: CdkConnectedOverlay;
 
     @ViewChild('origin', { static: true }) origin: CdkOverlayOrigin;

--- a/src/time-picker/time-picker.module.ts
+++ b/src/time-picker/time-picker.module.ts
@@ -1,20 +1,20 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
-import { ThyInnerTimePickerComponent } from './inner/inner-time-picker.component';
+import { ThyInnerTimePicker } from './inner/inner-time-picker.component';
 import { TimePickerConfig } from './inner/inner-time-picker.config';
 import { ThyTimePickerStore } from './inner/inner-time-picker.store';
-import { ThyTimePickerComponent } from './time-picker.component';
+import { ThyTimePicker } from './time-picker.component';
 import { FormsModule } from '@angular/forms';
 import { OverlayModule } from '@angular/cdk/overlay';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyInputModule } from 'ngx-tethys/input';
 import { ThyPopoverModule } from 'ngx-tethys/popover';
 import { ThySharedModule } from 'ngx-tethys/shared';
-import { ThyTimePanelComponent } from './time-picker-panel.component';
+import { ThyTimePanel } from './time-picker-panel.component';
 import { ThyButtonModule } from 'ngx-tethys/button';
 
-const COMPONENTS = [ThyInnerTimePickerComponent, ThyTimePickerComponent, ThyTimePanelComponent];
+const COMPONENTS = [ThyInnerTimePicker, ThyTimePicker, ThyTimePanel];
 
 @NgModule({
     imports: [

--- a/src/timeline/test/timline.spec.ts
+++ b/src/timeline/test/timline.spec.ts
@@ -2,7 +2,7 @@ import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { ThyTimelineModule } from '../timeline.module';
 import { By } from '@angular/platform-browser';
-import { ThyTimeDirection, ThyTimelineComponent } from '../timeline.component';
+import { ThyTimeDirection, ThyTimeline } from '../timeline.component';
 
 @Component({
     template: `
@@ -94,7 +94,7 @@ describe('timeline', () => {
             fixture = TestBed.createComponent(TestTimelineBasicComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            debugElement = fixture.debugElement.query(By.directive(ThyTimelineComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyTimeline));
             items = Array.from((fixture.debugElement.nativeElement as HTMLElement).querySelectorAll('.thy-timeline-item'));
             fixture.detectChanges();
         });
@@ -191,7 +191,7 @@ describe('timeline', () => {
         }));
         beforeEach(() => {
             fixture = TestBed.createComponent(TestTimelineCustomDescriptionComponent);
-            debugElement = fixture.debugElement.query(By.directive(ThyTimelineComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyTimeline));
             fixture.detectChanges();
         });
 
@@ -211,7 +211,7 @@ describe('timeline', () => {
 
         beforeEach(() => {
             fixture = TestBed.createComponent(TestTimelineCustomHorizontalComponent);
-            debugElement = fixture.debugElement.query(By.directive(ThyTimelineComponent));
+            debugElement = fixture.debugElement.query(By.directive(ThyTimeline));
             fixture.detectChanges();
         });
 

--- a/src/timeline/timeline-item.component.ts
+++ b/src/timeline/timeline-item.component.ts
@@ -31,7 +31,7 @@ export type thyColor = 'primary' | 'success' | 'warning' | 'danger' | 'info';
     standalone: true,
     imports: [NgIf, NgTemplateOutlet]
 })
-export class ThyTimelineItemComponent implements OnInit, OnChanges {
+export class ThyTimelineItem implements OnInit, OnChanges {
     @ViewChild('timelineItem', { static: false }) template: TemplateRef<void>;
 
     @HostBinding('class') className: string;

--- a/src/timeline/timeline.component.ts
+++ b/src/timeline/timeline.component.ts
@@ -15,7 +15,7 @@ import {
     ChangeDetectionStrategy
 } from '@angular/core';
 import { takeUntil } from 'rxjs/operators';
-import { ThyTimelineItemComponent } from './timeline-item.component';
+import { ThyTimelineItem } from './timeline-item.component';
 import { ThyTimelineService } from './timeline.service';
 import { Subject } from 'rxjs';
 import { InputBoolean } from 'ngx-tethys/core';
@@ -54,7 +54,7 @@ export type ThyTimeDirection = 'horizontal' | 'vertical';
     standalone: true,
     imports: [NgFor, NgTemplateOutlet]
 })
-export class ThyTimelineComponent implements OnInit, AfterContentInit, OnChanges, OnDestroy {
+export class ThyTimeline implements OnInit, AfterContentInit, OnChanges, OnDestroy {
     /**
      * 节点排序是否倒序
      * @default false
@@ -74,7 +74,7 @@ export class ThyTimelineComponent implements OnInit, AfterContentInit, OnChanges
      */
     @Input() thyDirection: ThyTimeDirection = 'vertical';
 
-    public timelineItems: ThyTimelineItemComponent[] = [];
+    public timelineItems: ThyTimelineItem[] = [];
 
     private destroy$ = new Subject<void>();
 
@@ -84,8 +84,8 @@ export class ThyTimelineComponent implements OnInit, AfterContentInit, OnChanges
     @HostBinding(`class.thy-timeline-template`) templateTimeline = false;
     @HostBinding(`class.thy-timeline-horizontal`) horizontal = false;
 
-    @ContentChildren(ThyTimelineItemComponent)
-    listOfItems: QueryList<ThyTimelineItemComponent>;
+    @ContentChildren(ThyTimelineItem)
+    listOfItems: QueryList<ThyTimelineItem>;
 
     constructor(private cdr: ChangeDetectorRef, private timelineService: ThyTimelineService) {}
 

--- a/src/timeline/timeline.module.ts
+++ b/src/timeline/timeline.module.ts
@@ -2,12 +2,12 @@ import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ThySharedModule } from 'ngx-tethys/shared';
 import { ThyIconModule } from 'ngx-tethys/icon';
-import { ThyTimelineComponent } from './timeline.component';
-import { ThyTimelineItemComponent } from './timeline-item.component';
+import { ThyTimeline } from './timeline.component';
+import { ThyTimelineItem } from './timeline-item.component';
 
 @NgModule({
-    imports: [CommonModule, ThySharedModule, ThyIconModule, ThyTimelineComponent, ThyTimelineItemComponent],
-    exports: [ThyTimelineComponent, ThyTimelineItemComponent],
+    imports: [CommonModule, ThySharedModule, ThyIconModule, ThyTimeline, ThyTimelineItem],
+    exports: [ThyTimeline, ThyTimelineItem],
     providers: []
 })
 export class ThyTimelineModule {}

--- a/src/tooltip/tooltip-ref.ts
+++ b/src/tooltip/tooltip-ref.ts
@@ -8,17 +8,17 @@ import { isNumber } from 'ngx-tethys/util';
 import { Subject } from 'rxjs';
 import { take, takeUntil } from 'rxjs/operators';
 import { ThyTooltipContent } from './interface';
-import { ThyTooltipComponent } from './tooltip.component';
+import { ThyTooltip } from './tooltip.component';
 import { ThyTooltipConfig } from './tooltip.config';
 
 export class ThyTooltipRef {
     private overlayRef: OverlayRef;
 
-    private tooltipInstance: ThyTooltipComponent;
+    private tooltipInstance: ThyTooltip;
 
     private scrollStrategy: ScrollStrategy;
 
-    private portal: ComponentPortal<ThyTooltipComponent>;
+    private portal: ComponentPortal<ThyTooltip>;
 
     private readonly dispose$ = new Subject<void>();
 
@@ -114,7 +114,7 @@ export class ThyTooltipRef {
         }
         const overlayRef = this.createOverlay();
         this.detach();
-        this.portal = this.portal || new ComponentPortal(ThyTooltipComponent, this.config.viewContainerRef);
+        this.portal = this.portal || new ComponentPortal(ThyTooltip, this.config.viewContainerRef);
         this.tooltipInstance = overlayRef.attach(this.portal).instance;
         this.tooltipInstance
             .afterHidden()

--- a/src/tooltip/tooltip.component.ts
+++ b/src/tooltip/tooltip.component.ts
@@ -24,7 +24,7 @@ import { NgIf, NgTemplateOutlet } from '@angular/common';
     standalone: true,
     imports: [NgIf, NgTemplateOutlet]
 })
-export class ThyTooltipComponent implements OnInit {
+export class ThyTooltip implements OnInit {
     @HostBinding(`class.thy-tooltip`) addTooltipContainerClass = true;
 
     _content: string | TemplateRef<HTMLElement>;

--- a/src/tooltip/tooltip.module.ts
+++ b/src/tooltip/tooltip.module.ts
@@ -3,11 +3,11 @@ import { A11yModule } from '@angular/cdk/a11y';
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ThyTooltipDirective } from './tooltip.directive';
-import { ThyTooltipComponent } from './tooltip.component';
+import { ThyTooltip } from './tooltip.component';
 import { THY_TOOLTIP_DEFAULT_CONFIG_PROVIDER } from './tooltip.config';
 
 @NgModule({
-    imports: [A11yModule, CommonModule, OverlayModule, ThyTooltipDirective, ThyTooltipComponent],
+    imports: [A11yModule, CommonModule, OverlayModule, ThyTooltipDirective, ThyTooltip],
     exports: [ThyTooltipDirective],
     providers: [THY_TOOLTIP_DEFAULT_CONFIG_PROVIDER]
 })

--- a/src/transfer/test/transfer.spec.ts
+++ b/src/transfer/test/transfer.spec.ts
@@ -7,7 +7,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
-import { ThyTransferComponent } from '../transfer.component';
+import { ThyTransfer } from '../transfer.component';
 import {
     ThyTransferChangeEvent,
     ThyTransferDragEvent,
@@ -149,7 +149,7 @@ function buildDataList() {
     encapsulation: ViewEncapsulation.None
 })
 class TestTransferComponent {
-    @ViewChild('comp', { static: true }) comp: ThyTransferComponent;
+    @ViewChild('comp', { static: true }) comp: ThyTransfer;
     dataSource: any[] = buildDataList();
     titles = ['Source', 'Target'];
 
@@ -170,7 +170,7 @@ class TestTransferComponent {
     `
 })
 class TestTransferCustomRenderComponent {
-    @ViewChild('comp', { static: true }) comp: ThyTransferComponent;
+    @ViewChild('comp', { static: true }) comp: ThyTransfer;
     dataSource: any[] = buildDataList();
 }
 
@@ -179,7 +179,7 @@ class TestTransferCustomRenderComponent {
     encapsulation: ViewEncapsulation.None
 })
 class TestTransferCustomRenderContentComponent {
-    @ViewChild('comp', { static: true }) comp: ThyTransferComponent;
+    @ViewChild('comp', { static: true }) comp: ThyTransfer;
     dataSource: any[] = buildDataList();
     titles = ['Source', 'Target'];
 
@@ -199,7 +199,7 @@ describe('transfer', () => {
     let dl: DebugElement;
     let instance: TestTransferComponent;
     let pageObject: TransferPageObject;
-    let transferComponent: ThyTransferComponent;
+    let transferComponent: ThyTransfer;
 
     beforeEach(() => {
         TestBed.configureTestingModule({
@@ -218,9 +218,7 @@ describe('transfer', () => {
     });
 
     it('should have class thy-transfer', () => {
-        expect(
-            fixture.debugElement.query(By.directive(ThyTransferComponent)).nativeElement.classList.contains('thy-transfer')
-        ).toBeTruthy();
+        expect(fixture.debugElement.query(By.directive(ThyTransfer)).nativeElement.classList.contains('thy-transfer')).toBeTruthy();
     });
 
     it('should show correct title', () => {

--- a/src/transfer/transfer-list.component.ts
+++ b/src/transfer/transfer-list.component.ts
@@ -15,7 +15,7 @@ import {
 } from '@angular/core';
 
 import { NgClass, NgFor, NgIf, NgTemplateOutlet } from '@angular/common';
-import { ThyListComponent, ThyListItemComponent } from 'ngx-tethys/list';
+import { ThyList, ThyListItem } from 'ngx-tethys/list';
 import { ThyDragDropDirective } from 'ngx-tethys/shared';
 import { InnerTransferDragEvent, ThyTransferDragEvent, ThyTransferItem, ThyTransferSelectEvent } from './transfer.interface';
 
@@ -27,20 +27,9 @@ import { InnerTransferDragEvent, ThyTransferDragEvent, ThyTransferItem, ThyTrans
     templateUrl: './transfer-list.component.html',
     encapsulation: ViewEncapsulation.None,
     standalone: true,
-    imports: [
-        NgIf,
-        CdkDropListGroup,
-        ThyListComponent,
-        CdkDropList,
-        ThyDragDropDirective,
-        NgFor,
-        ThyListItemComponent,
-        CdkDrag,
-        NgClass,
-        NgTemplateOutlet
-    ]
+    imports: [NgIf, CdkDropListGroup, ThyList, CdkDropList, ThyDragDropDirective, NgFor, ThyListItem, CdkDrag, NgClass, NgTemplateOutlet]
 })
-export class ThyTransferListComponent implements OnInit, DoCheck {
+export class ThyTransferList implements OnInit, DoCheck {
     public lockItems: ThyTransferItem[] = [];
 
     public unlockItems: ThyTransferItem[] = [];

--- a/src/transfer/transfer.component.ts
+++ b/src/transfer/transfer.component.ts
@@ -9,10 +9,10 @@ import {
     ThyTransferSelectEvent,
     TransferDirection
 } from './transfer.interface';
-import { ThyFlexibleTextComponent } from 'ngx-tethys/flexible-text';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyFlexibleText } from 'ngx-tethys/flexible-text';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgClass, NgTemplateOutlet } from '@angular/common';
-import { ThyTransferListComponent } from './transfer-list.component';
+import { ThyTransferList } from './transfer-list.component';
 
 /**
  * 穿梭框组件
@@ -24,9 +24,9 @@ import { ThyTransferListComponent } from './transfer-list.component';
     templateUrl: './transfer.component.html',
     encapsulation: ViewEncapsulation.None,
     standalone: true,
-    imports: [ThyTransferListComponent, NgIf, ThyIconComponent, NgClass, NgTemplateOutlet, ThyFlexibleTextComponent]
+    imports: [ThyTransferList, NgIf, ThyIcon, NgClass, NgTemplateOutlet, ThyFlexibleText]
 })
-export class ThyTransferComponent implements OnInit {
+export class ThyTransfer implements OnInit {
     @HostBinding('class') hostClass = 'thy-transfer';
 
     public leftDataSource: ThyTransferItem[] = [];

--- a/src/transfer/transfer.module.ts
+++ b/src/transfer/transfer.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
-import { ThyTransferComponent } from './transfer.component';
-import { ThyTransferListComponent } from './transfer-list.component';
+import { ThyTransfer } from './transfer.component';
+import { ThyTransferList } from './transfer-list.component';
 import { ThyButtonModule } from 'ngx-tethys/button';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { ThyIconModule } from 'ngx-tethys/icon';
@@ -17,9 +17,9 @@ import { ThyFlexibleTextModule } from 'ngx-tethys/flexible-text';
         ThyListModule,
         ThySharedModule,
         ThyFlexibleTextModule,
-        ThyTransferComponent,
-        ThyTransferListComponent
+        ThyTransfer,
+        ThyTransferList
     ],
-    exports: [ThyTransferComponent]
+    exports: [ThyTransfer]
 })
 export class ThyTransferModule {}

--- a/src/tree-select/module.ts
+++ b/src/tree-select/module.ts
@@ -6,7 +6,7 @@ import { ThyEmptyModule } from 'ngx-tethys/empty';
 import { ThyIconModule } from 'ngx-tethys/icon';
 import { ThyListModule } from 'ngx-tethys/list';
 import { ThySelectCommonModule, ThySharedModule } from 'ngx-tethys/shared';
-import { ThyTreeSelectComponent, ThyTreeSelectNodesComponent } from './tree-select.component';
+import { ThyTreeSelect, ThyTreeSelectNodes } from './tree-select.component';
 
 @NgModule({
     imports: [
@@ -18,9 +18,9 @@ import { ThyTreeSelectComponent, ThyTreeSelectNodesComponent } from './tree-sele
         ThyEmptyModule,
         ThySelectCommonModule,
         ThySharedModule,
-        ThyTreeSelectComponent,
-        ThyTreeSelectNodesComponent
+        ThyTreeSelect,
+        ThyTreeSelectNodes
     ],
-    exports: [ThyTreeSelectComponent, ThyTreeSelectNodesComponent]
+    exports: [ThyTreeSelect, ThyTreeSelectNodes]
 })
 export class ThyTreeSelectModule {}

--- a/src/tree-select/test/tree-select.spec.ts
+++ b/src/tree-select/test/tree-select.spec.ts
@@ -9,11 +9,11 @@ import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { By, DomSanitizer } from '@angular/platform-browser';
 
 import { ThyFormModule } from '../../form';
-import { ThyIconComponent, ThyIconRegistry } from '../../icon';
+import { ThyIcon, ThyIconRegistry } from '../../icon';
 import { bigTreeNodes, searchTreeSelectData } from '../examples/mock-data';
 import { ThyTreeSelectModule } from '../module';
 import { ThyTreeSelectNode } from '../tree-select.class';
-import { filterTreeData, ThyTreeSelectComponent } from '../tree-select.component';
+import { filterTreeData, ThyTreeSelect } from '../tree-select.component';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 function treeNodesExpands(nodes: ThyTreeSelectNode[]) {
@@ -52,7 +52,7 @@ function treeNodesExpands(nodes: ThyTreeSelectNode[]) {
     `
 })
 class BasicTreeSelectComponent {
-    @ViewChild(ThyTreeSelectComponent, { static: false }) treeComponent: ThyTreeSelectComponent;
+    @ViewChild(ThyTreeSelect, { static: false }) treeComponent: ThyTreeSelect;
 
     nodes: ThyTreeSelectNode[] = [
         {
@@ -141,7 +141,7 @@ class BasicTreeSelectComponent {
     expandTreeSelectOptions = false;
 
     @ViewChild('treeSelect', { static: true })
-    treeSelect: ThyTreeSelectComponent;
+    treeSelect: ThyTreeSelect;
 
     asyncNode = true;
 
@@ -268,7 +268,7 @@ class PlaceHolderTreeSelectComponent {
     thyPlaceholder = 'this is a placeholder';
 
     @ViewChild('treeSelect', { static: true })
-    treeSelect: ThyTreeSelectComponent;
+    treeSelect: ThyTreeSelect;
 }
 
 @Component({
@@ -365,7 +365,7 @@ class NgModelTreeSelectComponent {
     multiple = false;
 
     @ViewChild('treeSelect', { static: true })
-    treeSelect: ThyTreeSelectComponent;
+    treeSelect: ThyTreeSelect;
 
     treeSelectChange = jasmine.createSpy('treeSelectChange');
 }
@@ -392,7 +392,7 @@ class SearchTreeSelectComponent {
     treeShowSearch = true;
 
     @ViewChild('treeSelect', { static: true })
-    treeSelect: ThyTreeSelectComponent;
+    treeSelect: ThyTreeSelect;
 }
 
 @Component({
@@ -402,7 +402,7 @@ class SearchTreeSelectComponent {
     `
 })
 export class VirtualScrollingTreeSelectComponent implements OnInit {
-    @ViewChild('treeSelect', { static: true }) treeSelect: ThyTreeSelectComponent;
+    @ViewChild('treeSelect', { static: true }) treeSelect: ThyTreeSelect;
 
     mockData = bigTreeNodes;
     public selectedValue = '';
@@ -457,7 +457,7 @@ describe('ThyTreeSelect', () => {
                 configureThyCustomSelectTestingModule([BasicTreeSelectComponent]);
                 const fixture = TestBed.createComponent(BasicTreeSelectComponent);
                 fixture.detectChanges();
-                treeSelectDebugElement = fixture.debugElement.query(By.directive(ThyTreeSelectComponent));
+                treeSelectDebugElement = fixture.debugElement.query(By.directive(ThyTreeSelect));
                 treeSelectElement = treeSelectDebugElement.nativeElement;
             }));
 
@@ -468,7 +468,7 @@ describe('ThyTreeSelect', () => {
             });
 
             it('should get correct icon class', () => {
-                const iconDebugElement = treeSelectDebugElement.query(By.directive(ThyIconComponent));
+                const iconDebugElement = treeSelectDebugElement.query(By.directive(ThyIcon));
                 expect(iconDebugElement).toBeTruthy();
                 const iconElement = iconDebugElement.nativeElement;
                 expect(iconElement).toBeTruthy();
@@ -603,7 +603,7 @@ describe('ThyTreeSelect', () => {
 
             it('should call onFocus methods when focus', fakeAsync(() => {
                 const fixture = TestBed.createComponent(BasicTreeSelectComponent);
-                const treeSelectDebugElement = fixture.debugElement.query(By.directive(ThyTreeSelectComponent));
+                const treeSelectDebugElement = fixture.debugElement.query(By.directive(ThyTreeSelect));
                 fixture.detectChanges();
                 const focusSpy = spyOn(fixture.componentInstance.treeComponent, 'onFocus').and.callThrough();
 
@@ -888,7 +888,7 @@ describe('ThyTreeSelect', () => {
             tick(100);
             fixture.detectChanges();
 
-            treeSelectElement = fixture.debugElement.query(By.directive(ThyTreeSelectComponent)).nativeElement;
+            treeSelectElement = fixture.debugElement.query(By.directive(ThyTreeSelect)).nativeElement;
         }));
 
         it('should create', () => {

--- a/src/tree-select/tree-select.component.ts
+++ b/src/tree-select/tree-select.component.ts
@@ -33,10 +33,10 @@ import {
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 import { CdkFixedSizeVirtualScroll, CdkVirtualForOf, CdkVirtualScrollViewport } from '@angular/cdk/scrolling';
-import { ThyEmptyComponent } from 'ngx-tethys/empty';
-import { ThyIconComponent } from 'ngx-tethys/icon';
-import { ThyFlexibleTextComponent } from 'ngx-tethys/flexible-text';
-import { ThySelectControlComponent, ThyStopPropagationDirective } from 'ngx-tethys/shared';
+import { ThyEmpty } from 'ngx-tethys/empty';
+import { ThyIcon } from 'ngx-tethys/icon';
+import { ThyFlexibleText } from 'ngx-tethys/flexible-text';
+import { ThySelectControl, ThyStopPropagationDirective } from 'ngx-tethys/shared';
 import { ThyTreeSelectNode, ThyTreeSelectType } from './tree-select.class';
 import { scaleYMotion } from 'ngx-tethys/core';
 
@@ -72,18 +72,18 @@ export function filterTreeData(treeNodes: ThyTreeSelectNode[], searchText: strin
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThyTreeSelectComponent),
+            useExisting: forwardRef(() => ThyTreeSelect),
             multi: true
         }
     ],
     standalone: true,
     imports: [
         CdkOverlayOrigin,
-        ThySelectControlComponent,
+        ThySelectControl,
         NgIf,
         NgTemplateOutlet,
         CdkConnectedOverlay,
-        forwardRef(() => ThyTreeSelectNodesComponent),
+        forwardRef(() => ThyTreeSelectNodes),
         ThyStopPropagationDirective
     ],
     host: {
@@ -93,7 +93,7 @@ export function filterTreeData(treeNodes: ThyTreeSelectNode[], searchText: strin
     },
     animations: [scaleYMotion]
 })
-export class ThyTreeSelectComponent extends TabIndexDisabledControlValueAccessorMixin implements OnInit, OnDestroy, ControlValueAccessor {
+export class ThyTreeSelect extends TabIndexDisabledControlValueAccessorMixin implements OnInit, OnDestroy, ControlValueAccessor {
     @HostBinding('class.thy-select-custom') treeSelectClass = true;
 
     @HostBinding('class.thy-select') isTreeSelect = true;
@@ -576,17 +576,17 @@ const DEFAULT_ITEM_SIZE = 40;
         CdkVirtualScrollViewport,
         CdkFixedSizeVirtualScroll,
         CdkVirtualForOf,
-        ThyEmptyComponent,
+        ThyEmpty,
         NgClass,
         NgStyle,
-        ThyIconComponent,
-        ThyFlexibleTextComponent
+        ThyIcon,
+        ThyFlexibleText
     ],
     host: {
         '[attr.tabindex]': '-1'
     }
 })
-export class ThyTreeSelectNodesComponent implements OnInit {
+export class ThyTreeSelectNodes implements OnInit {
     @HostBinding('class') class: string;
 
     nodeList: ThyTreeSelectNode[] = [];
@@ -618,7 +618,7 @@ export class ThyTreeSelectNodesComponent implements OnInit {
 
     public thyVirtualHeight: string = null;
 
-    constructor(public parent: ThyTreeSelectComponent) {}
+    constructor(public parent: ThyTreeSelect) {}
 
     ngOnInit() {
         this.class = this.isMultiple ? 'thy-tree-select-dropdown thy-tree-select-dropdown-multiple' : 'thy-tree-select-dropdown';

--- a/src/tree/examples/async/async.component.ts
+++ b/src/tree/examples/async/async.component.ts
@@ -1,12 +1,12 @@
 import { Component, ViewChild } from '@angular/core';
-import { ThyTreeComponent, ThyTreeEmitEvent, ThyTreeNodeData } from 'ngx-tethys/tree';
+import { ThyTree, ThyTreeEmitEvent, ThyTreeNodeData } from 'ngx-tethys/tree';
 
 @Component({
     selector: 'thy-tree-async-example',
     templateUrl: './async.component.html'
 })
 export class ThyTreeAsyncExampleComponent {
-    @ViewChild('tree') treeComponent: ThyTreeComponent;
+    @ViewChild('tree') treeComponent: ThyTree;
 
     treeNodes: ThyTreeNodeData[] = [
         {

--- a/src/tree/test/tree.spec.ts
+++ b/src/tree/test/tree.spec.ts
@@ -17,7 +17,7 @@ import {
     ThyTreeDropPosition,
     ThyTreeEmitEvent
 } from '../tree.class';
-import { ThyTreeComponent } from '../tree.component';
+import { ThyTree } from '../tree.component';
 import { ThyTreeModule } from '../tree.module';
 import { bigTreeNodes, treeNodes, hasCheckTreeNodes } from './mock';
 import { ThyTreeNodeComponent } from '../tree-node.component';
@@ -54,7 +54,7 @@ describe('ThyTreeComponent', () => {
         let component: TestBasicTreeComponent;
         let fixture: ComponentFixture<TestBasicTreeComponent>;
         let multipleFixture: ComponentFixture<TestMultipleTreeComponent>;
-        let treeComponent: ThyTreeComponent;
+        let treeComponent: ThyTree;
 
         beforeEach(fakeAsync(() => {
             configureThyTreeTestingModule([TestBasicTreeComponent, TestMultipleTreeComponent]);
@@ -64,7 +64,7 @@ describe('ThyTreeComponent', () => {
             fixture.detectChanges();
             treeInstance = fixture.debugElement.componentInstance;
             treeComponent = fixture.debugElement.componentInstance.tree;
-            treeElement = fixture.debugElement.query(By.directive(ThyTreeComponent)).nativeElement;
+            treeElement = fixture.debugElement.query(By.directive(ThyTree)).nativeElement;
         }));
 
         it('should create', () => {
@@ -384,7 +384,7 @@ describe('ThyTreeComponent', () => {
             multipleFixture.detectChanges();
             tick(100);
             multipleFixture.detectChanges();
-            const multipleElement = multipleFixture.debugElement.query(By.directive(ThyTreeComponent)).nativeElement;
+            const multipleElement = multipleFixture.debugElement.query(By.directive(ThyTree)).nativeElement;
             const multipleTree = multipleFixture.debugElement.componentInstance.tree;
             const selectionModelSpy = spyOn(multipleTree._selectionModel, 'toggle');
             const nodeElement = multipleElement.querySelector('.thy-tree-node-wrapper') as HTMLElement;
@@ -457,7 +457,7 @@ describe('ThyTreeComponent', () => {
             fixture = TestBed.createComponent(TestAsyncTreeComponent);
             component = fixture.componentInstance;
             fixture.detectChanges();
-            treeElement = fixture.debugElement.query(By.directive(ThyTreeComponent)).nativeElement;
+            treeElement = fixture.debugElement.query(By.directive(ThyTree)).nativeElement;
         }));
 
         it('should create', () => {
@@ -494,7 +494,7 @@ describe('ThyTreeComponent', () => {
             fixture.detectChanges();
             tick(100);
             fixture.detectChanges();
-            treeElement = fixture.debugElement.query(By.directive(ThyTreeComponent)).nativeElement;
+            treeElement = fixture.debugElement.query(By.directive(ThyTree)).nativeElement;
         }));
 
         it('should create', () => {
@@ -579,7 +579,7 @@ describe('ThyTreeComponent', () => {
         let treeInstance: TestHasCheckedTreeComponent;
         let component: TestHasCheckedTreeComponent;
         let fixture: ComponentFixture<TestHasCheckedTreeComponent>;
-        let treeComponent: ThyTreeComponent;
+        let treeComponent: ThyTree;
 
         beforeEach(fakeAsync(() => {
             configureThyTreeTestingModule([TestHasCheckedTreeComponent, TestMultipleTreeComponent]);
@@ -588,7 +588,7 @@ describe('ThyTreeComponent', () => {
             fixture.detectChanges();
             treeInstance = fixture.debugElement.componentInstance;
             treeComponent = fixture.debugElement.componentInstance.tree;
-            treeElement = fixture.debugElement.query(By.directive(ThyTreeComponent)).nativeElement;
+            treeElement = fixture.debugElement.query(By.directive(ThyTree)).nativeElement;
         }));
 
         it('should create', () => {
@@ -623,7 +623,7 @@ describe('ThyTreeComponent', () => {
             component = fixture.componentInstance;
             elementFromPointSpy = spyOn(document, 'elementFromPoint');
             fixture.detectChanges();
-            treeElement = fixture.debugElement.query(By.directive(ThyTreeComponent)).nativeElement;
+            treeElement = fixture.debugElement.query(By.directive(ThyTree)).nativeElement;
             tick();
             fixture.detectChanges();
         }));
@@ -813,7 +813,7 @@ describe('ThyTreeComponent', () => {
     `
 })
 class TestBasicTreeComponent {
-    @ViewChild('tree', { static: true }) tree: ThyTreeComponent;
+    @ViewChild('tree', { static: true }) tree: ThyTree;
 
     // mock 不可变数据
     treeNodes = JSON.parse(JSON.stringify(treeNodes));
@@ -874,7 +874,7 @@ class TestBasicTreeComponent {
 export class TestMultipleTreeComponent {
     mockData = JSON.parse(JSON.stringify(treeNodes));
 
-    @ViewChild('tree', { static: true }) tree: ThyTreeComponent;
+    @ViewChild('tree', { static: true }) tree: ThyTree;
 
     constructor() {}
 }
@@ -898,7 +898,7 @@ export class TestAsyncTreeComponent {
         return { ...item, children: [], expanded: false };
     });
 
-    @ViewChild('tree', { static: true }) treeComponent: ThyTreeComponent;
+    @ViewChild('tree', { static: true }) treeComponent: ThyTree;
 
     constructor() {}
 
@@ -938,7 +938,7 @@ export class TestAsyncTreeComponent {
 export class TestVirtualScrollingTreeComponent implements OnInit {
     mockData = bigTreeNodes;
 
-    @ViewChild('tree', { static: true }) treeComponent: ThyTreeComponent;
+    @ViewChild('tree', { static: true }) treeComponent: ThyTree;
 
     setNodeItemClass(className: string, index: number): void {
         this.mockData[index].itemClass = className;
@@ -998,7 +998,7 @@ export class TestDragDropTreeComponent {
         }
     ];
 
-    @ViewChild('tree', { static: true }) treeComponent: ThyTreeComponent;
+    @ViewChild('tree', { static: true }) treeComponent: ThyTree;
 
     constructor() {}
 
@@ -1046,7 +1046,7 @@ export class TestDragDropTreeComponent {
     `
 })
 class TestHasCheckedTreeComponent {
-    @ViewChild('tree', { static: true }) tree: ThyTreeComponent;
+    @ViewChild('tree', { static: true }) tree: ThyTree;
 
     // mock 不可变数据
     hasCheckTreeNodes = JSON.parse(JSON.stringify(hasCheckTreeNodes));

--- a/src/tree/tree-node.component.ts
+++ b/src/tree/tree-node.component.ts
@@ -25,8 +25,8 @@ import { ThyTreeNode } from './tree-node.class';
 import { ThyTreeEmitEvent, ThyTreeNodeCheckState, ThyClickBehavior } from './tree.class';
 import { ThyTreeService } from './tree.service';
 import { InputBoolean, InputNumber } from 'ngx-tethys/core';
-import { ThyLoadingComponent } from 'ngx-tethys/loading';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyLoading } from 'ngx-tethys/loading';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgClass, NgStyle, NgTemplateOutlet } from '@angular/common';
 
 const passiveEventListenerOptions = <AddEventListenerOptions>normalizePassiveListenerOptions({ passive: true });
@@ -41,7 +41,7 @@ const passiveEventListenerOptions = <AddEventListenerOptions>normalizePassiveLis
     templateUrl: './tree-node.component.html',
     encapsulation: ViewEncapsulation.None,
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgClass, NgStyle, NgTemplateOutlet, ThyLoadingComponent]
+    imports: [NgIf, ThyIcon, NgClass, NgStyle, NgTemplateOutlet, ThyLoading]
 })
 export class ThyTreeNodeComponent implements OnDestroy, OnInit, OnChanges {
     /**

--- a/src/tree/tree.component.ts
+++ b/src/tree/tree.component.ts
@@ -73,12 +73,12 @@ const treeItemSizeMap = {
     providers: [
         {
             provide: NG_VALUE_ACCESSOR,
-            useExisting: forwardRef(() => ThyTreeComponent),
+            useExisting: forwardRef(() => ThyTree),
             multi: true
         },
         {
             provide: THY_TREE_ABSTRACT_TOKEN,
-            useExisting: forwardRef(() => ThyTreeComponent)
+            useExisting: forwardRef(() => ThyTree)
         },
         ThyTreeService
     ],
@@ -95,7 +95,7 @@ const treeItemSizeMap = {
         ThyTreeNodeDraggablePipe
     ]
 })
-export class ThyTreeComponent implements ControlValueAccessor, OnInit, OnChanges, AfterViewInit, OnDestroy {
+export class ThyTree implements ControlValueAccessor, OnInit, OnChanges, AfterViewInit, OnDestroy {
     private _templateRef: TemplateRef<any>;
 
     private _emptyChildrenTemplateRef: TemplateRef<any>;

--- a/src/tree/tree.module.ts
+++ b/src/tree/tree.module.ts
@@ -12,7 +12,7 @@ import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
 
 import { ThyTreeNodeComponent } from './tree-node.component';
-import { ThyTreeComponent } from './tree.component';
+import { ThyTree } from './tree.component';
 import { ThyTreeService } from './tree.service';
 import { DragDropModule } from '@angular/cdk/drag-drop';
 import { ThyTreeNodeDraggablePipe } from './tree.pipe';
@@ -31,11 +31,11 @@ import { ThyTreeNodeDraggablePipe } from './tree.pipe';
         ThyIconModule,
         ThyCheckboxModule,
         ScrollingModule,
-        ThyTreeComponent,
+        ThyTree,
         ThyTreeNodeComponent,
         ThyTreeNodeDraggablePipe
     ],
-    exports: [ThyTreeComponent, ThyTreeNodeComponent],
+    exports: [ThyTree, ThyTreeNodeComponent],
     providers: [ThyTreeService]
 })
 export class ThyTreeModule {}

--- a/src/typography/module.ts
+++ b/src/typography/module.ts
@@ -1,13 +1,13 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { ThyIconModule } from 'ngx-tethys/icon';
-import { ThyTextComponent } from './text/text.component';
+import { ThyText } from './text/text.component';
 import { ThyTextColorDirective } from './text-color.directive';
 import { ThyBackgroundColorDirective } from './bg-color.directive';
 
 @NgModule({
-    imports: [CommonModule, ThyIconModule, ThyTextComponent, ThyTextColorDirective, ThyBackgroundColorDirective],
-    exports: [ThyTextComponent, ThyTextColorDirective, ThyBackgroundColorDirective],
+    imports: [CommonModule, ThyIconModule, ThyText, ThyTextColorDirective, ThyBackgroundColorDirective],
+    exports: [ThyText, ThyTextColorDirective, ThyBackgroundColorDirective],
     providers: []
 })
 export class ThyTypographyModule {}

--- a/src/typography/text/text.component.ts
+++ b/src/typography/text/text.component.ts
@@ -1,5 +1,5 @@
 import { ChangeDetectionStrategy, Component, Input, OnInit } from '@angular/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf } from '@angular/common';
 
 /**
@@ -15,9 +15,9 @@ import { NgIf } from '@angular/common';
         class: 'thy-text'
     },
     standalone: true,
-    imports: [NgIf, ThyIconComponent]
+    imports: [NgIf, ThyIcon]
 })
-export class ThyTextComponent implements OnInit {
+export class ThyText implements OnInit {
     /**
      * 前置图标
      */

--- a/src/upload/file-select.component.ts
+++ b/src/upload/file-select.component.ts
@@ -19,7 +19,7 @@ import { InputBoolean, InputNumber } from 'ngx-tethys/core';
     templateUrl: './file-select.component.html',
     standalone: true
 })
-export class ThyFileSelectComponent extends FileSelectBaseDirective implements OnDestroy {
+export class ThyFileSelect extends FileSelectBaseDirective implements OnDestroy {
     private multiple: boolean;
 
     private acceptFolder: boolean;

--- a/src/upload/module.ts
+++ b/src/upload/module.ts
@@ -3,15 +3,15 @@ import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 
 import { ThyFileDropDirective } from './file-drop.directive';
-import { ThyFileSelectComponent } from './file-select.component';
+import { ThyFileSelect } from './file-select.component';
 import { THY_UPLOAD_DEFAULT_OPTIONS_PROVIDER } from './upload.config';
 import { ThyUploadService } from './upload.service';
 
 // import { ThyDirectiveModule } from 'ngx-tethys/directive';
 
 @NgModule({
-    imports: [CommonModule, HttpClientModule, ThyFileSelectComponent, ThyFileDropDirective],
+    imports: [CommonModule, HttpClientModule, ThyFileSelect, ThyFileDropDirective],
     providers: [ThyUploadService, THY_UPLOAD_DEFAULT_OPTIONS_PROVIDER],
-    exports: [ThyFileSelectComponent, ThyFileDropDirective]
+    exports: [ThyFileSelect, ThyFileDropDirective]
 })
 export class ThyUploadModule {}

--- a/src/upload/test/file-select.spec.ts
+++ b/src/upload/test/file-select.spec.ts
@@ -5,7 +5,7 @@ import { ApplicationRef, Component, DebugElement, NgModule } from '@angular/core
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { ThyFileSelectComponent } from '../file-select.component';
+import { ThyFileSelect } from '../file-select.component';
 import { ThyUploadModule } from '../module';
 import { ThyUploadResponse } from '../upload.service';
 import { createFile } from './utils';
@@ -52,7 +52,7 @@ describe('ThyFileSelect', () => {
     let fixture: ComponentFixture<FileSelectBasicComponent>;
     let testComponent: FileSelectBasicComponent;
     let fileSelectDebugElement: DebugElement;
-    let fileSelectComponent: ThyFileSelectComponent;
+    let fileSelectComponent: ThyFileSelect;
     let inputElement: HTMLInputElement;
     let dataTransfer: DataTransfer;
 
@@ -65,7 +65,7 @@ describe('ThyFileSelect', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(FileSelectBasicComponent);
         testComponent = fixture.debugElement.componentInstance;
-        fileSelectDebugElement = fixture.debugElement.query(By.directive(ThyFileSelectComponent));
+        fileSelectDebugElement = fixture.debugElement.query(By.directive(ThyFileSelect));
         fileSelectComponent = fileSelectDebugElement.componentInstance;
         fileSelectDebugElement.componentInstance;
         inputElement = fileSelectDebugElement.nativeElement.querySelector('input');

--- a/src/vote/test/vote.spec.ts
+++ b/src/vote/test/vote.spec.ts
@@ -2,7 +2,7 @@ import { Component, NgModule } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { ThyVoteComponent } from '../vote.component';
+import { ThyVote } from '../vote.component';
 import { ThyVoteModule } from '../vote.module';
 
 describe('ThyVote', () => {
@@ -24,7 +24,7 @@ describe('ThyVote', () => {
     beforeEach(() => {
         fixture = TestBed.createComponent(ThyDemoVoteBasicComponent);
         basicTestComponent = fixture.debugElement.componentInstance;
-        voteComponent = fixture.debugElement.query(By.directive(ThyVoteComponent));
+        voteComponent = fixture.debugElement.query(By.directive(ThyVote));
     });
 
     it('should have correct class', () => {

--- a/src/vote/vote.component.ts
+++ b/src/vote/vote.component.ts
@@ -3,7 +3,7 @@ import { coerceBooleanProperty } from 'ngx-tethys/util';
 import { useHostRenderer } from '@tethys/cdk/dom';
 
 import { Component, ContentChild, HostBinding, Input, OnInit, TemplateRef } from '@angular/core';
-import { ThyIconComponent } from 'ngx-tethys/icon';
+import { ThyIcon } from 'ngx-tethys/icon';
 import { NgIf, NgTemplateOutlet } from '@angular/common';
 
 export type ThyVoteSizes = 'default' | 'sm';
@@ -24,9 +24,9 @@ export type ThyVoteLayout = 'vertical' | 'horizontal';
         '[class.thy-vote-disabled]': `thyDisabled`
     },
     standalone: true,
-    imports: [NgIf, ThyIconComponent, NgTemplateOutlet]
+    imports: [NgIf, ThyIcon, NgTemplateOutlet]
 })
-export class ThyVoteComponent implements OnInit {
+export class ThyVote implements OnInit {
     _size: ThyVoteSizes;
 
     _type: ThyVoteType;

--- a/src/vote/vote.module.ts
+++ b/src/vote/vote.module.ts
@@ -1,11 +1,11 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { ThySharedModule } from 'ngx-tethys/shared';
-import { ThyVoteComponent } from './vote.component';
+import { ThyVote } from './vote.component';
 import { ThyIconModule } from 'ngx-tethys/icon';
 @NgModule({
-    imports: [CommonModule, ThySharedModule, ThyIconModule, ThyVoteComponent],
-    exports: [ThyVoteComponent],
+    imports: [CommonModule, ThySharedModule, ThyIconModule, ThyVote],
+    exports: [ThyVote],
     providers: []
 })
 export class ThyVoteModule {}


### PR DESCRIPTION
1. 去掉独立组件的 Component 后缀
2. 提供相关 schematics 自动替换使用方的组件
3. 去掉组件必须以 Component 作为后缀的限制
4. 备注：下面9个组件暂时不去掉 Component 后缀，去掉后会与已有的类/服务等冲突：
    ThyCascaderOptionComponent
    ThyCascaderSearchOptionComponent
    ThyDropdownMenuComponent
    ThyFullscreenComponent
    ThyFlexComponent
    ThyFlexItemComponent
    ThyGridComponent
    ThyTableColumnComponent
    ThyTreeNodeComponent
