### PR TITLE
feat(date-picker): support set time tamp length default length to 10 #INFR-11707 @wumeimin @xuhaifeng (#INFR-11707)

### DIFF
--- a/src/date-picker/abstract-picker.component.ts
+++ b/src/date-picker/abstract-picker.component.ts
@@ -21,7 +21,7 @@ import { ControlValueAccessor } from '@angular/forms';
 
 import { CompatibleValue, RangeAdvancedValue } from './inner-types';
 import { ThyPicker } from './picker.component';
-import { makeValue, setValueByTimeTampPrecision, transformDateValue } from './picker.util';
+import { makeValue, setValueByTimestampPrecision, transformDateValue } from './picker.util';
 import {
     CompatibleDate,
     DateEntry,
@@ -119,7 +119,7 @@ export abstract class AbstractPickerComponent
      * 设置时间戳精度
      * @default seconds 10位
      */
-    @Input() thyTimeTampPrecision: 'seconds' | 'milliseconds' = 'seconds';
+    @Input() thyTimestampPrecision: 'seconds' | 'milliseconds' = 'seconds';
 
     /**
      * 展示的日期格式
@@ -386,6 +386,6 @@ export abstract class AbstractPickerComponent
     }
 
     private setValueByPrecision(value: CompatibleDate | number | Date | DateEntry | ThyDateRangeEntry | SafeAny): number | number[] {
-        return setValueByTimeTampPrecision(value, this.isRange, this.thyTimeTampPrecision, this.datePickerConfigService?.config);
+        return setValueByTimestampPrecision(value, this.isRange, this.thyTimestampPrecision, this.datePickerConfigService?.config);
     }
 }

--- a/src/date-picker/abstract-picker.component.ts
+++ b/src/date-picker/abstract-picker.component.ts
@@ -48,6 +48,8 @@ export abstract class AbstractPickerComponent
 
     _panelMode: ThyPanelMode = 'date';
 
+    private datePickerConfigService = inject(ThyDatePickerConfigService);
+
     /**
      * 模式
      * @type decade | year | month | date | week | flexible
@@ -119,7 +121,7 @@ export abstract class AbstractPickerComponent
      * 设置时间戳精度
      * @default seconds 10位
      */
-    @Input() thyTimestampPrecision: 'seconds' | 'milliseconds' = 'seconds';
+    @Input() thyTimestampPrecision: 'seconds' | 'milliseconds' = this.datePickerConfigService.config?.timestampPrecision || 'seconds';
 
     /**
      * 展示的日期格式
@@ -189,8 +191,6 @@ export abstract class AbstractPickerComponent
     get thyDisabled(): boolean {
         return this.disabled;
     }
-
-    private datePickerConfigService = inject(ThyDatePickerConfigService);
 
     disabled = false;
 
@@ -386,6 +386,6 @@ export abstract class AbstractPickerComponent
     }
 
     private setValueByPrecision(value: CompatibleDate | number | Date | DateEntry | ThyDateRangeEntry | SafeAny): number | number[] {
-        return setValueByTimestampPrecision(value, this.isRange, this.thyTimestampPrecision, this.datePickerConfigService?.config);
+        return setValueByTimestampPrecision(value, this.isRange, this.thyTimestampPrecision);
     }
 }

--- a/src/date-picker/base-picker.component.html
+++ b/src/date-picker/base-picker.component.html
@@ -45,7 +45,7 @@
     [showShortcut]="thyShowShortcut"
     [shortcutPresets]="shortcutPresets"
     [shortcutPosition]="shortcutPosition"
-    [timeTampLength]="thyTimeTampLength"
+    [timeTampPrecision]="thyTimeTampPrecision"
     (dateValueChange)="onDateValueChange($event)"
     [className]="thyPanelClassName"
     (resultOk)="onResultOk()"></date-popup>

--- a/src/date-picker/base-picker.component.html
+++ b/src/date-picker/base-picker.component.html
@@ -45,6 +45,7 @@
     [showShortcut]="thyShowShortcut"
     [shortcutPresets]="shortcutPresets"
     [shortcutPosition]="shortcutPosition"
+    [timeTampLength]="thyTimeTampLength"
     (dateValueChange)="onDateValueChange($event)"
     [className]="thyPanelClassName"
     (resultOk)="onResultOk()"></date-popup>

--- a/src/date-picker/base-picker.component.html
+++ b/src/date-picker/base-picker.component.html
@@ -45,7 +45,7 @@
     [showShortcut]="thyShowShortcut"
     [shortcutPresets]="shortcutPresets"
     [shortcutPosition]="shortcutPosition"
-    [timeTampPrecision]="thyTimeTampPrecision"
+    [timestampPrecision]="thyTimestampPrecision"
     (dateValueChange)="onDateValueChange($event)"
     [className]="thyPanelClassName"
     (resultOk)="onResultOk()"></date-popup>

--- a/src/date-picker/date-picker.component.spec.ts
+++ b/src/date-picker/date-picker.component.spec.ts
@@ -54,7 +54,7 @@ describe('ThyDatePickerComponent', () => {
                         showShortcut: true,
                         shortcutDatePresets: shortcutDatePresets,
                         weekStartsOn: weekStartsOn,
-                        defaultTimeTampPrecision: 'seconds'
+                        defaultTimestampPrecision: 'seconds'
                     }
                 }
             ]
@@ -585,9 +585,9 @@ describe('ThyDatePickerComponent', () => {
             expect(result).toEqual(jasmine.objectContaining({ value: jasmine.anything() }));
         }));
 
-        it('should support thyTimeTampPrecision to milliseconds', fakeAsync(() => {
+        it('should support thyTimestampPrecision to milliseconds', fakeAsync(() => {
             const thyDateChange = spyOn(fixtureInstance, 'thyDateChange');
-            fixtureInstance.thyTimeTampPrecision = 'milliseconds';
+            fixtureInstance.thyTimestampPrecision = 'milliseconds';
             const datePresets = shortcutDatePresets();
             const triggerPreset = Object.assign(datePresets[0], { value: new TinyDate(datePresets[0].value).getTime(), disabled: false });
             fixture.detectChanges();
@@ -1355,7 +1355,7 @@ describe('ThyDatePickerComponent', () => {
                 (ngModelChange)="thyOnChange($event)"
                 [thyDateRender]="thyDateRender"
                 [thyMode]="thyMode"
-                [thyTimeTampPrecision]="thyTimeTampPrecision"
+                [thyTimestampPrecision]="thyTimestampPrecision"
                 [thyPlacement]="thyPlacement"
                 (thyOnPanelChange)="thyOnPanelChange($event)"
                 (thyOnCalendarChange)="thyOnCalendarChange($event)"
@@ -1402,7 +1402,7 @@ class ThyTestDatePickerComponent {
     thyShowTime: boolean | object = false;
     thyMode: string;
     thyPlacement: string = 'bottomLeft';
-    thyTimeTampPrecision = 'seconds';
+    thyTimestampPrecision = 'seconds';
     thyMinDate: Date | number;
     thyMaxDate: Date | number;
     thyOnChange(): void {}

--- a/src/date-picker/date-picker.component.spec.ts
+++ b/src/date-picker/date-picker.component.spec.ts
@@ -54,7 +54,7 @@ describe('ThyDatePickerComponent', () => {
                         showShortcut: true,
                         shortcutDatePresets: shortcutDatePresets,
                         weekStartsOn: weekStartsOn,
-                        defaultTimestampPrecision: 'seconds'
+                        timestampPrecision: 'seconds'
                     }
                 }
             ]

--- a/src/date-picker/date-picker.component.spec.ts
+++ b/src/date-picker/date-picker.component.spec.ts
@@ -53,7 +53,8 @@ describe('ThyDatePickerComponent', () => {
                     useValue: {
                         showShortcut: true,
                         shortcutDatePresets: shortcutDatePresets,
-                        weekStartsOn: weekStartsOn
+                        weekStartsOn: weekStartsOn,
+                        defaultTimeTampPrecision: 'seconds'
                     }
                 }
             ]
@@ -553,7 +554,8 @@ describe('ThyDatePickerComponent', () => {
         it('should support thyDateChange', fakeAsync(() => {
             const thyDateChange = spyOn(fixtureInstance, 'thyDateChange');
             const datePresets = shortcutDatePresets();
-            const triggerPreset = Object.assign(datePresets[0], { disabled: false });
+            const dateValue = new TinyDate(datePresets[0].value).getUnixTime();
+            const triggerPreset = Object.assign(datePresets[0], { value: dateValue, disabled: false });
             fixture.detectChanges();
             openPickerByClickTrigger();
             const shortcutItems = getShortcutItems();
@@ -581,6 +583,26 @@ describe('ThyDatePickerComponent', () => {
             expect(thyDateChange).toHaveBeenCalled();
             const result = thyDateChange.calls.allArgs()[0][0];
             expect(result).toEqual(jasmine.objectContaining({ value: jasmine.anything() }));
+        }));
+
+        it('should support thyTimeTampPrecision to milliseconds', fakeAsync(() => {
+            const thyDateChange = spyOn(fixtureInstance, 'thyDateChange');
+            fixtureInstance.thyTimeTampPrecision = 'milliseconds';
+            const datePresets = shortcutDatePresets();
+            const triggerPreset = Object.assign(datePresets[0], { value: new TinyDate(datePresets[0].value).getTime(), disabled: false });
+            fixture.detectChanges();
+            openPickerByClickTrigger();
+            const shortcutItems = getShortcutItems();
+            const now = new TinyDate(new Date());
+            dispatchMouseEvent(shortcutItems[0], 'click');
+            fixture.detectChanges();
+            tick(500);
+            fixture.detectChanges();
+            expect(thyDateChange).toHaveBeenCalledTimes(1);
+            expect(thyDateChange).toHaveBeenCalledWith({
+                value: now.startOfDay(),
+                triggerPreset: triggerPreset
+            });
         }));
     });
 
@@ -1333,6 +1355,7 @@ describe('ThyDatePickerComponent', () => {
                 (ngModelChange)="thyOnChange($event)"
                 [thyDateRender]="thyDateRender"
                 [thyMode]="thyMode"
+                [thyTimeTampPrecision]="thyTimeTampPrecision"
                 [thyPlacement]="thyPlacement"
                 (thyOnPanelChange)="thyOnPanelChange($event)"
                 (thyOnCalendarChange)="thyOnCalendarChange($event)"
@@ -1379,6 +1402,7 @@ class ThyTestDatePickerComponent {
     thyShowTime: boolean | object = false;
     thyMode: string;
     thyPlacement: string = 'bottomLeft';
+    thyTimeTampPrecision = 'seconds';
     thyMinDate: Date | number;
     thyMaxDate: Date | number;
     thyOnChange(): void {}

--- a/src/date-picker/date-picker.config.ts
+++ b/src/date-picker/date-picker.config.ts
@@ -9,14 +9,14 @@ export interface ThyDatePickerConfig {
     shortcutRangesPresets: CompatiblePresets;
     showShortcut: boolean;
     weekStartsOn: WeekDayIndex;
-    defaultTimestampPrecision: 'seconds' | 'milliseconds';
+    timestampPrecision: 'seconds' | 'milliseconds';
 }
 
 export const DEFAULT_DATE_PICKER_CONFIG: ThyDatePickerConfig = {
     shortcutPosition: 'left',
     showShortcut: false,
     weekStartsOn: 1,
-    defaultTimestampPrecision: 'seconds',
+    timestampPrecision: 'seconds',
     shortcutDatePresets: () => {
         return [
             {

--- a/src/date-picker/date-picker.config.ts
+++ b/src/date-picker/date-picker.config.ts
@@ -9,14 +9,14 @@ export interface ThyDatePickerConfig {
     shortcutRangesPresets: CompatiblePresets;
     showShortcut: boolean;
     weekStartsOn: WeekDayIndex;
-    defaultTimeTampPrecision: 'seconds' | 'milliseconds';
+    defaultTimestampPrecision: 'seconds' | 'milliseconds';
 }
 
 export const DEFAULT_DATE_PICKER_CONFIG: ThyDatePickerConfig = {
     shortcutPosition: 'left',
     showShortcut: false,
     weekStartsOn: 1,
-    defaultTimeTampPrecision: 'seconds',
+    defaultTimestampPrecision: 'seconds',
     shortcutDatePresets: () => {
         return [
             {

--- a/src/date-picker/date-picker.config.ts
+++ b/src/date-picker/date-picker.config.ts
@@ -9,12 +9,14 @@ export interface ThyDatePickerConfig {
     shortcutRangesPresets: CompatiblePresets;
     showShortcut: boolean;
     weekStartsOn: WeekDayIndex;
+    defaultTimeTampLength: number;
 }
 
 export const DEFAULT_DATE_PICKER_CONFIG: ThyDatePickerConfig = {
     shortcutPosition: 'left',
     showShortcut: false,
     weekStartsOn: 1,
+    defaultTimeTampLength: 10,
     shortcutDatePresets: () => {
         return [
             {

--- a/src/date-picker/date-picker.config.ts
+++ b/src/date-picker/date-picker.config.ts
@@ -9,14 +9,14 @@ export interface ThyDatePickerConfig {
     shortcutRangesPresets: CompatiblePresets;
     showShortcut: boolean;
     weekStartsOn: WeekDayIndex;
-    defaultTimeTampLength: number;
+    defaultTimeTampPrecision: 'seconds' | 'milliseconds';
 }
 
 export const DEFAULT_DATE_PICKER_CONFIG: ThyDatePickerConfig = {
     shortcutPosition: 'left',
     showShortcut: false,
     weekStartsOn: 1,
-    defaultTimeTampLength: 10,
+    defaultTimeTampPrecision: 'seconds',
     shortcutDatePresets: () => {
         return [
             {

--- a/src/date-picker/examples/basic/basic.component.html
+++ b/src/date-picker/examples/basic/basic.component.html
@@ -15,7 +15,7 @@
     class="d-block w-50 mb-3"
     thyShowTime
     [thyFormat]="dateShowTime | thyDatePickerFormatString"
-    thyTimeTampPrecision="milliseconds"
+    thyTimestampPrecision="milliseconds"
     thyPlaceHolder="选择时间"
     [(ngModel)]="flexibleDateTime"
     (ngModelChange)="onChange($event)"

--- a/src/date-picker/examples/basic/basic.component.html
+++ b/src/date-picker/examples/basic/basic.component.html
@@ -15,6 +15,7 @@
     class="d-block w-50 mb-3"
     thyShowTime
     [thyFormat]="dateShowTime | thyDatePickerFormatString"
+    thyTimeTampPrecision="milliseconds"
     thyPlaceHolder="选择时间"
     [(ngModel)]="flexibleDateTime"
     (ngModelChange)="onChange($event)"

--- a/src/date-picker/examples/directive/directive.component.html
+++ b/src/date-picker/examples/directive/directive.component.html
@@ -119,7 +119,9 @@
   [thyValue]="flexibleDateRange | thyDatePickerFormat"
   thyIcon="calendar-check"
   thyRangePicker
+  thyTimeTampLength="13"
   [(ngModel)]="flexibleDateRange"
+  (ngModelChange)="onChange($event)"
   thyMode="flexible"
   [thyShowShortcut]="true"></thy-property-operation>
 <br />
@@ -131,6 +133,7 @@
   thyIcon="calendar-check"
   thyRangePicker
   [(ngModel)]="weekRange"
+  (ngModelChange)="onChange($event)"
   thyMode="week"
   [thyShowShortcut]="true"
   [thyShortcutPresets]="shortcutMonthPresets"></thy-property-operation>

--- a/src/date-picker/examples/directive/directive.component.html
+++ b/src/date-picker/examples/directive/directive.component.html
@@ -119,7 +119,7 @@
   [thyValue]="flexibleDateRange | thyDatePickerFormat"
   thyIcon="calendar-check"
   thyRangePicker
-  thyTimeTampPrecision="milliseconds"
+  thyTimestampPrecision="milliseconds"
   [(ngModel)]="flexibleDateRange"
   (ngModelChange)="onChange($event)"
   thyMode="flexible"

--- a/src/date-picker/examples/directive/directive.component.html
+++ b/src/date-picker/examples/directive/directive.component.html
@@ -119,7 +119,7 @@
   [thyValue]="flexibleDateRange | thyDatePickerFormat"
   thyIcon="calendar-check"
   thyRangePicker
-  thyTimeTampLength="13"
+  thyTimeTampPrecision="milliseconds"
   [(ngModel)]="flexibleDateRange"
   (ngModelChange)="onChange($event)"
   thyMode="flexible"

--- a/src/date-picker/examples/directive/directive.component.ts
+++ b/src/date-picker/examples/directive/directive.component.ts
@@ -60,6 +60,10 @@ export class ThyDatePickerDirectiveExampleComponent implements OnInit {
         this.selectedDateRange = date;
     }
 
+    onChange(date: Date[]) {
+        console.log('onChange', date);
+    }
+
     panelOpenChange(open: boolean) {
         if (!open) {
             this.selectedDateRange = [];

--- a/src/date-picker/examples/shortcut/shortcut.component.html
+++ b/src/date-picker/examples/shortcut/shortcut.component.html
@@ -31,7 +31,7 @@
   [(ngModel)]="date"
   [thyMinDate]="minDate"
   [thyShowShortcut]="true"
-  thyTimeTampLength="13"
+  thyTimeTampPrecision="milliseconds"
   (ngModelChange)="onChange($event)"
   (thyDateChange)="dateValueChange($event)"
 ></thy-date-picker>

--- a/src/date-picker/examples/shortcut/shortcut.component.html
+++ b/src/date-picker/examples/shortcut/shortcut.component.html
@@ -31,6 +31,7 @@
   [(ngModel)]="date"
   [thyMinDate]="minDate"
   [thyShowShortcut]="true"
+  thyTimeTampLength="13"
   (ngModelChange)="onChange($event)"
   (thyDateChange)="dateValueChange($event)"
 ></thy-date-picker>
@@ -38,9 +39,9 @@
 <thy-date-picker
   class="d-block w-50 mb-3"
   [(ngModel)]="date"
-  [thyMaxDate]="maxDate"
   [thyShowShortcut]="true"
   (ngModelChange)="onChange($event)"
+  (thyDateChange)="dateValueChange($event)"
 ></thy-date-picker>
 
 <thy-date-picker

--- a/src/date-picker/examples/shortcut/shortcut.component.html
+++ b/src/date-picker/examples/shortcut/shortcut.component.html
@@ -31,7 +31,7 @@
   [(ngModel)]="date"
   [thyMinDate]="minDate"
   [thyShowShortcut]="true"
-  thyTimeTampPrecision="milliseconds"
+  thyTimestampPrecision="milliseconds"
   (ngModelChange)="onChange($event)"
   (thyDateChange)="dateValueChange($event)"
 ></thy-date-picker>

--- a/src/date-picker/lib/popups/date-popup.component.ts
+++ b/src/date-picker/lib/popups/date-popup.component.ts
@@ -21,7 +21,7 @@ import { ThyButtonIcon } from 'ngx-tethys/button';
 import { ThyNav, ThyNavItemDirective } from 'ngx-tethys/nav';
 import { ThyDatePickerConfigService } from '../../date-picker.service';
 import { CompatibleValue, DatePickerFlexibleTab, RangeAdvancedValue, RangePartType } from '../../inner-types';
-import { dateAddAmount, getShortcutValue, hasValue, makeValue, setTimeTampLength, transformDateValue } from '../../picker.util';
+import { dateAddAmount, getShortcutValue, hasValue, makeValue, setValueByTimeTampPrecision, transformDateValue } from '../../picker.util';
 import {
     CompatibleDate,
     CompatiblePresets,
@@ -97,7 +97,7 @@ export class DatePopup implements OnChanges, OnInit {
 
     @Input() flexibleDateGranularity: ThyDateGranularity;
 
-    @Input({ transform: numberAttribute }) timeTampLength: number;
+    @Input() timeTampPrecision: 'seconds' | 'milliseconds';
 
     @Output() readonly panelModeChange = new EventEmitter<ThyPanelMode | ThyPanelMode[]>();
     @Output() readonly calendarChange = new EventEmitter<CompatibleValue>();
@@ -613,10 +613,10 @@ export class DatePopup implements OnChanges, OnInit {
             selectedPresetValue = this.getSelectedShortcutPreset(singleTinyDate) as TinyDate;
         }
         this.setValue(selectedPresetValue);
-        const shortcutPresetsValue = setTimeTampLength(
+        const shortcutPresetsValue = setValueByTimeTampPrecision(
             shortcutPresets?.value,
             this.isRange,
-            this.timeTampLength,
+            this.timeTampPrecision,
             this.datePickerConfigService?.config
         ) as number;
         this.dateValueChange.emit({

--- a/src/date-picker/lib/popups/date-popup.component.ts
+++ b/src/date-picker/lib/popups/date-popup.component.ts
@@ -613,12 +613,7 @@ export class DatePopup implements OnChanges, OnInit {
             selectedPresetValue = this.getSelectedShortcutPreset(singleTinyDate) as TinyDate;
         }
         this.setValue(selectedPresetValue);
-        const shortcutPresetsValue = setValueByTimestampPrecision(
-            shortcutPresets?.value,
-            this.isRange,
-            this.timestampPrecision,
-            this.datePickerConfigService?.config
-        ) as number;
+        const shortcutPresetsValue = setValueByTimestampPrecision(shortcutPresets?.value, this.isRange, this.timestampPrecision) as number;
         this.dateValueChange.emit({
             value: helpers.isArray(value) ? this.selectedValue : selectedPresetValue,
             triggerPreset: Object.assign({}, shortcutPresets, { value: shortcutPresetsValue })

--- a/src/date-picker/lib/popups/date-popup.component.ts
+++ b/src/date-picker/lib/popups/date-popup.component.ts
@@ -7,6 +7,7 @@ import {
     Component,
     EventEmitter,
     Input,
+    numberAttribute,
     OnChanges,
     OnInit,
     Output,
@@ -20,7 +21,7 @@ import { ThyButtonIcon } from 'ngx-tethys/button';
 import { ThyNav, ThyNavItemDirective } from 'ngx-tethys/nav';
 import { ThyDatePickerConfigService } from '../../date-picker.service';
 import { CompatibleValue, DatePickerFlexibleTab, RangeAdvancedValue, RangePartType } from '../../inner-types';
-import { dateAddAmount, getShortcutValue, hasValue, makeValue, transformDateValue } from '../../picker.util';
+import { dateAddAmount, getShortcutValue, hasValue, makeValue, setTimeTampLength, transformDateValue } from '../../picker.util';
 import {
     CompatibleDate,
     CompatiblePresets,
@@ -95,6 +96,8 @@ export class DatePopup implements OnChanges, OnInit {
     @Input() flexible: boolean;
 
     @Input() flexibleDateGranularity: ThyDateGranularity;
+
+    @Input({ transform: numberAttribute }) timeTampLength: number;
 
     @Output() readonly panelModeChange = new EventEmitter<ThyPanelMode | ThyPanelMode[]>();
     @Output() readonly calendarChange = new EventEmitter<CompatibleValue>();
@@ -610,9 +613,15 @@ export class DatePopup implements OnChanges, OnInit {
             selectedPresetValue = this.getSelectedShortcutPreset(singleTinyDate) as TinyDate;
         }
         this.setValue(selectedPresetValue);
+        const shortcutPresetsValue = setTimeTampLength(
+            shortcutPresets?.value,
+            this.isRange,
+            this.timeTampLength,
+            this.datePickerConfigService?.config
+        ) as number;
         this.dateValueChange.emit({
             value: helpers.isArray(value) ? this.selectedValue : selectedPresetValue,
-            triggerPreset: shortcutPresets
+            triggerPreset: Object.assign({}, shortcutPresets, { value: shortcutPresetsValue })
         });
         if (!helpers.isArray(value) && this.showTime && this.showTimePicker) {
             this.updateActiveDate();

--- a/src/date-picker/lib/popups/date-popup.component.ts
+++ b/src/date-picker/lib/popups/date-popup.component.ts
@@ -21,7 +21,7 @@ import { ThyButtonIcon } from 'ngx-tethys/button';
 import { ThyNav, ThyNavItemDirective } from 'ngx-tethys/nav';
 import { ThyDatePickerConfigService } from '../../date-picker.service';
 import { CompatibleValue, DatePickerFlexibleTab, RangeAdvancedValue, RangePartType } from '../../inner-types';
-import { dateAddAmount, getShortcutValue, hasValue, makeValue, setValueByTimeTampPrecision, transformDateValue } from '../../picker.util';
+import { dateAddAmount, getShortcutValue, hasValue, makeValue, setValueByTimestampPrecision, transformDateValue } from '../../picker.util';
 import {
     CompatibleDate,
     CompatiblePresets,
@@ -97,7 +97,7 @@ export class DatePopup implements OnChanges, OnInit {
 
     @Input() flexibleDateGranularity: ThyDateGranularity;
 
-    @Input() timeTampPrecision: 'seconds' | 'milliseconds';
+    @Input() timestampPrecision: 'seconds' | 'milliseconds';
 
     @Output() readonly panelModeChange = new EventEmitter<ThyPanelMode | ThyPanelMode[]>();
     @Output() readonly calendarChange = new EventEmitter<CompatibleValue>();
@@ -613,10 +613,10 @@ export class DatePopup implements OnChanges, OnInit {
             selectedPresetValue = this.getSelectedShortcutPreset(singleTinyDate) as TinyDate;
         }
         this.setValue(selectedPresetValue);
-        const shortcutPresetsValue = setValueByTimeTampPrecision(
+        const shortcutPresetsValue = setValueByTimestampPrecision(
             shortcutPresets?.value,
             this.isRange,
-            this.timeTampPrecision,
+            this.timestampPrecision,
             this.datePickerConfigService?.config
         ) as number;
         this.dateValueChange.emit({

--- a/src/date-picker/picker.util.ts
+++ b/src/date-picker/picker.util.ts
@@ -229,17 +229,17 @@ function fixStringDate(dateStr: string) {
     return replacedStr;
 }
 
-export function setValueByTimeTampPrecision(
+export function setValueByTimestampPrecision(
     date: CompatibleDate | number | Date | DateEntry | ThyDateRangeEntry | SafeAny,
     isRange: boolean,
-    timeTampPrecision: 'seconds' | 'milliseconds',
+    timestampPrecision: 'seconds' | 'milliseconds',
     config: ThyDatePickerConfig
 ): number | number[] {
     const { value } = transformDateValue(date);
     if (!value || (helpers.isArray(value) && !value?.length)) {
         return helpers.isArray(value) ? [null, null] : null;
     }
-    if (timeTampPrecision === 'milliseconds' || config?.defaultTimeTampPrecision === 'milliseconds') {
+    if (timestampPrecision === 'milliseconds' || config?.defaultTimestampPrecision === 'milliseconds') {
         return isRange ? coerceArray(value).map(val => new TinyDate(val).getTime()) : new TinyDate(value as Date).getTime();
     } else {
         return isRange ? coerceArray(value).map(val => new TinyDate(val).getUnixTime()) : new TinyDate(value as Date)?.getUnixTime();

--- a/src/date-picker/picker.util.ts
+++ b/src/date-picker/picker.util.ts
@@ -239,7 +239,7 @@ export function setValueByTimestampPrecision(
     if (!value || (helpers.isArray(value) && !value?.length)) {
         return helpers.isArray(value) ? [null, null] : null;
     }
-    if (timestampPrecision === 'milliseconds' || config?.defaultTimestampPrecision === 'milliseconds') {
+    if (timestampPrecision === 'milliseconds' || config?.timestampPrecision === 'milliseconds') {
         return isRange ? coerceArray(value).map(val => new TinyDate(val).getTime()) : new TinyDate(value as Date).getTime();
     } else {
         return isRange ? coerceArray(value).map(val => new TinyDate(val).getUnixTime()) : new TinyDate(value as Date)?.getUnixTime();

--- a/src/date-picker/picker.util.ts
+++ b/src/date-picker/picker.util.ts
@@ -229,17 +229,17 @@ function fixStringDate(dateStr: string) {
     return replacedStr;
 }
 
-export function setTimeTampLength(
+export function setValueByTimeTampPrecision(
     date: CompatibleDate | number | Date | DateEntry | ThyDateRangeEntry | SafeAny,
     isRange: boolean,
-    timeTampLength: number,
+    timeTampPrecision: 'seconds' | 'milliseconds',
     config: ThyDatePickerConfig
 ): number | number[] {
     const { value } = transformDateValue(date);
-    if (!value) {
-        return null;
+    if (!value || (helpers.isArray(value) && !value?.length)) {
+        return helpers.isArray(value) ? [null, null] : null;
     }
-    if (timeTampLength === 13 || config?.defaultTimeTampLength === 13) {
+    if (timeTampPrecision === 'milliseconds' || config?.defaultTimeTampPrecision === 'milliseconds') {
         return isRange ? coerceArray(value).map(val => new TinyDate(val).getTime()) : new TinyDate(value as Date).getTime();
     } else {
         return isRange ? coerceArray(value).map(val => new TinyDate(val).getUnixTime()) : new TinyDate(value as Date)?.getUnixTime();

--- a/src/date-picker/picker.util.ts
+++ b/src/date-picker/picker.util.ts
@@ -3,7 +3,6 @@ import { CompatibleDate, DateEntry, ThyDateRangeEntry, ThyPanelMode, ThyDateGran
 import { fromUnixTime } from 'date-fns';
 import { coerceArray, helpers, TinyDate } from 'ngx-tethys/util';
 import { CompatibleValue, RangeAdvancedValue } from './inner-types';
-import { ThyDatePickerConfig } from './date-picker.config';
 import { SafeAny } from 'ngx-tethys/types';
 
 export function transformDateValue(value: CompatibleDate | CompatibleValue | number | DateEntry | ThyDateRangeEntry | RangeAdvancedValue): {
@@ -232,14 +231,13 @@ function fixStringDate(dateStr: string) {
 export function setValueByTimestampPrecision(
     date: CompatibleDate | number | Date | DateEntry | ThyDateRangeEntry | SafeAny,
     isRange: boolean,
-    timestampPrecision: 'seconds' | 'milliseconds',
-    config: ThyDatePickerConfig
+    timestampPrecision: 'seconds' | 'milliseconds'
 ): number | number[] {
     const { value } = transformDateValue(date);
     if (!value || (helpers.isArray(value) && !value?.length)) {
         return helpers.isArray(value) ? [null, null] : null;
     }
-    if (timestampPrecision === 'milliseconds' || config?.timestampPrecision === 'milliseconds') {
+    if (timestampPrecision === 'milliseconds') {
         return isRange ? coerceArray(value).map(val => new TinyDate(val).getTime()) : new TinyDate(value as Date).getTime();
     } else {
         return isRange ? coerceArray(value).map(val => new TinyDate(val).getUnixTime()) : new TinyDate(value as Date)?.getUnixTime();

--- a/src/date-picker/picker.util.ts
+++ b/src/date-picker/picker.util.ts
@@ -1,8 +1,10 @@
 import { CompatibleDate, DateEntry, ThyDateRangeEntry, ThyPanelMode, ThyDateGranularity, ThyShortcutValue } from './standard-types';
 
 import { fromUnixTime } from 'date-fns';
-import { helpers, TinyDate } from 'ngx-tethys/util';
+import { coerceArray, helpers, TinyDate } from 'ngx-tethys/util';
 import { CompatibleValue, RangeAdvancedValue } from './inner-types';
+import { ThyDatePickerConfig } from './date-picker.config';
+import { SafeAny } from 'ngx-tethys/types';
 
 export function transformDateValue(value: CompatibleDate | CompatibleValue | number | DateEntry | ThyDateRangeEntry | RangeAdvancedValue): {
     value: CompatibleDate;
@@ -225,4 +227,21 @@ function fixStringDate(dateStr: string) {
         replacedStr = `${new TinyDate(new Date()).getYear()}-${replacedStr}`;
     }
     return replacedStr;
+}
+
+export function setTimeTampLength(
+    date: CompatibleDate | number | Date | DateEntry | ThyDateRangeEntry | SafeAny,
+    isRange: boolean,
+    timeTampLength: number,
+    config: ThyDatePickerConfig
+): number | number[] {
+    const { value } = transformDateValue(date);
+    if (!value) {
+        return null;
+    }
+    if (timeTampLength === 13 || config?.defaultTimeTampLength === 13) {
+        return isRange ? coerceArray(value).map(val => new TinyDate(val).getTime()) : new TinyDate(value as Date).getTime();
+    } else {
+        return isRange ? coerceArray(value).map(val => new TinyDate(val).getUnixTime()) : new TinyDate(value as Date)?.getUnixTime();
+    }
 }

--- a/src/date-picker/range-picker.component.spec.ts
+++ b/src/date-picker/range-picker.component.spec.ts
@@ -55,7 +55,7 @@ describe('ThyRangePickerComponent', () => {
                     useValue: {
                         showShortcut: true,
                         shortcutRangesPresets: shortcutRangesPresets,
-                        defaultTimestampPrecision: 'seconds'
+                        timestampPrecision: 'seconds'
                     }
                 }
             ]

--- a/src/date-picker/range-picker.component.spec.ts
+++ b/src/date-picker/range-picker.component.spec.ts
@@ -54,7 +54,8 @@ describe('ThyRangePickerComponent', () => {
                     provide: THY_DATE_PICKER_CONFIG,
                     useValue: {
                         showShortcut: true,
-                        shortcutRangesPresets: shortcutRangesPresets
+                        shortcutRangesPresets: shortcutRangesPresets,
+                        defaultTimeTampPrecision: 'seconds'
                     }
                 }
             ]
@@ -398,6 +399,7 @@ describe('ThyRangePickerComponent', () => {
 
         it('should support thyDateChange', fakeAsync(() => {
             fixtureInstance.thyShowShortcut = true;
+            fixtureInstance.thyTimeTampPrecision = 'milliseconds';
             let rangePresets = shortcutRangesPresets();
             const triggerPreset = Object.assign(rangePresets[0], { disabled: false });
             const thyDateChange = spyOn(fixtureInstance, 'thyDateChange');
@@ -976,6 +978,7 @@ describe('ThyRangePickerComponent', () => {
                 (thyOpenChange)="thyOpenChange($event)"
                 [(ngModel)]="modelValue"
                 [thyMode]="thyMode"
+                [thyTimeTampPrecision]="thyTimeTampPrecision"
                 [thyMinDate]="thyMinDate"
                 [thyMaxDate]="thyMaxDate"
                 (ngModelChange)="modelValueChange($event)"
@@ -1017,6 +1020,7 @@ class ThyTestRangePickerComponent {
     thyPanelClassName: string;
     thySize: string;
     thySuffixIcon: string;
+    thyTimeTampPrecision = 'seconds';
     modelValue: ThyDateRangeEntry;
     thyMode: ThyPanelMode;
     thyOpen: boolean;

--- a/src/date-picker/range-picker.component.spec.ts
+++ b/src/date-picker/range-picker.component.spec.ts
@@ -55,7 +55,7 @@ describe('ThyRangePickerComponent', () => {
                     useValue: {
                         showShortcut: true,
                         shortcutRangesPresets: shortcutRangesPresets,
-                        defaultTimeTampPrecision: 'seconds'
+                        defaultTimestampPrecision: 'seconds'
                     }
                 }
             ]
@@ -399,7 +399,7 @@ describe('ThyRangePickerComponent', () => {
 
         it('should support thyDateChange', fakeAsync(() => {
             fixtureInstance.thyShowShortcut = true;
-            fixtureInstance.thyTimeTampPrecision = 'milliseconds';
+            fixtureInstance.thyTimestampPrecision = 'milliseconds';
             let rangePresets = shortcutRangesPresets();
             const triggerPreset = Object.assign(rangePresets[0], { disabled: false });
             const thyDateChange = spyOn(fixtureInstance, 'thyDateChange');
@@ -978,7 +978,7 @@ describe('ThyRangePickerComponent', () => {
                 (thyOpenChange)="thyOpenChange($event)"
                 [(ngModel)]="modelValue"
                 [thyMode]="thyMode"
-                [thyTimeTampPrecision]="thyTimeTampPrecision"
+                [thyTimestampPrecision]="thyTimestampPrecision"
                 [thyMinDate]="thyMinDate"
                 [thyMaxDate]="thyMaxDate"
                 (ngModelChange)="modelValueChange($event)"
@@ -1020,7 +1020,7 @@ class ThyTestRangePickerComponent {
     thyPanelClassName: string;
     thySize: string;
     thySuffixIcon: string;
-    thyTimeTampPrecision = 'seconds';
+    thyTimestampPrecision = 'seconds';
     modelValue: ThyDateRangeEntry;
     thyMode: ThyPanelMode;
     thyOpen: boolean;


### PR DESCRIPTION
1. 支持 `thyTimestampPrecision: 'seconds' | 'milliseconds' = 'seconds' ` 设置时间戳精度，默认 'seconds'
2. 支持全局配置 `defaultTimestampPrecision`， 默认为 'seconds'
3. 统一处理返回值的时间戳精度（ 日期、指令、快捷操作 ）