### PR TITLE
fix(anchor): warnings should not be displayed when the thy anchor link is not nested under  horizontal layout #TINFR-480

### DIFF
--- a/src/anchor/anchor.component.ts
+++ b/src/anchor/anchor.component.ts
@@ -157,9 +157,7 @@ export class ThyAnchor implements OnDestroy, AfterViewInit, OnChanges {
     private warningPrompt() {
         if (this.thyDirection === 'horizontal') {
             const hasChildren = this.links.some(link =>
-                Array.from(link?.elementRef?.nativeElement?.childNodes)?.some((item: HTMLElement) =>
-                    item?.className.includes('thy-anchor-link')
-                )
+                Array.from(link?.elementRef?.nativeElement?.childNodes)?.some((item: HTMLElement) => item?.nodeName === 'THY-ANCHOR-LINK')
             );
             if (hasChildren) {
                 console.warn("Anchor link nesting is not supported when 'Anchor' direction is horizontal.");

--- a/src/anchor/anchor.component.ts
+++ b/src/anchor/anchor.component.ts
@@ -127,8 +127,7 @@ export class ThyAnchor implements OnDestroy, AfterViewInit, OnChanges {
         private platform: Platform,
         private zone: NgZone,
         private renderer: Renderer2,
-        private scrollService: ThyScrollService,
-        private elementRef: ElementRef
+        private scrollService: ThyScrollService
     ) {}
 
     registerLink(link: ThyAnchorLink): void {

--- a/src/anchor/test/anchor.component.spec.ts
+++ b/src/anchor/test/anchor.component.spec.ts
@@ -16,6 +16,7 @@ describe('thy-anchor', () => {
         let component: ThyAnchor;
         let scrollService: ThyScrollService;
         const id = 'components-anchor-demo-basic';
+
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [ThyAnchorModule, NoopAnimationsModule],
@@ -72,13 +73,13 @@ describe('thy-anchor', () => {
             });
         });
     });
+
     describe('thyContainer', () => {
         let fixture: ComponentFixture<TestContainerAnchorComponent>;
         let debugElement: DebugElement;
-        let component: ThyAnchor;
-        let scrollService: ThyScrollService;
         const id = 'components-anchor-demo-basic';
         const containerClass = '.demo-card';
+
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [ThyAnchorModule, NoopAnimationsModule],
@@ -86,11 +87,10 @@ describe('thy-anchor', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestContainerAnchorComponent);
-            component = fixture.componentInstance.thyAnchorComponent;
             debugElement = fixture.debugElement;
-            scrollService = TestBed.get(ThyScrollService);
             fixture.detectChanges();
         });
+
         it('should active associated thy-anchor-link when scrolling to anchor', (done: () => void) => {
             const container: HTMLElement = debugElement.query(By.css(containerClass)).nativeElement;
             const targetAnchor: HTMLElement = container.querySelector(`#${id}`);
@@ -106,8 +106,6 @@ describe('thy-anchor', () => {
 
     describe('thyAnchorLink', () => {
         let fixture: ComponentFixture<TestThyAnchorLinkComponent>;
-        let debugElement: DebugElement;
-        let component: ThyAnchor;
 
         beforeEach(() => {
             TestBed.configureTestingModule({
@@ -116,8 +114,6 @@ describe('thy-anchor', () => {
             }).compileComponents();
 
             fixture = TestBed.createComponent(TestThyAnchorLinkComponent);
-            component = fixture.componentInstance.thyAnchorComponent;
-            debugElement = fixture.debugElement;
 
             fixture.detectChanges();
         });
@@ -154,13 +150,24 @@ describe('thy-anchor', () => {
             window.scrollTo(0, 0);
         });
 
-        it('should warn when nested levels are present', () => {
+        it('should warn when thyDirection is horizontal and thy-anchor-link is nested', () => {
             const warnSpy = spyOn(console, 'warn');
             fixture.componentInstance.thyDirection = 'horizontal';
+            fixture.componentInstance.showChildren = true;
             fixture.detectChanges();
 
             expect(warnSpy).toHaveBeenCalled();
             expect(warnSpy).toHaveBeenCalledWith("Anchor link nesting is not supported when 'Anchor' direction is horizontal.");
+        });
+
+        it('should not warn when thyDirection is horizontal and thy-anchor-link is nested', () => {
+            const warnSpy = spyOn(console, 'warn');
+            fixture.componentInstance.thyDirection = 'horizontal';
+            fixture.componentInstance.showChildren = false;
+            fixture.detectChanges();
+
+            expect(warnSpy).not.toHaveBeenCalled();
+            expect(warnSpy).not.toHaveBeenCalledWith("Anchor link nesting is not supported when 'Anchor' direction is horizontal.");
         });
 
         it('should add the correct class', () => {


### PR DESCRIPTION
水平布局下，thy-anchor-link 没有嵌套时，不应该打印警告