### PR TITLE
refactor: the TransormT type specified in input should be consistent with the transform function parameter type

### DIFF
--- a/src/action/action.component.ts
+++ b/src/action/action.component.ts
@@ -117,7 +117,7 @@ export class ThyAction implements OnInit, AfterViewInit, OnDestroy {
     /**
      * 是否处于禁用状态
      */
-    readonly thyDisabled = input<boolean, boolean | string | number>(false, { transform: coerceBooleanProperty });
+    readonly thyDisabled = input(false, { transform: coerceBooleanProperty });
 
     ngOnInit(): void {
         this.updateClasses();

--- a/src/icon/icon.component.ts
+++ b/src/icon/icon.component.ts
@@ -65,13 +65,10 @@ export class ThyIcon {
 
     /**
      * 图标打底色，镂空的图标，会透过颜色来
-     * @default false
      */
-    readonly thyIconLegging = input<boolean, undefined>(undefined, { transform: coerceBooleanProperty });
+    readonly thyIconLegging = input(false, { transform: coerceBooleanProperty });
 
-    readonly thyIconLinearGradient = input<boolean, unknown>(undefined, {
-        transform: coerceBooleanProperty
-    });
+    readonly thyIconLinearGradient = input(false, { transform: coerceBooleanProperty });
 
     private hostRenderer = useHostRenderer();
 

--- a/src/input-number/input-number.component.ts
+++ b/src/input-number/input-number.component.ts
@@ -71,7 +71,7 @@ export class ThyInputNumber extends TabIndexDisabledControlValueAccessorMixin im
      * 是否自动聚焦
      * @default false
      */
-    readonly thyAutoFocus = input<boolean, boolean | string | number>(false, { transform: coerceBooleanProperty });
+    readonly thyAutoFocus = input(false, { transform: coerceBooleanProperty });
 
     /**
      * 输入框的placeholder

--- a/src/progress/progress.component.ts
+++ b/src/progress/progress.component.ts
@@ -104,7 +104,7 @@ export class ThyProgress implements ThyParentProgress {
     /**
      * 最大值，主要计算百分比进度的分母使用，当 thyValue 传入数组时，自动累加数组中的 value 之和为 max
      */
-    readonly thyMax = input<number, number | string | unknown>(undefined, { transform: numberAttribute });
+    readonly thyMax = input<number, unknown>(undefined, { transform: numberAttribute });
 
     /**
      * 鼠标移入进度条时显示的提示文案或者模板

--- a/src/property/property-item.component.ts
+++ b/src/property/property-item.component.ts
@@ -56,7 +56,6 @@ export class ThyPropertyItem implements OnDestroy {
 
     /**
      * 属性名称
-     * @type sting
      */
     readonly thyLabelText = input<string>();
 

--- a/src/resizable/resizable.directive.ts
+++ b/src/resizable/resizable.directive.ts
@@ -19,7 +19,7 @@ import { ThyResizeHandleMouseDownEvent } from './interface';
 import { ThyResizeEvent } from './interface';
 import { getEventWithPoint, ensureInBounds, setCompatibleStyle } from './utils';
 import { fromEvent } from 'rxjs';
-import { coerceBooleanProperty, ThyNumberInput } from 'ngx-tethys/util';
+import { coerceBooleanProperty } from 'ngx-tethys/util';
 
 /**
  * 调整尺寸
@@ -51,12 +51,12 @@ export class ThyResizableDirective implements OnDestroy {
     /**
      * 最大高度(超过边界部分忽略)
      */
-    readonly thyMaxHeight = input<number, ThyNumberInput>(undefined, { transform: numberAttribute });
+    readonly thyMaxHeight = input<number, unknown>(undefined, { transform: numberAttribute });
 
     /**
      * 最大宽度(超过边界部分忽略)
      */
-    readonly thyMaxWidth = input<number, ThyNumberInput>(undefined, { transform: numberAttribute });
+    readonly thyMaxWidth = input<number, unknown>(undefined, { transform: numberAttribute });
 
     /**
      * 最小高度

--- a/src/util/helpers/helpers.ts
+++ b/src/util/helpers/helpers.ts
@@ -3,8 +3,6 @@ import { ElementRef, TemplateRef } from '@angular/core';
 
 export type ThyBooleanInput = boolean | string | number | unknown;
 
-export type ThyNumberInput = number | string | unknown;
-
 export function isUndefined(value: any): value is undefined {
     return value === undefined;
 }


### PR DESCRIPTION
1. input 中指定的 TransformT 类型应该和 transform 函数参数类型保持一致，否则之后开启严格类型模式后会有「类型不匹配」的报错。
2. 我使用的 coerceBooleanProperty 是我们自己的函数，指定了参数类型是 value: ThyBooleanInput。
而 numberAttribute 是 @angular/core 提供的，接收的类型是 unknown，我们无法指定为 value: ThyNumberInput，所以先把 ThyNumberInput 删了。
