### PR TITLE
refactor(styles): add primary-subtle token to replace rgba($primary, 0.1) #TINFR-3828

### DIFF
--- a/site/src/styles/themes/bright-purple.scss
+++ b/site/src/styles/themes/bright-purple.scss
@@ -5,6 +5,6 @@ $success: #22d7bb;
 $warning: #ffc442;
 $danger: #ff5b57;
 $primary-active: #3870f7;
-$secondary-item-active: #edf3ff; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #edf3ff;
 
 @import '../theme-bootstrap';

--- a/site/src/styles/themes/bright-yellow.scss
+++ b/site/src/styles/themes/bright-yellow.scss
@@ -5,6 +5,6 @@ $success: #22d7bb;
 $warning: #ffc442;
 $danger: #ff5b57;
 $primary-active: #ffa715;
-$secondary-item-active: #fff8e8; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #fff8e8;
 
 @import '../theme-bootstrap';

--- a/site/src/styles/themes/brown-black.scss
+++ b/site/src/styles/themes/brown-black.scss
@@ -5,6 +5,6 @@ $success: #22d7bb;
 $warning: #ffc442;
 $danger: #ff5b57;
 $primary-active: #383838;
-$secondary-item-active: #ececec; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #ececec;
 
 @import '../theme-bootstrap';

--- a/site/src/styles/themes/qq-blue.scss
+++ b/site/src/styles/themes/qq-blue.scss
@@ -5,6 +5,6 @@ $success: #22d7bb;
 $warning: #ffc442;
 $danger: #ff5b57;
 $primary-active: #1ea8ff;
-$secondary-item-active: #eaf9ff; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #eaf9ff;
 
 @import '../theme-bootstrap';

--- a/site/src/styles/themes/sky-blue.scss
+++ b/site/src/styles/themes/sky-blue.scss
@@ -5,6 +5,6 @@ $success: #22d7bb;
 $warning: #ffc442;
 $danger: #ff5b57;
 $primary-active: #575df9;
-$secondary-item-active: #f1f0fe; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #f1f0fe;
 
 @import '../theme-bootstrap';

--- a/site/src/styles/themes/watermelon.scss
+++ b/site/src/styles/themes/watermelon.scss
@@ -4,6 +4,6 @@ $success: #22d7bb;
 $warning: #ffc442;
 $danger: #ff5b57;
 $primary-active: #18bfa4;
-$secondary-item-active: #e7f9f6; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #e7f9f6;
 
 @import '../theme-bootstrap';

--- a/src/action/styles/action.scss
+++ b/src/action/styles/action.scss
@@ -1,3 +1,4 @@
+@use 'sass:map';
 @use '../../styles/mixins/hover.scss';
 @use '../../styles/bootstrap/functions-variables';
 @use '../../styles/variables.scss';
@@ -68,8 +69,12 @@
 @each $color, $value in functions-variables.$theme-colors {
     // 默认就是 Primary 无需设置样式，避免覆写 $action-hover-bg-color 颜色失效
     @if $color != 'primary' {
+        $subtle: map.get(variables.$theme-colors-subtle, $color);
+        @if not $subtle {
+            $subtle: rgba($value, 0.1);
+        }
         .action-#{$color} {
-            @include action-mixin.action-variant(variables.$action-color, $value, rgba($value, 0.1));
+            @include action-mixin.action-variant(variables.$action-color, $value, $subtle);
         }
     }
 }

--- a/src/alert/styles/alert.scss
+++ b/src/alert/styles/alert.scss
@@ -1,3 +1,4 @@
+@use "sass:map";
 @use "../../styles/bootstrap/functions";
 @use "../../styles/bootstrap/functions-variables";
 @use "../../styles/bootstrap/mixins/border-radius";
@@ -101,7 +102,11 @@
 
 @each $color, $value in functions-variables.$theme-colors {
     .thy-alert-fill-#{$color} {
-        @include mixin.thy-alert-variant(functions.theme-color($color));
+        $subtle: map.get(variables.$theme-colors-subtle, $color);
+        @if not $subtle {
+            $subtle: rgba($value, 0.1);
+        }
+        @include mixin.thy-alert-variant(functions.theme-color($color), $subtle);
     }
 
     .thy-alert-bordered-#{$color} {

--- a/src/alert/styles/mixin.scss
+++ b/src/alert/styles/mixin.scss
@@ -10,9 +10,9 @@
     }
 }
 
-@mixin thy-alert-variant($color) {
+@mixin thy-alert-variant($color, $subtle: rgba($color, 0.1)) {
     color: variables.$gray-700;
-    @include gradients.gradient-bg(rgba($color, 0.1));
+    @include gradients.gradient-bg($subtle);
     border-color: $color;
     @include thy-alert-inner($color);
 }

--- a/src/cascader/styles/cascader.scss
+++ b/src/cascader/styles/cascader.scss
@@ -89,7 +89,7 @@ $cascader-menu-min-width: 122px;
         &-active:not(&-disabled) {
             &,
             &:hover {
-                background: rgba(variables.$primary, 0.1);
+                background: variables.$primary-subtle;
                 color: variables.$primary;
             }
         }
@@ -160,7 +160,7 @@ $cascader-menu-min-width: 122px;
             background-color: variables.$dropdown-menu-item-hover-bg;
         }
         &.active:not(.multiple) {
-            background: rgba(variables.$primary, 0.1);
+            background: variables.$primary-subtle;
             color: variables.$primary;
         }
         // 覆盖 thyFlexibleText 默认样式使其垂直居中

--- a/src/cascader/styles/theme.scss
+++ b/src/cascader/styles/theme.scss
@@ -14,7 +14,7 @@
         &-active:not(&-disabled) {
             &,
             &:hover {
-                background: rgba($primary, .1);
+                background: $primary-subtle;
                 color: $primary;
             }
 

--- a/src/dropdown/styles/dropdown.scss
+++ b/src/dropdown/styles/dropdown.scss
@@ -41,7 +41,7 @@
         }
 
         &:not(.dropdown-menu-item--disabled).active {
-            background-color: rgba(variables.$primary, 0.1);
+            background-color: variables.$primary-subtle;
             &:not(.dropdown-submenu) {
                 color: variables.$dropdown-menu-item-hover-color;
             }

--- a/src/menu/styles/menu.scss
+++ b/src/menu/styles/menu.scss
@@ -17,7 +17,7 @@
         }
 
         &.active .thy-menu-item-content {
-            background: rgba(variables.$primary, 0.1);
+            background: variables.$primary-subtle;
         }
 
         .thy-menu-item-content {
@@ -182,7 +182,7 @@
                 display: inline-block !important;
                 margin-left: 4px;
                 .thy-action {
-                    background: rgba(variables.$primary, 0.1);
+                    background: variables.$primary-subtle;
                     color: variables.$primary;
                 }
             }

--- a/src/nav/styles/icon-nav.scss
+++ b/src/nav/styles/icon-nav.scss
@@ -42,7 +42,7 @@
 
 .thy-icon-nav-link {
     transition: opacity 0.2s ease-in-out;
-    @include icon-nav-link-variant(variables.$icon-nav-link-color, variables.$icon-nav-link-hover-color, rgba(variables.$primary, 0.1));
+    @include icon-nav-link-variant(variables.$icon-nav-link-color, variables.$icon-nav-link-hover-color, variables.$primary-subtle);
 }
 
 .thy-icon-nav {
@@ -68,7 +68,7 @@
         // @include icon-nav-link-variant(
         //     variables.$icon-nav-link-secondary-color,
         //     variables.$icon-nav-link-hover-color,
-        //     rgba(variables.$primary, 0.1)
+        //     variables.$primary-subtle
         // );
     }
 }
@@ -82,7 +82,7 @@
         // @include icon-nav-link-variant(
         //     variables.$icon-nav-link-secondary-color,
         //     variables.$icon-nav-link-hover-color,
-        //     rgba(variables.$primary, 0.1)
+        //     variables.$primary-subtle
         // );
     }
 }

--- a/src/nav/styles/mixin.scss
+++ b/src/nav/styles/mixin.scss
@@ -40,7 +40,13 @@
     }
 }
 
-@mixin nav-item-pills-variant($color, $hover-color, $background: variables.$gray-100, $border-radius: 18px) {
+@mixin nav-item-pills-variant(
+    $color,
+    $hover-color,
+    $background: variables.$gray-100,
+    $border-radius: 18px,
+    $hover-bg: variables.$primary-subtle
+) {
     & {
         background: $background;
         color: $color;
@@ -49,13 +55,13 @@
 
     &.thy-nav-origin-active {
         text-decoration: none;
-        background: rgba($hover-color, 0.1);
+        background: $hover-bg;
         color: $hover-color;
     }
 
     @include hover.hover-active {
         text-decoration: none;
-        background: rgba($hover-color, 0.1);
+        background: $hover-bg;
         color: $hover-color;
     }
     &.disabled {

--- a/src/shared/option/styles/option.mixin.scss
+++ b/src/shared/option/styles/option.mixin.scss
@@ -54,7 +54,7 @@
         }
 
         &.active {
-            background: rgba(variables.$primary, 0.1);
+            background: variables.$primary-subtle;
             color: variables.$primary;
 
             .prefix-icon {
@@ -83,7 +83,7 @@
         }
 
         &.active {
-            background: rgba(variables.$primary, 0.1);
+            background: variables.$primary-subtle;
             color: variables.$primary;
 
             // &.hover,
@@ -201,7 +201,7 @@
             }
 
             &.active {
-                background: rgba(variables.$primary, 0.1);
+                background: variables.$primary-subtle;
                 color: variables.$body-color;
                 border: solid 1px variables.$primary;
 
@@ -282,7 +282,7 @@
         }
 
         &.active {
-            background: rgba(variables.$primary, 0.1);
+            background: variables.$primary-subtle;
             color: variables.$body-color;
             border: solid 1px variables.$primary;
 

--- a/src/shared/select/styles/select.mixin.scss
+++ b/src/shared/select/styles/select.mixin.scss
@@ -74,7 +74,7 @@ $avatarHeight: (
                 &:hover {
                     background-color: variables.$bg-default;
                     span {
-                        background-color: rgba(variables.$danger, 0.1);
+                        background-color: variables.$danger-subtle;
                     }
 
                     .thy-icon {

--- a/src/styles/themes/bright-purple.scss
+++ b/src/styles/themes/bright-purple.scss
@@ -2,7 +2,7 @@
 //青出于蓝
 $primary: #4e8afa;
 $primary-active: #3870f7;
-$secondary-item-active: #edf3ff; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #edf3ff;
 
 // @import "../theme-bootstrap";
 

--- a/src/styles/themes/bright-yellow.scss
+++ b/src/styles/themes/bright-yellow.scss
@@ -2,6 +2,6 @@
 //午后暖阳
 $primary: #febc20;
 $primary-active: #ffa715;
-$secondary-item-active: #fff8e8; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #fff8e8;
 
 @import './index.scss';

--- a/src/styles/themes/brown-black.scss
+++ b/src/styles/themes/brown-black.scss
@@ -2,6 +2,6 @@
 //千岩竞秀
 $primary: #484848;
 $primary-active: #383838;
-$secondary-item-active: #ececec; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #ececec;
 
 @import './index.scss';

--- a/src/styles/themes/olivine.scss
+++ b/src/styles/themes/olivine.scss
@@ -2,6 +2,6 @@
 //郁郁葱葱
 $primary: #66c060;
 $primary-active: #4ead49;
-$secondary-item-active: #eff9f0; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #eff9f0;
 
 @import './index.scss';

--- a/src/styles/themes/pink.scss
+++ b/src/styles/themes/pink.scss
@@ -2,6 +2,6 @@
 //水墨丹青
 $primary: #f7a3b7;
 $primary-active: #f7f0f2;
-$secondary-item-active: #ecedef; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #ecedef;
 
 @import './index.scss';

--- a/src/styles/themes/purple.scss
+++ b/src/styles/themes/purple.scss
@@ -2,6 +2,6 @@
 //水墨丹青
 $primary: #48525c;
 $primary-active: #39414c;
-$secondary-item-active: #ecedef; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #ecedef;
 
 @import './index.scss';

--- a/src/styles/themes/qq-blue.scss
+++ b/src/styles/themes/qq-blue.scss
@@ -5,6 +5,6 @@ $success: #66c060;
 $warning: #ffc442;
 $danger: #ff5b57;
 $primary-active: #1ea8ff;
-$secondary-item-active: #eaf9ff; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #eaf9ff;
 
 @import './index.scss';

--- a/src/styles/themes/sky-blue.scss
+++ b/src/styles/themes/sky-blue.scss
@@ -2,6 +2,6 @@
 //紫气东来
 $primary: #6f76fa;
 $primary-active: #575df9;
-$secondary-item-active: #f1f0fe; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #f1f0fe;
 
 @import './index.scss';

--- a/src/styles/themes/watermelon.scss
+++ b/src/styles/themes/watermelon.scss
@@ -4,6 +4,6 @@ $success: #66c060;
 $warning: #ffc442;
 $danger: #ff5b57;
 $primary-active: #18bfa4;
-$secondary-item-active: #e7f9f6; // item 选中背景色, 项目或者任务列表选中
+$primary-subtle: #e7f9f6;
 
 @import './index.scss';

--- a/src/styles/variables.scss
+++ b/src/styles/variables.scss
@@ -23,10 +23,30 @@ $warning: #ffcd5d !default;
 $danger: #ff7575 !default;
 $black: #000 !default;
 
+$primary-subtle: rgba($primary, 0.1) !default;
+$success-subtle: rgba($success, 0.1) !default;
+$info-subtle: rgba($info, 0.1) !default;
+$warning-subtle: rgba($warning, 0.1) !default;
+$danger-subtle: rgba($danger, 0.1) !default;
+
+$theme-colors-subtle: () !default;
+$theme-colors-subtle: map.merge(
+    (
+        'primary': $primary-subtle,
+        'success': $success-subtle,
+        'info': $info-subtle,
+        'warning': $warning-subtle,
+        'danger': $danger-subtle
+    ),
+    $theme-colors-subtle
+);
+
 $body-color: $gray-800 !default;
 $secondary: $gray-700 !default;
-$secondary-item-active: rgba($primary, 0.1) !default;
-$item-active-bg-color: rgba($primary, 0.1) !default;
+//废弃，请使用 $primary-subtle
+$secondary-item-active: $primary-subtle !default;
+//废弃，请使用 $primary-subtle
+$item-active-bg-color: $primary-subtle !default;
 $light: $gray-300 !default;
 $dark: #48525c !default;
 $pass: #2cccda !default;
@@ -565,7 +585,7 @@ $icon-nav-link-padding-y: 0.282rem !default;
 
 $action-color: $gray-600 !default;
 $action-hover-color: $primary !default;
-$action-hover-bg-color: rgba($primary, 0.1) !default;
+$action-hover-bg-color: $primary-subtle !default;
 $action-padding-x: 0.5rem !default;
 $action-padding-y: 0.5rem !default;
 
@@ -825,7 +845,7 @@ $tree-node-wrapper-height: 44px !default;
 $tree-node-wrapper-line-height: 44px !default;
 $tree-node-wrapper-border-bottom: 1px solid $gray-200 !default;
 $tree-node-wrapper-active-border-color: rgba($primary, 0.3) !default;
-$tree-node-wrapper-active-background-color: rgba($primary, 0.1) !default;
+$tree-node-wrapper-active-background-color: $primary-subtle !default;
 $tree-node-wrapper-hover-shadow: 0 2px 8px 1px rgba(0, 0, 0, 0.08) !default;
 $tree-node-wrapper-height-sm: 42px !default;
 // stepper

--- a/src/tag/styles/mixin.scss
+++ b/src/tag/styles/mixin.scss
@@ -1,4 +1,5 @@
 @use 'sass:color';
+@use 'sass:meta';
 @use '../../styles/variables.scss';
 
 @mixin tag-bg-variant($bg-color, $hover-bg-color: null) {
@@ -10,8 +11,10 @@
         &:hover {
             @if $hover-bg-color != null {
                 background-color: $hover-bg-color;
-            } @else {
+            } @else if meta.type-of($bg-color) == 'color' {
                 background-color: color.adjust($bg-color, $lightness: -5%);
+            } @else {
+                background-color: color-mix(in srgb, #{$bg-color} 90%, black);
             }
             cursor: variables.$hand-cursor;
         }

--- a/src/tag/styles/tag.scss
+++ b/src/tag/styles/tag.scss
@@ -56,7 +56,11 @@
             @include mixin.tag-color-variant(variables.$white, variables.$white);
         }
         &-weak-fill-#{$color} {
-            @include mixin.tag-bg-variant(rgba($value, 0.1));
+            $subtle: map.get(variables.$theme-colors-subtle, $color);
+            @if not $subtle {
+                $subtle: rgba($value, 0.1);
+            }
+            @include mixin.tag-bg-variant($subtle);
             @include mixin.tag-color-variant($value, $value);
         }
         &-outline-#{$color} {

--- a/src/time-picker/styles/variables.scss
+++ b/src/time-picker/styles/variables.scss
@@ -18,7 +18,7 @@ $time-picker-panel-column-cell-height: 24px;
 $time-picker-panel-column-cell-padding-left: 23px;
 $time-picker-panel-column-cell-spacing: 4px;
 
-$time-picker-column-hover-bg-color: rgba(variables.$primary, 0.1);
+$time-picker-column-hover-bg-color: variables.$primary-subtle;
 $time-picker-column-hover-color: variables.$primary;
 
 $time-picker-panel-padding: 12px;

--- a/src/tree/styles/theme.scss
+++ b/src/tree/styles/theme.scss
@@ -2,7 +2,7 @@
     &-node {
         &-wrapper {
             &.active {
-                background: rgba($primary, 0.1);
+                background: $tree-node-wrapper-active-background-color;
                 color: $primary;
 
                 .thy-tree-node-content {

--- a/src/tree/styles/tree.scss
+++ b/src/tree/styles/tree.scss
@@ -118,7 +118,7 @@
                 }
 
                 &.active {
-                    background: rgba(variables.$primary, 0.1);
+                    background: variables.$tree-node-wrapper-active-background-color;
                     color: variables.$primary;
 
                     .thy-tree-node-content {

--- a/src/vote/styles/vote.scss
+++ b/src/vote/styles/vote.scss
@@ -1,7 +1,7 @@
 @use '../../styles/variables';
 
-@mixin vote-color-variant($color) {
-    background: rgba($color, 0.1);
+@mixin vote-color-variant($color, $subtle: rgba($color, 0.1)) {
+    background: $subtle;
     color: $color;
     &:hover {
         background: rgba($color, 0.2);
@@ -12,7 +12,7 @@
         color: variables.$white;
     }
 }
-@mixin vote-color-variant-weak($color) {
+@mixin vote-color-variant-weak($color, $subtle: rgba($color, 0.1)) {
     background-color: variables.$gray-100;
     color: variables.$gray-600;
     &:hover {
@@ -20,7 +20,7 @@
         color: $color;
     }
     &.has-voted {
-        background: rgba($color, 0.1);
+        background: $subtle;
         color: $color;
         &:hover {
             background: rgba($color, 0.2);
@@ -96,19 +96,19 @@
 }
 
 .thy-vote-success {
-    @include vote-color-variant(variables.$success);
+    @include vote-color-variant(variables.$success, variables.$success-subtle);
 }
 
 .thy-vote-primary {
-    @include vote-color-variant(variables.$primary);
+    @include vote-color-variant(variables.$primary, variables.$primary-subtle);
 }
 
 .thy-vote-success-weak {
-    @include vote-color-variant-weak(variables.$success);
+    @include vote-color-variant-weak(variables.$success, variables.$success-subtle);
 }
 
 .thy-vote-primary-weak {
-    @include vote-color-variant-weak(variables.$primary);
+    @include vote-color-variant-weak(variables.$primary, variables.$primary-subtle);
 }
 
 .thy-vote-disabled {


### PR DESCRIPTION
- 新增 $primary-subtle 等 token，替换组件里硬编码的 rgba($primary, 0.1)
- Menu / Tree / Select / Nav / Action / Tag / Alert / Vote 等浅底色改用 subtle
- 皮肤里 $secondary-item-active 迁移为 $primary-subtle（旧变量标记废弃）