### PR TITLE
fix(button): intercept thyDisabled clicks on native button #TINFR-3833

### DIFF
--- a/src/button/button.component.ts
+++ b/src/button/button.component.ts
@@ -83,8 +83,6 @@ export class ThyButton {
         return this.elementRef.nativeElement;
     }
 
-    private readonly isNativeButton = this.elementRef.nativeElement.tagName === 'BUTTON';
-
     private hostRenderer = useHostRenderer();
 
     /**
@@ -246,7 +244,7 @@ export class ThyButton {
 
     private preventClickWhenUnavailable(): void {
         const onClick = (event: Event) => {
-            if ((this.thyDisabled() && !this.isNativeButton) || this.thyLoading()) {
+            if (this.thyDisabled() || this.thyLoading()) {
                 event.preventDefault();
                 event.stopImmediatePropagation();
             }


### PR DESCRIPTION
## Summary
- Remove the native-button exception from capture-phase click intercept.
- `thyDisabled` and `thyLoading` now share the same condition, so `<button thyButton [thyDisabled]="true">` also blocks `(click)`.
- Native `<button disabled>` is unchanged: the browser still does not dispatch click.

## Test plan
- [ ] `<button thyButton [thyDisabled]="true">` does not fire `(click)`
- [ ] `<button thyButton disabled>` still relies on native disabled
- [ ] `<thy-button [thyDisabled]="true">` still does not fire `(click)`
- [ ] Loading still blocks click on both `<button thyButton>` and `<thy-button>`
