### PR TITLE
fix(nav): support non-link nav items and disable pointer events #TINFR-3844

### DIFF
--- a/src/nav/examples/basic/basic.component.html
+++ b/src/nav/examples/basic/basic.component.html
@@ -1,12 +1,7 @@
 <thy-nav thyType="pulled">
   @for (item of navList; track $index) {
-    <a
-      href="javascript:;"
-      thyNavItem
-      [thyNavItemActive]="item.index === activeIndex"
-      [thyNavItemDisabled]="item.disabled"
-      (click)="activeIndex = item.index"
-      >{{ item.name }}</a
-    >
+    <div thyNavItem [thyNavItemActive]="item.index === activeIndex" [thyNavItemDisabled]="item.disabled" (click)="activeIndex = item.index">
+      {{ item.name }}
+    </div>
   }
 </thy-nav>

--- a/src/nav/examples/basic/basic.component.html
+++ b/src/nav/examples/basic/basic.component.html
@@ -1,7 +1,12 @@
 <thy-nav thyType="pulled">
   @for (item of navList; track $index) {
-    <div thyNavItem [thyNavItemActive]="item.index === activeIndex" [thyNavItemDisabled]="item.disabled" (click)="activeIndex = item.index">
-      {{ item.name }}
-    </div>
+    <a
+      href="javascript:;"
+      thyNavItem
+      [thyNavItemActive]="item.index === activeIndex"
+      [thyNavItemDisabled]="item.disabled"
+      (click)="activeIndex = item.index"
+      >{{ item.name }}</a
+    >
   }
 </thy-nav>

--- a/src/nav/styles/nav.scss
+++ b/src/nav/styles/nav.scss
@@ -25,6 +25,11 @@
         border-bottom-color: transparent;
         flex: 0 auto;
         white-space: nowrap;
+        cursor: pointer;
+        &.disabled {
+            pointer-events: none;
+            cursor: not-allowed;
+        }
     }
 
     .thy-nav-extra {


### PR DESCRIPTION
## Summary
- Add `cursor: pointer` on `.thy-nav-item`, and `pointer-events: none` / `cursor: not-allowed` when disabled.
- Switch the basic nav example from `<a>` to `<div thyNavItem>` so items are not native links.

## Test plan
- [ ] Enabled nav items show pointer cursor and can be selected
- [ ] Disabled nav items cannot be clicked
- [ ] Basic example still highlights the active item
