### PR TITLE
feat(schematics): unify placeholder input and thyPlaceHolder to thyPlaceholder #NEXUS-5016

### DIFF
--- a/schematics/ng-update/update-22/index.spec.ts
+++ b/schematics/ng-update/update-22/index.spec.ts
@@ -37,7 +37,7 @@ import { ThyInputModule } from 'ngx-tethys/input';
 @Component({
     selector: 'app-input-demo',
     template: \`
-        <thy-input type="password" placeholder="Password"></thy-input>
+        <thy-input type="password" thyPlaceholder="Password"></thy-input>
     \`,
     imports: [ThyInputModule]
 })
@@ -491,5 +491,169 @@ export class TabsDemoComponent {
         const content = workspaceTree.readContent('/projects/update-22-test/src/app/tabs-demo.component.ts');
         expect(content).toContain('ThyActiveTabValue');
         expect(content).not.toContain('ThyActiveTabInfo');
+    });
+
+    it('should migrate placeholder to thyPlaceholder for thy-input', async () => {
+        const factory = createTestWorkspaceFactory(schematicRunner);
+        await factory.create();
+        await factory.addApplication({ name: 'update-22-test' });
+        const testTree = factory.addNewFile(
+            '/projects/update-22-test/src/app/input-demo.component.ts',
+            `
+import { Component } from '@angular/core';
+import { ThyInputModule } from 'ngx-tethys/input';
+
+@Component({
+    selector: 'app-input-demo',
+    template: \`
+        <thy-input placeholder="Please type"></thy-input>
+    \`,
+    imports: [ThyInputModule]
+})
+export class InputDemoComponent {}
+`
+        );
+
+        workspaceTree = await schematicRunner.runSchematic('migration-v22', undefined, testTree);
+        const content = workspaceTree.readContent('/projects/update-22-test/src/app/input-demo.component.ts');
+        expect(content).toContain('thyPlaceholder="Please type"');
+        expect(content).not.toMatch(/\splaceholder="/);
+    });
+
+    it('should migrate placeholder to thyPlaceholder for thy-input binding', async () => {
+        const factory = createTestWorkspaceFactory(schematicRunner);
+        await factory.create();
+        await factory.addApplication({ name: 'update-22-test' });
+        const testTree = factory.addNewFile(
+            '/projects/update-22-test/src/app/input-demo.component.ts',
+            `
+import { Component } from '@angular/core';
+import { ThyInputModule } from 'ngx-tethys/input';
+
+@Component({
+    selector: 'app-input-demo',
+    template: \`
+        <thy-input [placeholder]="inputPlaceholder"></thy-input>
+    \`,
+    imports: [ThyInputModule]
+})
+export class InputDemoComponent {
+    inputPlaceholder = 'Please type';
+}
+`
+        );
+
+        workspaceTree = await schematicRunner.runSchematic('migration-v22', undefined, testTree);
+        const content = workspaceTree.readContent('/projects/update-22-test/src/app/input-demo.component.ts');
+        expect(content).toContain('[thyPlaceholder]="inputPlaceholder"');
+        expect(content).not.toContain('[placeholder]');
+    });
+
+    it('should not migrate placeholder for native input', async () => {
+        const factory = createTestWorkspaceFactory(schematicRunner);
+        await factory.create();
+        await factory.addApplication({ name: 'update-22-test' });
+        const testTree = factory.addNewFile(
+            '/projects/update-22-test/src/app/input-demo.component.ts',
+            `
+import { Component } from '@angular/core';
+import { ThyInputModule } from 'ngx-tethys/input';
+
+@Component({
+    selector: 'app-input-demo',
+    template: \`
+        <input thyInput placeholder="Please type" />
+    \`,
+    imports: [ThyInputModule]
+})
+export class InputDemoComponent {}
+`
+        );
+
+        workspaceTree = await schematicRunner.runSchematic('migration-v22', undefined, testTree);
+        const content = workspaceTree.readContent('/projects/update-22-test/src/app/input-demo.component.ts');
+        expect(content).toContain('placeholder="Please type"');
+        expect(content).not.toContain('thyPlaceholder');
+    });
+
+    it('should migrate placeholder to thyPlaceholder for thy-input-search', async () => {
+        const factory = createTestWorkspaceFactory(schematicRunner);
+        await factory.create();
+        await factory.addApplication({ name: 'update-22-test' });
+        const testTree = factory.addNewFile(
+            '/projects/update-22-test/src/app/input-search-demo.component.ts',
+            `
+import { Component } from '@angular/core';
+import { ThyInputModule } from 'ngx-tethys/input';
+
+@Component({
+    selector: 'app-input-search-demo',
+    template: \`
+        <thy-input-search placeholder="Search"></thy-input-search>
+    \`,
+    imports: [ThyInputModule]
+})
+export class InputSearchDemoComponent {}
+`
+        );
+
+        workspaceTree = await schematicRunner.runSchematic('migration-v22', undefined, testTree);
+        const content = workspaceTree.readContent('/projects/update-22-test/src/app/input-search-demo.component.ts');
+        expect(content).toContain('thyPlaceholder="Search"');
+        expect(content).not.toMatch(/\splaceholder="/);
+    });
+
+    it('should migrate thyPlaceHolder to thyPlaceholder for thy-select', async () => {
+        const factory = createTestWorkspaceFactory(schematicRunner);
+        await factory.create();
+        await factory.addApplication({ name: 'update-22-test' });
+        const testTree = factory.addNewFile(
+            '/projects/update-22-test/src/app/select-demo.component.ts',
+            `
+import { Component } from '@angular/core';
+import { ThySelectModule } from 'ngx-tethys/select';
+
+@Component({
+    selector: 'app-select-demo',
+    template: \`
+        <thy-select thyPlaceHolder="请选择"></thy-select>
+    \`,
+    imports: [ThySelectModule]
+})
+export class SelectDemoComponent {}
+`
+        );
+
+        workspaceTree = await schematicRunner.runSchematic('migration-v22', undefined, testTree);
+        const content = workspaceTree.readContent('/projects/update-22-test/src/app/select-demo.component.ts');
+        expect(content).toContain('thyPlaceholder="请选择"');
+        expect(content).not.toContain('thyPlaceHolder');
+    });
+
+    it('should migrate thyPlaceHolder to thyPlaceholder for thy-date-picker', async () => {
+        const factory = createTestWorkspaceFactory(schematicRunner);
+        await factory.create();
+        await factory.addApplication({ name: 'update-22-test' });
+        const testTree = factory.addNewFile(
+            '/projects/update-22-test/src/app/date-picker-demo.component.ts',
+            `
+import { Component } from '@angular/core';
+import { ThyDatePickerModule } from 'ngx-tethys/date-picker';
+
+@Component({
+    selector: 'app-date-picker-demo',
+    template: \`
+        <thy-date-picker thyPlaceHolder="选择日期"></thy-date-picker>
+    \`,
+    imports: [ThyDatePickerModule]
+})
+export class DatePickerDemoComponent {}
+`
+        );
+
+        workspaceTree = await schematicRunner.runSchematic('migration-v22', undefined, testTree);
+        const content = workspaceTree.readContent('/projects/update-22-test/src/app/date-picker-demo.component.ts');
+        expect(content).toContain('thyPlaceholder="选择日期"');
+        expect(content).not.toContain('thyPlaceHolder');
     });
 });

--- a/schematics/ng-update/update-22/update-data.ts
+++ b/schematics/ng-update/update-22/update-data.ts
@@ -69,6 +69,30 @@ export const upgradeData: UpgradeData = {
                         limitedTo: {
                             elements: ['thy-avatar']
                         }
+                    },
+                    {
+                        replace: 'placeholder',
+                        replaceWith: 'thyPlaceholder',
+                        limitedTo: {
+                            elements: ['thy-input', 'thy-input-search']
+                        }
+                    },
+                    {
+                        replace: 'thyPlaceHolder',
+                        replaceWith: 'thyPlaceholder',
+                        limitedTo: {
+                            elements: [
+                                'thy-select',
+                                'thy-custom-select',
+                                'thy-date-picker',
+                                'thy-range-picker',
+                                'thy-month-picker',
+                                'thy-quarter-picker',
+                                'thy-year-picker',
+                                'thy-week-picker'
+                            ],
+                            attributes: ['thyDatePicker', 'thyRangePicker']
+                        }
                     }
                 ]
             }

--- a/src/autocomplete/examples/input-search/input-search.component.html
+++ b/src/autocomplete/examples/input-search/input-search.component.html
@@ -1,5 +1,5 @@
 <div>
-  <thy-input-search [(ngModel)]="keyword" [placeholder]="'请输入'" [thyAutocomplete]="auto" (ngModelChange)="valueChange($event)">
+  <thy-input-search [(ngModel)]="keyword" [thyPlaceholder]="'请输入'" [thyAutocomplete]="auto" (ngModelChange)="valueChange($event)">
   </thy-input-search>
   <thy-autocomplete #auto>
     @for (item of listOfOption; track $index) {

--- a/src/date-picker/abstract-picker.component.ts
+++ b/src/date-picker/abstract-picker.component.ts
@@ -102,7 +102,7 @@ export abstract class AbstractPickerComponent
      * 输入框提示文字
      * @type string | string[]
      */
-    readonly thyPlaceHolder = input<string | string[]>();
+    readonly thyPlaceholder = input<string | string[]>();
 
     readonly placeholder = signal<string | string[] | undefined>(undefined);
 
@@ -257,7 +257,7 @@ export abstract class AbstractPickerComponent
 
         effect(() => {
             if (this.isCustomPlaceHolder) {
-                this.placeholder.set(this.thyPlaceHolder());
+                this.placeholder.set(this.thyPlaceholder());
             }
         });
 
@@ -279,7 +279,7 @@ export abstract class AbstractPickerComponent
     }
 
     ngOnChanges(changes: SimpleChanges): void {
-        if (changes.thyPlaceHolder && changes.thyPlaceHolder.firstChange && typeof changes.thyPlaceHolder.currentValue !== 'undefined') {
+        if (changes.thyPlaceholder && changes.thyPlaceholder.firstChange && typeof changes.thyPlaceholder.currentValue !== 'undefined') {
             this.isCustomPlaceHolder = true;
         }
     }

--- a/src/date-picker/date-picker.component.spec.ts
+++ b/src/date-picker/date-picker.component.spec.ts
@@ -364,8 +364,8 @@ describe('ThyDatePickerComponent', () => {
             expect(disabledCell.textContent.trim()).toBe('15');
         }));
 
-        it('should support thyPlaceHolder', () => {
-            const featureKey = (fixtureInstance.thyPlaceHolder = 'TEST_PLACEHOLDER');
+        it('should support thyPlaceholder', () => {
+            const featureKey = (fixtureInstance.thyPlaceholder = 'TEST_PLACEHOLDER');
             fixture.detectChanges();
             expect(getPickerTrigger().getAttribute('placeholder')).toBe(featureKey);
         });
@@ -1373,7 +1373,7 @@ describe('ThyDatePickerComponent', () => {
                     [thyAutoFocus]="thyAutoFocus"
                     [thyDisabled]="thyDisabled"
                     [thyDisabledDate]="thyDisabledDate"
-                    [thyPlaceHolder]="thyPlaceHolder"
+                    [thyPlaceholder]="thyPlaceholder"
                     [thyPanelClassName]="thyPanelClassName"
                     [thyDefaultPickerValue]="thyDefaultPickerValue"
                     [thySize]="thySize"
@@ -1429,7 +1429,7 @@ class ThyTestDatePickerComponent {
     thyAutoFocus!: boolean;
     thyDisabled!: boolean;
     thyDisabledDate!: (d: Date) => boolean;
-    thyPlaceHolder!: string;
+    thyPlaceholder!: string;
     thyPanelClassName!: string;
     thySize!: string;
     thySuffixIcon!: string;

--- a/src/date-picker/date-picker.directive.spec.ts
+++ b/src/date-picker/date-picker.directive.spec.ts
@@ -550,7 +550,7 @@ describe('ThyPickerDirective', () => {
             [thyMaxDate]="thyMaxDate"
             [thyDefaultPickerValue]="thyDefaultPickerValue"
             [thyOffset]="thyOffset"
-            [thyPlaceHolder]="thyPlaceHolder"
+            [thyPlaceholder]="thyPlaceholder"
             [thyPlacement]="thyPlacement"
             [thyHasBackdrop]="thyHasBackdrop"
             [thyPopoverOptions]="popoverOptions"
@@ -567,7 +567,7 @@ describe('ThyPickerDirective', () => {
 })
 class ThyTestPickerComponent {
     readonly thyDatePickerDirective = viewChild.required<ThyDatePickerDirective>(ThyDatePickerDirective);
-    thyPlaceHolder!: string;
+    thyPlaceholder!: string;
     thyPanelClassName!: string;
     thyValue!: Date | null;
     thyDefaultPickerValue!: Date | number;

--- a/src/date-picker/doc/zh-cn.md
+++ b/src/date-picker/doc/zh-cn.md
@@ -37,7 +37,7 @@ import { ThyDatePickerModule } from 'ngx-tethys/date-picker';
 <thy-date-picker
   thyShowTime
   [thyFormat]="dateShowTime | thyDatePickerFormatString"
-  thyPlaceHolder="选择时间"
+  thyPlaceholder="选择时间"
   [(ngModel)]="dateTime"
   (ngModelChange)="onChange($event)"
 ></thy-date-picker>

--- a/src/date-picker/examples/basic/basic.component.html
+++ b/src/date-picker/examples/basic/basic.component.html
@@ -2,7 +2,7 @@
   <div class="d-flex flex-column w-50">
     <thy-date-picker
       class="d-block"
-      thyPlaceHolder="选择日期"
+      thyPlaceholder="选择日期"
       [(ngModel)]="date"
       (ngModelChange)="onChange($event)"
       [thyAllowClear]="isAllowClear"
@@ -15,7 +15,7 @@
   <div class="d-flex flex-column w-50">
     <thy-date-picker
       class="d-block"
-      thyPlaceHolder="选择周"
+      thyPlaceholder="选择周"
       [thyMode]="'week'"
       [(ngModel)]="week"
       (ngModelChange)="onChange($event)"
@@ -28,7 +28,7 @@
   <div class="d-flex flex-column w-50">
     <thy-month-picker
       class="d-block"
-      thyPlaceHolder="选择月份"
+      thyPlaceholder="选择月份"
       [(ngModel)]="dateTime"
       (ngModelChange)="onChange($event)"
       [thyAllowClear]="isAllowClear">
@@ -40,7 +40,7 @@
   <div class="d-flex flex-column w-50">
     <thy-quarter-picker
       class="d-block"
-      thyPlaceHolder="选择季度"
+      thyPlaceholder="选择季度"
       [(ngModel)]="dateTime"
       (ngModelChange)="onChange($event)"
       [thyAllowClear]="isAllowClear">
@@ -52,7 +52,7 @@
   <div class="d-flex flex-column w-50">
     <thy-year-picker
       class="d-block"
-      thyPlaceHolder="选择年份"
+      thyPlaceholder="选择年份"
       [(ngModel)]="dateTime"
       (ngModelChange)="onChange($event)"
       [thyAllowClear]="isAllowClear">

--- a/src/date-picker/examples/date-render/date-render.component.html
+++ b/src/date-picker/examples/date-render/date-render.component.html
@@ -2,7 +2,7 @@
   <thy-date-picker
     class="d-block"
     thyShowTime
-    thyPlaceHolder="全局自定义"
+    thyPlaceholder="全局自定义"
     [(ngModel)]="dateTime"
     (ngModelChange)="onChange($event)"
     [thyAllowClear]="false"
@@ -14,7 +14,7 @@
   <thy-date-picker
     class="d-block"
     thyShowTime
-    thyPlaceHolder="日期自定义"
+    thyPlaceholder="日期自定义"
     [(ngModel)]="dateTime"
     [thyDateRender]="dateCellRender"
     (ngModelChange)="onChange($event)"

--- a/src/date-picker/examples/disabled-date/disabled-date.component.html
+++ b/src/date-picker/examples/disabled-date/disabled-date.component.html
@@ -1,7 +1,7 @@
 <div class="d-flex align-items-center w-50 mb-3">
   <thy-date-picker
     class="d-block w-50 mr-4"
-    thyPlaceHolder="开始时间"
+    thyPlaceholder="开始时间"
     [thyShowShortcut]="true"
     [thyShowTime]="true"
     thyFormat="yyyy-MM-dd HH:mm:ss"
@@ -10,7 +10,7 @@
   </thy-date-picker>
   <thy-date-picker
     class="d-block w-50"
-    thyPlaceHolder="结束时间"
+    thyPlaceholder="结束时间"
     [thyShowShortcut]="true"
     [thyShowTime]="true"
     thyFormat="yyyy-MM-dd HH:mm:ss"
@@ -25,11 +25,11 @@
   thyFormat="yyyy-MM"
   [(ngModel)]="date"
   [thyDisabledDate]="disableDate1"
-  thyPlaceHolder="请选择月份">
+  thyPlaceholder="请选择月份">
 </thy-month-picker>
-<thy-quarter-picker class="d-block w-50 mb-3" [(ngModel)]="quarterDate" [thyDisabledDate]="disableDate1" thyPlaceHolder="请选择季度">
+<thy-quarter-picker class="d-block w-50 mb-3" [(ngModel)]="quarterDate" [thyDisabledDate]="disableDate1" thyPlaceholder="请选择季度">
 </thy-quarter-picker>
-<thy-year-picker class="d-block w-50 mb-3" thyFormat="yyyy" [(ngModel)]="date" [thyDisabledDate]="disableDate1" thyPlaceHolder="请选择年份">
+<thy-year-picker class="d-block w-50 mb-3" thyFormat="yyyy" [(ngModel)]="date" [thyDisabledDate]="disableDate1" thyPlaceholder="请选择年份">
 </thy-year-picker>
 
 <thy-range-picker

--- a/src/date-picker/examples/disabled/disabled.component.html
+++ b/src/date-picker/examples/disabled/disabled.component.html
@@ -1,5 +1,5 @@
 <thy-date-picker class="d-block w-50 mb-3" thyDisabled></thy-date-picker>
-<thy-month-picker class="d-block w-50 mb-3" thyDisabled thyPlaceHolder="选择月份"></thy-month-picker>
-<thy-quarter-picker class="d-block w-50 mb-3" thyDisabled thyPlaceHolder="选择季度"></thy-quarter-picker>
-<thy-year-picker class="d-block w-50 mb-3" thyDisabled thyPlaceHolder="选择年份"></thy-year-picker>
+<thy-month-picker class="d-block w-50 mb-3" thyDisabled thyPlaceholder="选择月份"></thy-month-picker>
+<thy-quarter-picker class="d-block w-50 mb-3" thyDisabled thyPlaceholder="选择季度"></thy-quarter-picker>
+<thy-year-picker class="d-block w-50 mb-3" thyDisabled thyPlaceholder="选择年份"></thy-year-picker>
 <thy-range-picker class="d-block w-50 mb-3" thyDisabled [thyShowShortcut]="true"></thy-range-picker>

--- a/src/date-picker/examples/size/size.component.html
+++ b/src/date-picker/examples/size/size.component.html
@@ -11,15 +11,15 @@
 </div>
 
 <div class="d-flex flex-column w-50 mb-3">
-  <thy-month-picker class="d-block" [thySize]="currentSize" thyPlaceHolder="选择月份"></thy-month-picker>
+  <thy-month-picker class="d-block" [thySize]="currentSize" thyPlaceholder="选择月份"></thy-month-picker>
 </div>
 
 <div class="d-flex flex-column w-50 mb-3">
-  <thy-quarter-picker class="d-block" [thySize]="currentSize" thyPlaceHolder="选择季度"></thy-quarter-picker>
+  <thy-quarter-picker class="d-block" [thySize]="currentSize" thyPlaceholder="选择季度"></thy-quarter-picker>
 </div>
 
 <div class="d-flex flex-column w-50 mb-3">
-  <thy-year-picker class="d-block" [thySize]="currentSize" thyPlaceHolder="选择年份"></thy-year-picker>
+  <thy-year-picker class="d-block" [thySize]="currentSize" thyPlaceholder="选择年份"></thy-year-picker>
 </div>
 
 <div class="d-flex flex-column w-50">

--- a/src/date-picker/month-picker.component.spec.ts
+++ b/src/date-picker/month-picker.component.spec.ts
@@ -115,8 +115,8 @@ describe('ThyMonthPickerComponent', () => {
             expect(allDisabledCells.textContent).toContain('3月');
         }));
 
-        it('should support thyPlaceHolder', () => {
-            const featureKey = (fixtureInstance.thyPlaceHolder = 'TEST_PLACEHOLDER');
+        it('should support thyPlaceholder', () => {
+            const featureKey = (fixtureInstance.thyPlaceholder = 'TEST_PLACEHOLDER');
             fixture.detectChanges();
             expect(getPickerTrigger().getAttribute('placeholder')).toBe(featureKey);
         });
@@ -267,7 +267,7 @@ describe('ThyMonthPickerComponent', () => {
             [thyAllowClear]="thyAllowClear"
             [thyDisabled]="thyDisabled"
             [thyDisabledDate]="thyDisabledDate"
-            [thyPlaceHolder]="thyPlaceHolder">
+            [thyPlaceholder]="thyPlaceholder">
         </thy-month-picker>
     `,
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -277,7 +277,7 @@ class TestMonthPickerComponent {
     thyAllowClear!: boolean;
     thyDisabled!: boolean;
     thyDisabledDate!: (d: Date) => boolean;
-    thyPlaceHolder: string = '请选择月份';
+    thyPlaceholder: string = '请选择月份';
     thyPanelClassName!: string;
     thyValue!: Date;
     thyOpen!: boolean;

--- a/src/date-picker/quarter-picker.component.spec.ts
+++ b/src/date-picker/quarter-picker.component.spec.ts
@@ -111,8 +111,8 @@ describe('ThyQuarterPickerComponent', () => {
             flush();
         }));
 
-        it('should support thyPlaceHolder', () => {
-            const featureKey = (fixtureInstance.thyPlaceHolder = 'TEST_PLACEHOLDER');
+        it('should support thyPlaceholder', () => {
+            const featureKey = (fixtureInstance.thyPlaceholder = 'TEST_PLACEHOLDER');
             fixture.detectChanges();
             expect(getPickerTrigger().getAttribute('placeholder')).toBe(featureKey);
         });
@@ -287,7 +287,7 @@ describe('ThyQuarterPickerComponent', () => {
             [thyDisabled]="thyDisabled"
             [thyDisabledDate]="thyDisabledDate"
             (thyDateChange)="thyDateChange($event)"
-            [thyPlaceHolder]="thyPlaceHolder">
+            [thyPlaceholder]="thyPlaceholder">
         </thy-quarter-picker>
     `,
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -297,7 +297,7 @@ class TestQuarterPickerComponent {
     thyAllowClear!: boolean;
     thyDisabled!: boolean;
     thyDisabledDate!: (d: Date) => boolean;
-    thyPlaceHolder: string = '请选择季度';
+    thyPlaceholder: string = '请选择季度';
     thyPanelClassName!: string;
     thyValue!: Date;
     thyOpen!: boolean;

--- a/src/date-picker/range-picker.component.spec.ts
+++ b/src/date-picker/range-picker.component.spec.ts
@@ -324,15 +324,15 @@ describe('ThyRangePickerComponent', () => {
             expect(disabledCell.textContent.trim()).toBe('15');
         }));
 
-        it('should support thyPlaceHolder as string array', () => {
+        it('should support thyPlaceholder as string array', () => {
             const featureKey = 'RIGHT_PLACEHOLDER';
-            fixtureInstance.thyPlaceHolder = ['Start', featureKey];
+            fixtureInstance.thyPlaceholder = ['Start', featureKey];
             fixture.detectChanges();
             expect(getPickerTrigger().getAttribute('placeholder')).toBe(`Start${fixture.componentInstance.thySeparator}RIGHT_PLACEHOLDER`);
         });
 
-        it('should support thyPlaceHolder as string', () => {
-            fixtureInstance.thyPlaceHolder = 'Range Date Picker PlaceHolder';
+        it('should support thyPlaceholder as string', () => {
+            fixtureInstance.thyPlaceholder = 'Range Date Picker PlaceHolder';
             fixture.detectChanges();
             expect(getPickerTrigger().getAttribute('placeholder')).toBe('Range Date Picker PlaceHolder');
         });
@@ -1053,7 +1053,7 @@ describe('ThyRangePickerComponent', () => {
                     [thyAllowClear]="thyAllowClear"
                     [thyDisabled]="thyDisabled"
                     [thyDisabledDate]="thyDisabledDate"
-                    [thyPlaceHolder]="thyPlaceHolder"
+                    [thyPlaceholder]="thyPlaceholder"
                     [thyPanelClassName]="thyPanelClassName"
                     [thySize]="thySize"
                     [thySuffixIcon]="thySuffixIcon"
@@ -1106,7 +1106,7 @@ class ThyTestRangePickerComponent {
     thyAllowClear!: boolean;
     thyDisabled!: boolean;
     thyDisabledDate!: (d: Date) => boolean;
-    thyPlaceHolder!: string | string[];
+    thyPlaceholder!: string | string[];
     thyPanelClassName!: string;
     thySize!: string;
     thySuffixIcon!: string;

--- a/src/date-picker/week-picker.component.spec.ts
+++ b/src/date-picker/week-picker.component.spec.ts
@@ -98,8 +98,8 @@ describe('ThyWeekPickerComponent', () => {
             expect(debugElement.query(By.css('.thy-picker .thy-input-disabled'))).toBeNull();
         }));
 
-        it('should support thyPlaceHolder', () => {
-            const featureKey = (fixtureInstance.thyPlaceHolder = 'TEST_PLACEHOLDER');
+        it('should support thyPlaceholder', () => {
+            const featureKey = (fixtureInstance.thyPlaceholder = 'TEST_PLACEHOLDER');
             fixture.detectChanges();
             expect(getPickerTrigger().getAttribute('placeholder')).toBe(featureKey);
         });
@@ -167,7 +167,7 @@ describe('ThyWeekPickerComponent', () => {
             (ngModelChange)="modelValueChange($event)"
             [thyAllowClear]="thyAllowClear"
             [thyDisabled]="thyDisabled"
-            [thyPlaceHolder]="thyPlaceHolder"
+            [thyPlaceholder]="thyPlaceholder"
             (thyDateChange)="thyDateChange($event)"></thy-week-picker>
     `,
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -176,7 +176,7 @@ describe('ThyWeekPickerComponent', () => {
 class TestWeekPickerComponent {
     thyAllowClear!: boolean;
     thyDisabled!: boolean;
-    thyPlaceHolder: string = '请选择周';
+    thyPlaceholder: string = '请选择周';
     thyValue!: Date;
     modelValueChange(): void {}
     thyDateChange(): void {}

--- a/src/date-picker/year-picker.component.spec.ts
+++ b/src/date-picker/year-picker.component.spec.ts
@@ -115,8 +115,8 @@ describe('ThyYearPickerComponent', () => {
             flush();
         }));
 
-        it('should support thyPlaceHolder', () => {
-            const featureKey = (fixtureInstance.thyPlaceHolder = 'TEST_PLACEHOLDER');
+        it('should support thyPlaceholder', () => {
+            const featureKey = (fixtureInstance.thyPlaceholder = 'TEST_PLACEHOLDER');
             fixture.detectChanges();
             expect(getPickerTrigger().getAttribute('placeholder')).toBe(featureKey);
         });
@@ -258,7 +258,7 @@ describe('ThyYearPickerComponent', () => {
             [thyDisabled]="thyDisabled"
             [thyDisabledDate]="thyDisabledDate"
             (thyDateChange)="thyDateChange($event)"
-            [thyPlaceHolder]="thyPlaceHolder">
+            [thyPlaceholder]="thyPlaceholder">
         </thy-year-picker>
     `,
     changeDetection: ChangeDetectionStrategy.Eager,
@@ -268,7 +268,7 @@ class TestYearPickerComponent {
     thyAllowClear!: boolean;
     thyDisabled!: boolean;
     thyDisabledDate!: (d: Date) => boolean;
-    thyPlaceHolder: string = '请选择年';
+    thyPlaceholder: string = '请选择年';
     thyPanelClassName!: string;
     thyValue!: Date;
     thyOpen!: boolean;

--- a/src/divider/examples/with-text/with-text.component.html
+++ b/src/divider/examples/with-text/with-text.component.html
@@ -17,7 +17,7 @@
   <p>{{ articleList[8] }}</p>
   <thy-divider [thyText]="dividerTemplateSelect"></thy-divider>
   <ng-template #dividerTemplateSelect>
-    <thy-select thyPlaceHolder="请选择" style="width: 80px">
+    <thy-select thyPlaceholder="请选择" style="width: 80px">
       <thy-option thyValue="or|or" thyLabelText="Or"></thy-option>
       <thy-option thyValue="and&and" thyLabelText="And"></thy-option>
     </thy-select>

--- a/src/divider/test/divider.spec.ts
+++ b/src/divider/test/divider.spec.ts
@@ -16,7 +16,7 @@ import { provideHttpClient, withXhr } from '@angular/common/http';
                 [thyDeeper]="isDeeper"
                 [thyColor]="color"></thy-divider>
             <ng-template #dividerTemplateSelect>
-                <thy-select [(ngModel)]="dividerSelectModel" thyPlaceHolder="请选择">
+                <thy-select [(ngModel)]="dividerSelectModel" thyPlaceholder="请选择">
                     <thy-option thyValue="or|or" thyLabelText="Or"></thy-option>
                     <thy-option thyValue="and&and" thyLabelText="And"></thy-option>
                 </thy-select>

--- a/src/form/examples/reactive/reactive.component.html
+++ b/src/form/examples/reactive/reactive.component.html
@@ -19,7 +19,7 @@
 @if (loadingDone()) {
   <form thyForm name="demoForm" thyLayout="horizontal" [thyFormValidatorConfig]="validateConfig" [formGroup]="formGroup()">
     <thy-form-group thyLabelText="Input" thyLayout="horizontal" thyLabelRequired>
-      <thy-input name="input" formControlName="input" placeholder="Please enter"></thy-input>
+      <thy-input name="input" formControlName="input" thyPlaceholder="Please enter"></thy-input>
     </thy-form-group>
     <thy-form-group thyLabelText="TreeSelect" thyLabelRequired>
       <thy-tree-select
@@ -35,7 +35,7 @@
     </thy-form-group>
     <thy-form-group thyLabelText="CustomerSelect" thyLabelRequired>
       <thy-select
-        thyPlaceHolder="请选择"
+        thyPlaceholder="请选择"
         formControlName="customersSelect"
         name="customersSelect"
         [thyShowSearch]="true"
@@ -46,15 +46,15 @@
       </thy-select>
     </thy-form-group>
     <thy-form-group thyLabelText="Search" thyLayout="horizontal" thyLabelRequired>
-      <thy-input-search name="search" formControlName="search" placeholder="Please enter"></thy-input-search>
+      <thy-input-search name="search" formControlName="search" thyPlaceholder="Please enter"></thy-input-search>
     </thy-form-group>
     <thy-form-group thyLabelText="Number" thyLayout="horizontal" thyLabelRequired>
-      <thy-input-number thyPlaceholder="Please enter" name="number" formControlName="number" placeholder="search"></thy-input-number>
+      <thy-input-number thyPlaceholder="Please enter" name="number" formControlName="number"></thy-input-number>
     </thy-form-group>
     <thy-form-group thyLabelText="customersMultiSelect" thyLabelRequired>
       <thy-select
         [thyMode]="'multiple'"
-        thyPlaceHolder="请选择"
+        thyPlaceholder="请选择"
         formControlName="customersMultiSelect"
         name="customersMultiSelect"
         [thyShowSearch]="true"

--- a/src/form/test/form-directive.spec.ts
+++ b/src/form/test/form-directive.spec.ts
@@ -117,7 +117,7 @@ export class TestFormFullComponent {
                 </thy-form-group>
                 <thy-form-group thyLabelText="CustomerSelect">
                     <thy-select
-                        thyPlaceHolder="请选择"
+                        thyPlaceholder="请选择"
                         formControlName="customersSelect"
                         name="customersSelect"
                         [thyShowSearch]="true"

--- a/src/input/examples/append-prepend/append-prepend.component.html
+++ b/src/input/examples/append-prepend/append-prepend.component.html
@@ -1,7 +1,7 @@
 <p>Please use <code>thy-input-group</code> prefix or suffix instead of it.</p>
 <div thyRow [thyGutter]="30">
   <div thyCol [thySpan]="12">
-    <thy-input placeholder="Please type">
+    <thy-input thyPlaceholder="Please type">
       <ng-template #prepend>
         <thy-icon class="text-placeholder" thyIconName="user"></thy-icon>
       </ng-template>
@@ -10,7 +10,7 @@
       </ng-template>
     </thy-input>
     <br />
-    <thy-input placeholder="Please type" thySize="md">
+    <thy-input thyPlaceholder="Please type" thySize="md">
       <ng-template #prepend>
         <thy-icon class="text-placeholder" thyIconName="user"></thy-icon>
       </ng-template>
@@ -20,7 +20,7 @@
     </thy-input>
   </div>
   <div thyCol [thySpan]="12">
-    <thy-input placeholder="Please type">
+    <thy-input thyPlaceholder="Please type">
       <ng-template #prepend>
         <a class="link-muted link-has-icon" href="javascript:;">中国+86 <thy-icon thyIconName="angle-down"></thy-icon></a>
       </ng-template>

--- a/src/input/examples/autofocus/autofocus.component.html
+++ b/src/input/examples/autofocus/autofocus.component.html
@@ -3,6 +3,6 @@
     <button thyButton="primary" (click)="autofocus = true" class="mb-3">Autofocus</button>
   </div>
   <div thyCol [thySpan]="12">
-    <thy-input [thyAutofocus]="autofocus" placeholder="Please type"></thy-input>
+    <thy-input [thyAutofocus]="autofocus" thyPlaceholder="Please type"></thy-input>
   </div>
 </div>

--- a/src/input/examples/basic/basic.component.html
+++ b/src/input/examples/basic/basic.component.html
@@ -5,8 +5,8 @@
     <input thyInput [disabled]="true" [(ngModel)]="value" placeholder="Disabled, can't type (thyInput)" class="mt-3" />
   </div>
   <div thyCol [thySpan]="12">
-    <thy-input [(ngModel)]="value" placeholder="Please type (thy-input)"></thy-input>
-    <thy-input thyInput readonly [(ngModel)]="value" placeholder="Readonly, can't type (thy-input)" class="mt-3"></thy-input>
-    <thy-input [(ngModel)]="value" [disabled]="true" placeholder="Disabled, can't type (thy-input)" class="mt-3"></thy-input>
+    <thy-input [(ngModel)]="value" thyPlaceholder="Please type (thy-input)"></thy-input>
+    <thy-input thyInput readonly [(ngModel)]="value" thyPlaceholder="Readonly, can't type (thy-input)" class="mt-3"></thy-input>
+    <thy-input [(ngModel)]="value" [disabled]="true" thyPlaceholder="Disabled, can't type (thy-input)" class="mt-3"></thy-input>
   </div>
 </div>

--- a/src/input/examples/label/label.component.html
+++ b/src/input/examples/label/label.component.html
@@ -1,9 +1,9 @@
 <div thyRow [thyGutter]="30">
   <div thyCol [thySpan]="12">
-    <thy-input thyLabelText="Name" name="username" [(ngModel)]="value" placeholder="Please type name"></thy-input>
+    <thy-input thyLabelText="Name" name="username" [(ngModel)]="value" thyPlaceholder="Please type name"></thy-input>
   </div>
   <div thyCol [thySpan]="12">
-    <thy-input thyLabelText="Name" name="username" [(ngModel)]="value" placeholder="Please type name">
+    <thy-input thyLabelText="Name" name="username" [(ngModel)]="value" thyPlaceholder="Please type name">
       <ng-template #prepend>
         <thy-icon class="text-placeholder" thyIconName="user"></thy-icon>
       </ng-template>

--- a/src/input/examples/search/search.component.html
+++ b/src/input/examples/search/search.component.html
@@ -7,7 +7,7 @@
       [(ngModel)]="searchText"
       (ngModelChange)="change()"
       (thyClear)="change()"
-      placeholder="Disabled, can't type (thy-input)"></thy-input-search>
+      thyPlaceholder="Disabled, can't type (thy-input)"></thy-input-search>
     <br />
     <thy-input-search
       (keydown.enter)="change()"
@@ -15,7 +15,7 @@
       (ngModelChange)="change()"
       (thyClear)="change()"
       thyIconPosition="after"
-      placeholder="Search"></thy-input-search>
+      thyPlaceholder="Search"></thy-input-search>
     <br />
     <thy-input-search
       (keydown.enter)="change()"
@@ -23,10 +23,10 @@
       (ngModelChange)="change()"
       (thyClear)="change()"
       thyTheme="transparent"
-      placeholder="Search"></thy-input-search>
+      thyPlaceholder="Search"></thy-input-search>
     <br />
     <thy-input-group>
-      <thy-input placeholder="Search" [(ngModel)]="searchText" [disabled]="true" placeholder="Disabled, can't type (thy-input)"></thy-input>
+      <thy-input thyPlaceholder="Disabled, can't type (thy-input)" [(ngModel)]="searchText" [disabled]="true"></thy-input>
       <ng-template #append>
         <button thyButton="primary"><thy-icon thyIconName="search"></thy-icon></button>
       </ng-template>
@@ -34,11 +34,11 @@
     <br />
   </div>
   <div thyCol [thySpan]="12">
-    <thy-input-search thyTheme="ellipse" placeholder="Search" [(ngModel)]="searchText"></thy-input-search>
+    <thy-input-search thyTheme="ellipse" thyPlaceholder="Search" [(ngModel)]="searchText"></thy-input-search>
     <br />
-    <thy-input-search thyTheme="ellipse" [(ngModel)]="searchText" thyIconPosition="after" placeholder="Search"></thy-input-search>
+    <thy-input-search thyTheme="ellipse" [(ngModel)]="searchText" thyIconPosition="after" thyPlaceholder="Search"></thy-input-search>
     <br />
-    <thy-input placeholder="Search">
+    <thy-input thyPlaceholder="Search">
       <ng-template #append>
         <thy-icon class="text-placeholder" thyIconName="search"></thy-icon>
       </ng-template>

--- a/src/input/examples/size/size.component.html
+++ b/src/input/examples/size/size.component.html
@@ -6,9 +6,9 @@
     <input thyInput thySize="lg" placeholder="size: lg (36px)" class="mt-3" />
   </div>
   <div thyCol [thySpan]="12">
-    <thy-input thySize="xs" placeholder="size: xs (24px)"></thy-input>
-    <thy-input thySize="sm" placeholder="size: sm (28px)" class="mt-3"></thy-input>
-    <thy-input thySize="md" placeholder="size: md (32px)" class="mt-3"></thy-input>
-    <thy-input thySize="lg" placeholder="size: lg (36px)" class="mt-3"></thy-input>
+    <thy-input thySize="xs" thyPlaceholder="size: xs (24px)"></thy-input>
+    <thy-input thySize="sm" thyPlaceholder="size: sm (28px)" class="mt-3"></thy-input>
+    <thy-input thySize="md" thyPlaceholder="size: md (32px)" class="mt-3"></thy-input>
+    <thy-input thySize="lg" thyPlaceholder="size: lg (36px)" class="mt-3"></thy-input>
   </div>
 </div>

--- a/src/input/input-search.component.html
+++ b/src/input/input-search.component.html
@@ -6,7 +6,7 @@
   #input
   thyInput
   [name]="name()"
-  [placeholder]="placeholder()"
+  [placeholder]="thyPlaceholder()"
   [disabled]="disabled()"
   [thyAutofocus]="autoFocus()"
   [(ngModel)]="searchText"

--- a/src/input/input-search.component.ts
+++ b/src/input/input-search.component.ts
@@ -93,7 +93,7 @@ export class ThyInputSearch extends _MixinBase implements ControlValueAccessor, 
     /**
      * 搜索框 Placeholder
      */
-    readonly placeholder = input('');
+    readonly thyPlaceholder = input('');
 
     /**
      * 搜索框风格

--- a/src/input/input.component.html
+++ b/src/input/input.component.html
@@ -9,7 +9,7 @@
   [thySize]="thySize()"
   [thyAutofocus]="thyAutofocus()"
   [type]="type()"
-  [placeholder]="placeholder()"
+  [placeholder]="thyPlaceholder()"
   [disabled]="disabled()"
   [(ngModel)]="value"
   [ngModelOptions]="{ standalone: true }"

--- a/src/input/input.component.ts
+++ b/src/input/input.component.ts
@@ -54,7 +54,7 @@ export class ThyInput implements ControlValueAccessor {
     /**
      * Placeholder
      */
-    readonly placeholder = input('');
+    readonly thyPlaceholder = input('');
 
     /**
      * 输入框大小

--- a/src/input/test/input-component.spec.ts
+++ b/src/input/test/input-component.spec.ts
@@ -16,7 +16,7 @@ import { provideHttpClient, withXhr } from '@angular/common/http';
             [readonly]="readonly"
             name="username"
             [(ngModel)]="value"
-            placeholder="请输入您的姓名"
+            thyPlaceholder="请输入您的姓名"
             (focus)="onFocus()"
             (blur)="onBlur()"
             [disabled]="disabled">

--- a/src/input/test/input-search.spec.ts
+++ b/src/input/test/input-search.spec.ts
@@ -12,7 +12,7 @@ import { provideHttpClient, withXhr } from '@angular/common/http';
     template: `
         <thy-input-search
             name="search"
-            placeholder="Please type"
+            thyPlaceholder="Please type"
             [disabled]="disabled"
             [thyTheme]="thyTheme"
             [thySearchFocus]="searchFocus"

--- a/src/property/examples/editable/date.component.ts
+++ b/src/property/examples/editable/date.component.ts
@@ -8,7 +8,7 @@ import { ThyDatePicker } from 'ngx-tethys/date-picker';
         <thy-date-picker
             thyShowTime
             [thyFormat]="'yyyy-MM-dd HH:mm'"
-            thyPlaceHolder="选择时间"
+            thyPlaceholder="选择时间"
             [(ngModel)]="user().birth_date"
             [thyHasBackdrop]="false"
             thySize="md"></thy-date-picker>

--- a/src/select/custom-select/custom-select.component.html
+++ b/src/select/custom-select/custom-select.component.html
@@ -10,7 +10,7 @@
   [thyShowSearch]="thyShowSearch()"
   [thyAllowClear]="thyAllowClear()"
   [thySize]="thySize()"
-  [thyPlaceholder]="thyPlaceHolder()"
+  [thyPlaceholder]="thyPlaceholder()"
   [customDisplayTemplate]="selectedValueDisplayRef()"
   [thyDisabled]="disabled"
   [thyBorderless]="thyBorderless()"

--- a/src/select/custom-select/custom-select.component.ts
+++ b/src/select/custom-select/custom-select.component.ts
@@ -315,7 +315,7 @@ export class ThySelect extends TabIndexDisabledControlValueAccessorMixin impleme
     /**
      * 选择框默认文字
      */
-    readonly thyPlaceHolder = input<string>(this.locale().placeholder);
+    readonly thyPlaceholder = input<string>(this.locale().placeholder);
 
     /**
      * 是否使用服务端搜索，当为 true 时，将不再在前端进行过滤

--- a/src/select/custom-select/custom-select.spec.ts
+++ b/src/select/custom-select/custom-select.spec.ts
@@ -36,7 +36,7 @@ interface FoodsInfo {
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
             <thy-select
-                thyPlaceHolder="Food"
+                thyPlaceholder="Food"
                 [thyEnableScrollLoad]="enableScrollLoad"
                 (thyOnScrollToBottom)="thyOnScrollToBottom()"
                 [formControl]="control"
@@ -105,12 +105,12 @@ class BasicSelectComponent {
 @Component({
     selector: 'thy-multiple-select',
     template: `
-        <thy-select class="foods" [thyMode]="'multiple'" [(ngModel)]="selectedFoods" #Foods thyPlaceHolder="Food">
+        <thy-select class="foods" [thyMode]="'multiple'" [(ngModel)]="selectedFoods" #Foods thyPlaceholder="Food">
             @for (food of foods; track food.value) {
                 <thy-option [thyValue]="food.value" [thyDisabled]="food.disabled" [thyLabelText]="food.viewValue"> </thy-option>
             }
         </thy-select>
-        <thy-select class="vegetables" #Vegetables thyPlaceHolder="Vegetables">
+        <thy-select class="vegetables" #Vegetables thyPlaceholder="Vegetables">
             @for (vegetable of vegetables; track vegetable.value) {
                 <thy-option [thyValue]="vegetable.value" [thyLabelText]="vegetable.viewValue"> </thy-option>
             }
@@ -142,7 +142,7 @@ class MultipleSelectComponent {
     selector: 'thy-ng-model-select',
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
-            <thy-select thyPlaceHolder="Food" ngModel name="food" [thyDisabled]="isDisabled">
+            <thy-select thyPlaceholder="Food" ngModel name="food" [thyDisabled]="isDisabled">
                 @for (food of foods; track food.value) {
                     <thy-option [thyValue]="food.value" [thyLabelText]="food.viewValue"> </thy-option>
                 }
@@ -167,7 +167,7 @@ class NgModelSelectComponent {
     selector: 'thy-select-with-groups',
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
-            <thy-select thyPlaceHolder="Pokemon" [formControl]="control">
+            <thy-select thyPlaceholder="Pokemon" [formControl]="control">
                 @for (group of pokemonTypes; track $index) {
                     <thy-option-group [thyGroupLabel]="group.name">
                         @for (pokemon of group.pokemon; track pokemon.value) {
@@ -194,7 +194,7 @@ class SelectWithGroupsAndNgContainerComponent {
 @Component({
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
-            <thy-select placeholder="Food" [(ngModel)]="selectedFoods" name="food">
+            <thy-select thyPlaceholder="Food" [(ngModel)]="selectedFoods" name="food">
                 @for (food of foods; track food.value) {
                     <thy-option [thyValue]="food.value" [thyLabelText]="food.viewValue"></thy-option>
                 }
@@ -219,7 +219,7 @@ class SingleSelectWithPreselectedArrayValuesComponent {
 @Component({
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
-            <thy-select placeholder="Food" [(ngModel)]="selectedValues" name="food">
+            <thy-select thyPlaceholder="Food" [(ngModel)]="selectedValues" name="food">
                 @for (item of values; track item.value) {
                     <thy-option [thyValue]="item.value" [thyLabelText]="item.viewValue"></thy-option>
                 }
@@ -276,7 +276,7 @@ class SelectEarlyAccessSiblingComponent {}
     selector: 'thy-select-with-search',
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
-            <thy-select thyPlaceHolder="Food" [thyShowSearch]="thyShowSearch">
+            <thy-select thyPlaceholder="Food" [thyShowSearch]="thyShowSearch">
                 @for (food of foods; track food.value) {
                     <thy-option [thyValue]="food.value" [thyDisabled]="food.disabled" [thyLabelText]="food.viewValue"> </thy-option>
                 }
@@ -306,7 +306,7 @@ class SelectWithSearchComponent {
     selector: 'thy-select-with-search',
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
-            <thy-select thyPlaceHolder="team-members" [thyShowSearch]="thyShowSearch">
+            <thy-select thyPlaceholder="team-members" [thyShowSearch]="thyShowSearch">
                 @for (member of teamMembers; track member._id) {
                     <thy-option [thyValue]="member._id" [thyLabelText]="member.name" thySearchKey="{{ member.name }},{{ member.pin_yin }}">
                     </thy-option>
@@ -350,7 +350,7 @@ class SelectWithSearchUseSearchKeyComponent {
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
             <thy-select
-                thyPlaceHolder="Pokemon"
+                thyPlaceholder="Pokemon"
                 [thyShowSearch]="true"
                 [thyEmptySearchMessageText]="emptySearchMessageText"
                 [formControl]="control">
@@ -394,7 +394,7 @@ class SelectWithSearchAndGroupComponent {
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
             <thy-select
-                thyPlaceHolder="Food"
+                thyPlaceholder="Food"
                 name="foods"
                 [thyShowSearch]="thyShowSearch"
                 [thyServerSearch]="true"
@@ -431,7 +431,7 @@ class SelectWithSearchAndServerSearchComponent {
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
             <thy-select
-                thyPlaceHolder="Food"
+                thyPlaceholder="Food"
                 [thyMode]="mode"
                 style="width:500px"
                 [thyAllowClear]="thyAllowClear"
@@ -491,7 +491,7 @@ class SelectWithExpandStatusComponent {
 @Component({
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
-            <thy-select placeholder="Food" [(ngModel)]="selectedFoods" name="food" [thyMode]="selectMode">
+            <thy-select thyPlaceholder="Food" [(ngModel)]="selectedFoods" name="food" [thyMode]="selectMode">
                 @for (food of foods; track food.value) {
                     <thy-option [thyValue]="food.value" [thyLabelText]="food.viewValue"></thy-option>
                 }
@@ -519,7 +519,7 @@ class SelectWithThyModeComponent {
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
             <thy-select
-                placeholder="Food"
+                thyPlaceholder="Food"
                 [(ngModel)]="selectedFoods"
                 name="food"
                 [thyMode]="selectMode"
@@ -630,7 +630,7 @@ class SelectWithThyFlexiblePositionComponent {
     template: `
         <form thyForm name="demoForm" #demoForm="ngForm">
             <thy-select
-                thyPlaceHolder="Food"
+                thyPlaceholder="Food"
                 name="foods"
                 [thyShowSearch]="showSearch"
                 [thyServerSearch]="serverSearch"

--- a/src/select/examples/basic/basic.component.html
+++ b/src/select/examples/basic/basic.component.html
@@ -4,7 +4,7 @@
       <thy-option [thyValue]="option.value" [thyLabelText]="option.text"> </thy-option>
     }
   </thy-select>
-  <thy-custom-select ngModel="option2" [thyAllowClear]="true" [thyPlaceHolder]="locale().placeholder">
+  <thy-custom-select ngModel="option2" [thyAllowClear]="true" [thyPlaceholder]="locale().placeholder">
     @for (option of listOfOption; track option.value) {
       <thy-option [thyValue]="option.value" [thyLabelText]="option.text"> </thy-option>
     }

--- a/src/select/examples/custom-display/custom-display.component.html
+++ b/src/select/examples/custom-display/custom-display.component.html
@@ -1,5 +1,5 @@
 <div class="mb-2">单选</div>
-<thy-select [(ngModel)]="selectedTaskType" thyPlaceHolder="请选择" style="width: 500px">
+<thy-select [(ngModel)]="selectedTaskType" thyPlaceholder="请选择" style="width: 500px">
   <thy-option thyValue="" thyRawValue="" thyLabelText="空">
     <ng-template #suffixTemplate>
       <thy-divider class="my-1 mx-5"></thy-divider>
@@ -26,7 +26,7 @@
   </ng-template>
 </thy-select>
 <div class="mt-2 mb-2">多选</div>
-<thy-select [(ngModel)]="selectedTaskTypes" thyMode="multiple" thyPlaceHolder="请选择" style="width: 500px">
+<thy-select [(ngModel)]="selectedTaskTypes" thyMode="multiple" thyPlaceholder="请选择" style="width: 500px">
   <thy-option thyValue="" thyLabelText="空"></thy-option>
   @for (option of optionData; track option._id) {
     <thy-option thyShowOptionCustom="true" [thyRawValue]="option" [thyValue]="option.name" [thyLabelText]="option.display_name">
@@ -49,7 +49,7 @@
   </ng-template>
 </thy-select>
 <div class="mt-2 mb-2">多选 自定义选中的option样式</div>
-<thy-select [(ngModel)]="selectedTaskTypes" thyMode="multiple" thyPlaceHolder="请选择" style="width: 500px" thyPreset="tag">
+<thy-select [(ngModel)]="selectedTaskTypes" thyMode="multiple" thyPlaceholder="请选择" style="width: 500px" thyPreset="tag">
   <thy-option thyValue="" thyLabelText="空"></thy-option>
   @for (option of optionData; track option._id) {
     <thy-option thyShowOptionCustom="true" [thyRawValue]="option" [thyValue]="option.name" [thyLabelText]="option.display_name">

--- a/src/select/examples/empty-option/empty-option.component.html
+++ b/src/select/examples/empty-option/empty-option.component.html
@@ -1,6 +1,6 @@
-<thy-select thyEmptyStateText="无任何选择项" thyPlaceHolder="无任何选择项" style="width: 500px"></thy-select>
+<thy-select thyEmptyStateText="无任何选择项" thyPlaceholder="无任何选择项" style="width: 500px"></thy-select>
 <br />
-<thy-select thyEmptySearchMessageText="搜索结果为空" thyPlaceHolder="搜索结果为空" [thyShowSearch]="true" style="width: 500px">
+<thy-select thyEmptySearchMessageText="搜索结果为空" thyPlaceholder="搜索结果为空" [thyShowSearch]="true" style="width: 500px">
   @for (option of listOfOption; track option.value) {
     <thy-option [thyValue]="option.value" [thyLabelText]="option.text"></thy-option>
   }

--- a/src/select/examples/footer/footer.component.html
+++ b/src/select/examples/footer/footer.component.html
@@ -1,4 +1,4 @@
-<thy-select thyPlaceHolder="自定义 Footer" [thyShowSearch]="true" style="width: 500px" [thyFooterTemplate]="footer">
+<thy-select thyPlaceholder="自定义 Footer" [thyShowSearch]="true" style="width: 500px" [thyFooterTemplate]="footer">
   @for (option of listOfOption; track option.value) {
     <thy-option [thyValue]="option.value" [thyLabelText]="option.text"></thy-option>
   }

--- a/src/select/examples/group/group.component.html
+++ b/src/select/examples/group/group.component.html
@@ -1,5 +1,5 @@
 <div style="display: flex; align-items: center">
-  <thy-select [(ngModel)]="selectedValue1" thyPlaceHolder="选择内容" [thyShowSearch]="true" style="width: 240px; margin-right: 50px">
+  <thy-select [(ngModel)]="selectedValue1" thyPlaceholder="选择内容" [thyShowSearch]="true" style="width: 240px; margin-right: 50px">
     @for (group of productGroups; track group.id) {
       <thy-option-group [thyGroupLabel]="group.name">
         @for (option of group.options; track option.value) {
@@ -9,7 +9,7 @@
     }
   </thy-select>
 
-  <thy-select [(ngModel)]="selectedValue2" thyPlaceHolder="选择标签" style="width: 240px; margin-right: 50px">
+  <thy-select [(ngModel)]="selectedValue2" thyPlaceholder="选择标签" style="width: 240px; margin-right: 50px">
     @for (group of labelGroups; track group.id) {
       <thy-option-group [thyGroupLabel]="group.name">
         @for (option of group.options; track option.value) {
@@ -24,7 +24,7 @@
     </ng-template>
   </thy-select>
 
-  <thy-select [(ngModel)]="selectedValue3" thyPlaceHolder="选择成员" style="width: 240px">
+  <thy-select [(ngModel)]="selectedValue3" thyPlaceholder="选择成员" style="width: 240px">
     @for (group of userGroups; track group.id) {
       <thy-option-group [thyGroupLabel]="group.name">
         @for (option of group.options; track option.uid) {

--- a/src/select/examples/search/search.component.html
+++ b/src/select/examples/search/search.component.html
@@ -5,7 +5,7 @@
     }
   </thy-select>
 
-  <thy-select [(ngModel)]="selectedUser" thyPlaceHolder="选择成员" style="width: 240px" thyShowSearch="true">
+  <thy-select [(ngModel)]="selectedUser" thyPlaceholder="选择成员" style="width: 240px" thyShowSearch="true">
     @for (option of users; track option.uid) {
       <thy-option [thyRawValue]="option" [thyValue]="option.uid" [thyShowOptionCustom]="true" [thySearchKey]="option.name">
         <thy-avatar [thyName]="option.name" [thyShowName]="true" thySize="xs"></thy-avatar>

--- a/src/select/examples/server-search/server-search.component.html
+++ b/src/select/examples/server-search/server-search.component.html
@@ -1,6 +1,6 @@
 <div class="mb-2 mt-2">服务端搜索</div>
 <thy-select
-  thyPlaceHolder="请选择"
+  thyPlaceholder="请选择"
   [thyShowSearch]="true"
   (thyOnSearch)="search($event)"
   [thyServerSearch]="true"

--- a/src/select/examples/size/size.component.html
+++ b/src/select/examples/size/size.component.html
@@ -6,18 +6,18 @@
       </button>
     }
   </thy-button-group>
-  <thy-select thyPlaceHolder="请选择" [thySize]="currentSize.name" ngModel="option1" [thyAllowClear]="true" [thyShowSearch]="true">
+  <thy-select thyPlaceholder="请选择" [thySize]="currentSize.name" ngModel="option1" [thyAllowClear]="true" [thyShowSearch]="true">
     @for (option of listOfOption; track option.value) {
       <thy-option [thyValue]="option.value" [thyLabelText]="option.text"> </thy-option>
     }
   </thy-select>
-  <thy-select thyPlaceHolder="请选择" [thySize]="currentSize.name" thyMode="multiple" [(ngModel)]="listOfSelectedValue">
+  <thy-select thyPlaceholder="请选择" [thySize]="currentSize.name" thyMode="multiple" [(ngModel)]="listOfSelectedValue">
     @for (option of listOfOption; track option.value) {
       <thy-option [thyValue]="option.value" [thyLabelText]="option.text"> </thy-option>
     }
   </thy-select>
   <thy-select
-    thyPlaceHolder="请选择"
+    thyPlaceholder="请选择"
     [thySize]="currentSize.name"
     thyMode="multiple"
     [thyShowSearch]="true"

--- a/src/select/examples/thy-options/thy-options.component.html
+++ b/src/select/examples/thy-options/thy-options.component.html
@@ -3,7 +3,7 @@
   (thyOnScrollToBottom)="onScrollToBottom()"
   thyEnableScrollLoad="true"
   style="width: 500px"
-  thyPlaceHolder="滚动加载"
+  thyPlaceholder="滚动加载"
   [thyOptions]="loadMoreOptions()">
   @if (loading()) {
     <div class="loading-more font-size-xs text-desc">加载中...</div>
@@ -11,7 +11,7 @@
 </thy-select>
 <br />
 <thy-select
-  thyPlaceHolder="多选可搜索"
+  thyPlaceholder="多选可搜索"
   [thyShowSearch]="true"
   [ngModel]="multipleValue"
   style="width: 500px"
@@ -19,14 +19,14 @@
   [thyOptions]="options()">
 </thy-select>
 <br />
-<thy-select thyPlaceHolder="无边框样式" thyBorderless style="width: 500px" [thyOptions]="options()" [(ngModel)]="value"></thy-select>
+<thy-select thyPlaceholder="无边框样式" thyBorderless style="width: 500px" [thyOptions]="options()" [(ngModel)]="value"></thy-select>
 <br />
-<thy-select thyPlaceHolder="禁用" [thyDisabled]="true" style="width: 500px" [thyOptions]="options()" [(ngModel)]="value"></thy-select>
+<thy-select thyPlaceholder="禁用" [thyDisabled]="true" style="width: 500px" [thyOptions]="options()" [(ngModel)]="value"></thy-select>
 <br />
 
 <thy-select
   [thyOptions]="options()"
-  thyPlaceHolder="自定义 Footer"
+  thyPlaceholder="自定义 Footer"
   [thyShowSearch]="true"
   style="width: 500px"
   [thyFooterTemplate]="footer">

--- a/src/select/examples/vertical-center/vertical-center.component.html
+++ b/src/select/examples/vertical-center/vertical-center.component.html
@@ -6,7 +6,7 @@
       </button>
     }
   </thy-button-group>
-  <thy-select thyPlaceHolder="请选择" [thySize]="currentSize.name" ngModel="option1" [thyAllowClear]="true" [thyShowSearch]="true">
+  <thy-select thyPlaceholder="请选择" [thySize]="currentSize.name" ngModel="option1" [thyAllowClear]="true" [thyShowSearch]="true">
     @for (option of listOfOption; track option.value) {
       <thy-option [thyValue]="option.value" [thyRawValue]="option" [thyLabelText]="option.text" thyShowOptionCustom="true">
         <thy-dot thyColor="primary" thySize="md" class="mr-2"></thy-dot>
@@ -25,7 +25,7 @@
       }
     </ng-template>
   </thy-select>
-  <thy-select thyPlaceHolder="请选择" [thySize]="currentSize.name" ngModel="option1" [thyAllowClear]="true" [thyShowSearch]="true">
+  <thy-select thyPlaceholder="请选择" [thySize]="currentSize.name" ngModel="option1" [thyAllowClear]="true" [thyShowSearch]="true">
     @for (option of listOfOption; track option.value) {
       <thy-option [thyValue]="option.value" [thyRawValue]="option" [thyLabelText]="option.text" thyShowOptionCustom="true">
         <div thyFlex class="w-100 justify-content-between">
@@ -52,7 +52,7 @@
       }
     </ng-template>
   </thy-select>
-  <thy-select thyPlaceHolder="请选择" [thySize]="currentSize.name" ngModel="option1" [thyAllowClear]="true" [thyShowSearch]="true">
+  <thy-select thyPlaceholder="请选择" [thySize]="currentSize.name" ngModel="option1" [thyAllowClear]="true" [thyShowSearch]="true">
     @for (option of listOfOption; track option.value) {
       <thy-option [thyValue]="option.value" [thyRawValue]="option" [thyLabelText]="option.text" thyShowOptionCustom="true">
         <thy-avatar [thySrc]="avatarSrc" thyName="张学友" class="mr-2"></thy-avatar>
@@ -71,7 +71,7 @@
       }
     </ng-template>
   </thy-select>
-  <thy-select thyPlaceHolder="请选择" [thySize]="currentSize.name" ngModel="option1" [thyAllowClear]="true" [thyShowSearch]="true">
+  <thy-select thyPlaceholder="请选择" [thySize]="currentSize.name" ngModel="option1" [thyAllowClear]="true" [thyShowSearch]="true">
     @for (option of listOfOption; track option.value) {
       <thy-option [thyValue]="option.value" [thyRawValue]="option" [thyLabelText]="option.text" thyShowOptionCustom="true">
         <span thyText class="text-truncate">
@@ -92,7 +92,7 @@
       }
     </ng-template>
   </thy-select>
-  <thy-select thyPlaceHolder="请选择" [thySize]="currentSize.name" thyMode="multiple" [(ngModel)]="listOfSelectedValue">
+  <thy-select thyPlaceholder="请选择" [thySize]="currentSize.name" thyMode="multiple" [(ngModel)]="listOfSelectedValue">
     @for (option of listOfOption; track option.value) {
       <thy-option [thyValue]="option.value" [thyRawValue]="option" [thyLabelText]="option.text" thyShowOptionCustom="true">
         <thy-dot thyColor="primary" thySize="md" class="mr-2"></thy-dot>
@@ -111,7 +111,7 @@
       }
     </ng-template>
   </thy-select>
-  <thy-select thyPlaceHolder="请选择" [thySize]="currentSize.name" thyMode="multiple" [(ngModel)]="listOfSelectedValue">
+  <thy-select thyPlaceholder="请选择" [thySize]="currentSize.name" thyMode="multiple" [(ngModel)]="listOfSelectedValue">
     @for (option of listOfOption; track option.value) {
       <thy-option [thyValue]="option.value" [thyRawValue]="option" [thyLabelText]="option.text" thyShowOptionCustom="true">
         <span thyText class="text-truncate">

--- a/src/slider/examples/input-value/input-value.component.ts
+++ b/src/slider/examples/input-value/input-value.component.ts
@@ -9,7 +9,7 @@ import { FormsModule } from '@angular/forms';
         <div class="input-container mb-2">
             <thy-slider [(ngModel)]="value"></thy-slider>
         </div>
-        <thy-input-number [(ngModel)]="value" placeholder="请输入"></thy-input-number>
+        <thy-input-number [(ngModel)]="value" thyPlaceholder="请输入"></thy-input-number>
     `,
     changeDetection: ChangeDetectionStrategy.Eager,
     imports: [ThySlider, ThyInputNumber, FormsModule]

--- a/src/tree-select/test/tree-select.spec.ts
+++ b/src/tree-select/test/tree-select.spec.ts
@@ -715,7 +715,7 @@ describe('ThyTreeSelect', () => {
             }));
         });
 
-        describe('with thyPlaceHolder', () => {
+        describe('with thyPlaceholder', () => {
             beforeEach(waitForAsync(() => {
                 configureThyCustomSelectTestingModule([PlaceHolderTreeSelectComponent]);
             }));


### PR DESCRIPTION
- thy-input: rename `placeholder` to `thyPlaceholder`
- thy-input-search: rename `placeholder` to `thyPlaceholder`
- thy-select / thy-custom-select: rename `thyPlaceHolder` to `thyPlaceholder`
- thy-date-picker: rename `thyPlaceHolder` to `thyPlaceholder`
- thy-range-picker: rename `thyPlaceHolder` to `thyPlaceholder`
- thy-month-picker: rename `thyPlaceHolder` to `thyPlaceholder`
- thy-quarter-picker: rename `thyPlaceHolder` to `thyPlaceholder`
- thy-year-picker: rename `thyPlaceHolder` to `thyPlaceholder`
- thy-week-picker: rename `thyPlaceHolder` to `thyPlaceholder`
- thyDatePicker / thyRangePicker directive: rename `thyPlaceHolder` to `thyPlaceholder`
