### PR TITLE
AGENLU-29: feat(button) add thyAppearance parameter

### DIFF
--- a/src/button/button.component.ts
+++ b/src/button/button.component.ts
@@ -17,40 +17,9 @@ import { useHostRenderer } from '@tethys/cdk/dom';
 import { ThyIcon } from 'ngx-tethys/icon';
 import { assertIconOnly, coerceBooleanProperty, ThyBooleanInput } from 'ngx-tethys/util';
 
-export type ThyButtonType =
-    | 'primary'
-    | 'secondary'
-    | 'info'
-    | 'outline-primary'
-    | 'outline-default'
-    | 'danger'
-    | 'link'
-    | 'link-secondary'
-    | 'warning'
-    | 'outline-warning'
-    | 'success'
-    | 'outline-success'
-    | 'outline-info'
-    | 'outline-danger'
-    | 'link-danger-weak'
-    | 'link-danger'
-    | 'link-success';
+export type ThyButtonAppearance = 'fill' | 'outline' | 'link';
 
-const btnTypeClassesMap: Record<string, string[]> = {
-    primary: ['btn-primary'],
-    secondary: ['btn-primary', 'btn-md'],
-    info: ['btn-info'],
-    warning: ['btn-warning'],
-    danger: ['btn-danger'],
-    'outline-primary': ['btn-outline-primary'],
-    'outline-default': ['btn-outline-default'],
-    link: ['btn-link'], // 链接按钮
-    'link-info': ['btn-link', 'btn-link-info'], // 幽灵链接按钮
-    'link-secondary': ['btn-link', 'btn-link-primary-weak'], // 幽灵链接按钮
-    'link-danger-weak': ['btn-link', 'btn-link-danger-weak'], // 幽灵危险按钮
-    'link-danger': ['btn-link', 'btn-link-danger'], // 危险按钮
-    'link-success': ['btn-link', 'btn-link-success'] // 成功按钮
-};
+export type ThyButtonType = 'primary' | 'default' | 'info' | 'warning' | 'danger' | 'success';
 
 const iconOnlyClass = 'thy-btn-icon-only';
 
@@ -86,17 +55,24 @@ export class ThyButton {
     private hostRenderer = useHostRenderer();
 
     /**
-     * 按钮类型，支持添加前缀`outline-`实现线框按钮，支持添加前缀`link-`实现按钮链接
-     * @type primary | info | warning | danger | success
+     * 按钮外观
+     * @type fill | outline | link
+     * @default fill
+     */
+    readonly thyAppearance = input<ThyButtonAppearance>('fill');
+
+    /**
+     * 按钮类型（颜色）
+     * @type primary | default | info | warning | danger | success
      * @default primary
      */
-    readonly thyButton = input<ThyButtonType>();
+    readonly thyButton = input<ThyButtonType | string>();
 
     /**
      * 和`thyButton`参数一样，一般使用`thyButton`，为了减少参数输入, 当通过`thy-button`使用时，只能使用该参数控制类型
      * @default primary
      */
-    readonly thyType = input<ThyButtonType>();
+    readonly thyType = input<ThyButtonType | string>();
 
     /**
      * 加载状态
@@ -165,7 +141,7 @@ export class ThyButton {
         return null;
     });
 
-    private readonly buttonType = computed<ThyButtonType>(() => {
+    private readonly buttonType = computed(() => {
         return this.thyButton() || this.thyType() || 'primary';
     });
 
@@ -192,20 +168,21 @@ export class ThyButton {
         }
     }
 
+    private buildTypeClass(appearance: ThyButtonAppearance, type: string): string {
+        if (appearance === 'fill') {
+            return `btn-${type}`;
+        }
+        return `btn-${appearance}-${type}`;
+    }
+
     private updateClasses() {
         const type = this.type();
         if (!type) {
             return;
         }
 
-        let classNames: string[] = [];
-        if (btnTypeClassesMap[type]) {
-            classNames = [...btnTypeClassesMap[type]];
-        } else {
-            if (type) {
-                classNames.push(`btn-${type}`);
-            }
-        }
+        const appearance = this.thyAppearance() || 'fill';
+        const classNames: string[] = [this.buildTypeClass(appearance, type)];
 
         const size = this.thySize();
         if (size) {

--- a/src/button/doc/zh-cn.md
+++ b/src/button/doc/zh-cn.md
@@ -15,33 +15,53 @@ order: 10
 import { ThyButtonModule } from "ngx-tethys/button";
 ```
 
+## API 模型
+
+按钮由两个正交参数组成：
+
+| 参数 | 含义 | 取值 |
+|------|------|------|
+| `thyAppearance` | 外观（样式） | `fill`（默认）/ `outline` / `link` |
+| `thyButton` | 颜色类型 | `primary`（默认）/ `default` / `info` / `warning` / `danger` / `success` |
+
+生成的 class：
+
+- `fill` → `btn-{type}`（如 `btn-primary`、`btn-default`）
+- `outline` → `btn-outline-{type}`
+- `link` → `btn-link-{type}`
+
+弱危险链接（灰→红）不属于 Button，请继续使用 Link CSS：`class="link-danger-weak"`。`class="link-secondary"` 同样不改动。
+
 ## 按钮种类
 在 Worktile Design 中，有四种按钮:
 
-- 主按钮：用于重要操作，一个操作区域只能有一个主按钮，常用于添加，保存
-- 线框按钮：用于视图，审批状态
-- 按钮链接：用于次要或外链的操作，比如 `取消`
+- 主按钮（fill）：用于重要操作，一个操作区域只能有一个主按钮，常用于添加，保存
+- 线框按钮（outline）：用于视图，审批状态
+- 按钮链接（link）：用于次要或外链的操作，比如 `取消`（`thyButton="default" thyAppearance="link"`）
 - 按钮图标：用于工具栏操作
-
-## 按钮状态
-
-- 主要按钮：主色
-- 信息按钮：用于展示信息
-- 危险按钮：删除/归档等危险操作，一般需要二次确认
-- 禁用：操作不可用的时候
 
 ## 基本使用
 推荐使用指令写法，写在原生 `button` 上。禁用时使用原生 `disabled`。
 ```html
 <button thyButton="primary">Primary</button>
+<button thyButton="default">Default</button>
 <button thyButton="primary" disabled>Primary</button>
 ```
 <example name="thy-button-basic-example"></example>
 
 ## 按钮链接
+```html
+<button thyButton="primary" thyAppearance="link">Primary</button>
+<button thyButton="default" thyAppearance="link">Cancel</button>
+<button thyButton="danger" thyAppearance="link">Danger</button>
+```
 <example name="thy-button-link-example"></example>
 
 ## 线框按钮
+```html
+<button thyButton="default" thyAppearance="outline">Default</button>
+<button thyButton="primary" thyAppearance="outline">Primary</button>
+```
 <example name="thy-button-outline-example"></example>
 
 ## 按钮大小

--- a/src/button/examples/basic/basic.component.html
+++ b/src/button/examples/basic/basic.component.html
@@ -1,5 +1,6 @@
 <thy-space>
   <button *thySpaceItem thyButton="primary">Primary</button>
+  <button *thySpaceItem thyButton="default">Default</button>
   <button *thySpaceItem thyButton="info">Info</button>
   <button *thySpaceItem thyButton="warning">Warning</button>
   <button *thySpaceItem thyButton="danger">Danger</button>
@@ -10,6 +11,7 @@
 
 <thy-space class="mt-2">
   <button *thySpaceItem thyButton="primary" disabled>Primary</button>
+  <button *thySpaceItem thyButton="default" disabled>Default</button>
   <button *thySpaceItem thyButton="info" disabled>Info</button>
   <button *thySpaceItem thyButton="warning" disabled>Warning</button>
   <button *thySpaceItem thyButton="danger" disabled>Danger</button>

--- a/src/button/examples/block/block.component.html
+++ b/src/button/examples/block/block.component.html
@@ -1,2 +1,2 @@
 <button thyButton="primary" thyBlock>Primary</button>
-<button thyButton="outline-default" thyBlock>Outline Default</button>
+<button thyButton="default" thyAppearance="outline" thyBlock>Outline Default</button>

--- a/src/button/examples/icon/icon.component.html
+++ b/src/button/examples/icon/icon.component.html
@@ -8,10 +8,10 @@
 </thy-space>
 
 <thy-space class="mt-2">
-  <button *thySpaceItem thyButton="outline-default"><thy-icon thyIconName="house"></thy-icon></button>
-  <button *thySpaceItem thyButton="outline-default"><thy-icon thyIconName="plus"></thy-icon>New</button>
-  <button *thySpaceItem thyButton="outline-primary">New<thy-icon thyIconName="angle-down"></thy-icon></button>
-  <button *thySpaceItem thyButton="outline-primary">
+  <button *thySpaceItem thyButton="default" thyAppearance="outline"><thy-icon thyIconName="house"></thy-icon></button>
+  <button *thySpaceItem thyButton="default" thyAppearance="outline"><thy-icon thyIconName="plus"></thy-icon>New</button>
+  <button *thySpaceItem thyButton="primary" thyAppearance="outline">New<thy-icon thyIconName="angle-down"></thy-icon></button>
+  <button *thySpaceItem thyButton="primary" thyAppearance="outline">
     <thy-icon thyIconName="plus"></thy-icon>New<thy-icon thyIconName="caret-down"></thy-icon>
   </button>
 </thy-space>

--- a/src/button/examples/link/link.component.html
+++ b/src/button/examples/link/link.component.html
@@ -1,15 +1,22 @@
 <div class="demo-buttons">
-  <button thyButton="link">Default</button>
-  <button thyButton="link-secondary">Secondary</button>
-  <button thyButton="link-danger-weak">Danger Weak</button>
-  <button thyButton="link-danger">Danger</button>
-  <button thyButton="link-success">Success</button>
+  <button thyButton="primary" thyAppearance="link">Primary</button>
+  <button thyButton="default" thyAppearance="link">Default</button>
+  <button thyButton="info" thyAppearance="link">Info</button>
+  <button thyButton="warning" thyAppearance="link">Warning</button>
+  <button thyButton="danger" thyAppearance="link">Danger</button>
+  <button thyButton="success" thyAppearance="link">Success</button>
 </div>
 
 <div class="demo-buttons mt-2">
-  <button thyButton="link" class="disabled">Default</button>
-  <button thyButton="link-secondary" disabled="disabled">Secondary</button>
-  <button thyButton="link-danger-weak" disabled="disabled">Danger Weak</button>
-  <button thyButton="link-danger" disabled="disabled">Danger</button>
-  <button thyButton="link-success" disabled="disabled">Success</button>
+  <button thyButton="primary" thyAppearance="link" disabled>Primary</button>
+  <button thyButton="default" thyAppearance="link" disabled>Default</button>
+  <button thyButton="info" thyAppearance="link" disabled>Info</button>
+  <button thyButton="warning" thyAppearance="link" disabled>Warning</button>
+  <button thyButton="danger" thyAppearance="link" disabled>Danger</button>
+  <button thyButton="success" thyAppearance="link" disabled>Success</button>
+</div>
+
+<div class="demo-buttons mt-4">
+  <div class="mb-2 text-muted">弱危险链接请使用 Link CSS（非 Button）：</div>
+  <a href="javascript:;" class="link-danger-weak">Danger Weak</a>
 </div>

--- a/src/button/examples/outline/outline.component.html
+++ b/src/button/examples/outline/outline.component.html
@@ -1,26 +1,26 @@
 <thy-space>
-  <button *thySpaceItem thyButton="outline-default">Default</button>
-  <button *thySpaceItem thyButton="outline-primary">Primary</button>
-  <button *thySpaceItem thyButton="outline-info">Info</button>
-  <button *thySpaceItem thyButton="outline-warning">Warning</button>
-  <button *thySpaceItem thyButton="outline-danger">Danger</button>
-  <button *thySpaceItem thyButton="outline-success">Success</button>
+  <button *thySpaceItem thyButton="default" thyAppearance="outline">Default</button>
+  <button *thySpaceItem thyButton="primary" thyAppearance="outline">Primary</button>
+  <button *thySpaceItem thyButton="info" thyAppearance="outline">Info</button>
+  <button *thySpaceItem thyButton="warning" thyAppearance="outline">Warning</button>
+  <button *thySpaceItem thyButton="danger" thyAppearance="outline">Danger</button>
+  <button *thySpaceItem thyButton="success" thyAppearance="outline">Success</button>
 </thy-space>
 
 <thy-space class="mt-2">
-  <button *thySpaceItem thyButton="outline-default" class="active">Default</button>
-  <button *thySpaceItem thyButton="outline-primary" class="active">Primary</button>
-  <button *thySpaceItem thyButton="outline-info" class="active">Info</button>
-  <button *thySpaceItem thyButton="outline-warning" class="active">Warning</button>
-  <button *thySpaceItem thyButton="outline-danger" class="active">Danger</button>
-  <button *thySpaceItem thyButton="outline-success" class="active">Success</button>
+  <button *thySpaceItem thyButton="default" thyAppearance="outline" class="active">Default</button>
+  <button *thySpaceItem thyButton="primary" thyAppearance="outline" class="active">Primary</button>
+  <button *thySpaceItem thyButton="info" thyAppearance="outline" class="active">Info</button>
+  <button *thySpaceItem thyButton="warning" thyAppearance="outline" class="active">Warning</button>
+  <button *thySpaceItem thyButton="danger" thyAppearance="outline" class="active">Danger</button>
+  <button *thySpaceItem thyButton="success" thyAppearance="outline" class="active">Success</button>
 </thy-space>
 
 <thy-space class="mt-2">
-  <button *thySpaceItem thyButton="outline-default" disabled>Default</button>
-  <button *thySpaceItem thyButton="outline-primary" disabled>Primary</button>
-  <button *thySpaceItem thyButton="outline-info" disabled>Info</button>
-  <button *thySpaceItem thyButton="outline-warning" disabled>Warning</button>
-  <button *thySpaceItem thyButton="outline-danger" disabled>Danger</button>
-  <button *thySpaceItem thyButton="outline-success" disabled>Success</button>
+  <button *thySpaceItem thyButton="default" thyAppearance="outline" disabled>Default</button>
+  <button *thySpaceItem thyButton="primary" thyAppearance="outline" disabled>Primary</button>
+  <button *thySpaceItem thyButton="info" thyAppearance="outline" disabled>Info</button>
+  <button *thySpaceItem thyButton="warning" thyAppearance="outline" disabled>Warning</button>
+  <button *thySpaceItem thyButton="danger" thyAppearance="outline" disabled>Danger</button>
+  <button *thySpaceItem thyButton="success" thyAppearance="outline" disabled>Success</button>
 </thy-space>

--- a/src/button/examples/pair/pair.component.html
+++ b/src/button/examples/pair/pair.component.html
@@ -1,9 +1,9 @@
 <div class="btn-pair">
   <button thyButton="primary">Save and Next</button>
-  <button thyButton="outline-default">Save</button>
-  <button thyButton="link-secondary">Cancel</button>
+  <button thyButton="default" thyAppearance="outline">Save</button>
+  <button thyButton="default" thyAppearance="link">Cancel</button>
 </div>
 <div class="btn-pair mt-2">
   <button thyButton="primary">Save</button>
-  <button thyButton="link-secondary">Cancel</button>
+  <button thyButton="default" thyAppearance="link">Cancel</button>
 </div>

--- a/src/button/examples/size/size.component.html
+++ b/src/button/examples/size/size.component.html
@@ -7,6 +7,7 @@
 </thy-button-group>
 <thy-space class="mt-4">
   <button *thySpaceItem thyButton="primary" [thySize]="size">Primary</button>
+  <button *thySpaceItem thyButton="default" [thySize]="size">Default</button>
   <button *thySpaceItem thyButton="info" [thySize]="size">Info</button>
   <button *thySpaceItem thyButton="warning" [thySize]="size">Warning</button>
   <button *thySpaceItem thyButton="danger" [thySize]="size">Danger</button>
@@ -14,17 +15,17 @@
   <button *thySpaceItem thyButton="primary" [thySize]="size"><thy-icon thyIconName="house"></thy-icon></button>
 </thy-space>
 <thy-space class="mt-2">
-  <button *thySpaceItem thyButton="outline-primary" [thySize]="size">Primary</button>
-  <button *thySpaceItem thyButton="outline-info" [thySize]="size">Info</button>
-  <button *thySpaceItem thyButton="outline-warning" [thySize]="size">Warning</button>
-  <button *thySpaceItem thyButton="outline-danger" [thySize]="size">Danger</button>
-  <button *thySpaceItem thyButton="outline-success" [thySize]="size">Success</button>
-  <button *thySpaceItem thyButton="outline-primary" [thySize]="size"><thy-icon thyIconName="house"></thy-icon></button>
+  <button *thySpaceItem thyButton="primary" thyAppearance="outline" [thySize]="size">Primary</button>
+  <button *thySpaceItem thyButton="default" thyAppearance="outline" [thySize]="size">Default</button>
+  <button *thySpaceItem thyButton="info" thyAppearance="outline" [thySize]="size">Info</button>
+  <button *thySpaceItem thyButton="warning" thyAppearance="outline" [thySize]="size">Warning</button>
+  <button *thySpaceItem thyButton="danger" thyAppearance="outline" [thySize]="size">Danger</button>
+  <button *thySpaceItem thyButton="success" thyAppearance="outline" [thySize]="size">Success</button>
+  <button *thySpaceItem thyButton="primary" thyAppearance="outline" [thySize]="size"><thy-icon thyIconName="house"></thy-icon></button>
 </thy-space>
 <thy-space class="mt-2">
-  <button *thySpaceItem thyButton="link" [thySize]="size">Default</button>
-  <button *thySpaceItem thyButton="link-secondary" [thySize]="size">Secondary</button>
-  <button *thySpaceItem thyButton="link-danger-weak" [thySize]="size">Danger Weak</button>
-  <button *thySpaceItem thyButton="link-danger" [thySize]="size">Danger</button>
-  <button *thySpaceItem thyButton="link-success" [thySize]="size">Success</button>
+  <button *thySpaceItem thyButton="primary" thyAppearance="link" [thySize]="size">Primary</button>
+  <button *thySpaceItem thyButton="default" thyAppearance="link" [thySize]="size">Default</button>
+  <button *thySpaceItem thyButton="danger" thyAppearance="link" [thySize]="size">Danger</button>
+  <button *thySpaceItem thyButton="success" thyAppearance="link" [thySize]="size">Success</button>
 </thy-space>

--- a/src/button/styles/button.scss
+++ b/src/button/styles/button.scss
@@ -97,6 +97,24 @@ fieldset:disabled a.btn {
     }
 }
 
+// fill default：文字 #666（gray-700），背景 #eee（gray-200），hover 浅阴影
+.btn-default {
+    @include mixin.button-variant(
+        variables.$gray-700,
+        variables.$gray-700,
+        variables.$gray-200,
+        variables.$gray-200,
+        variables.$gray-200,
+        variables.$gray-200,
+        variables.$gray-200,
+        variables.$gray-200
+    );
+
+    &:hover {
+        @include shadow.box-shadow(0px 2px 5px 1px #fafafa);
+    }
+}
+
 @each $color, $value in functions-variables.$theme-colors {
     .btn-outline-#{$color} {
         @include mixin.button-outline-variant($value, $value, variables.$white, $value, null, $value, null);
@@ -186,21 +204,18 @@ fieldset:disabled a.btn {
 // Link buttons
 //
 // Make a button look and behave like a link
-.btn-link {
+@mixin btn-link-base {
     font-weight: bootstrap-variables.$font-weight-normal;
-    color: variables.$link-color;
     background-color: transparent;
+    border-color: transparent;
 
     @include hover.hover {
-        color: variables.$link-hover-color;
-        text-decoration: variables.$link-hover-decoration;
         background-color: transparent;
         border-color: transparent;
     }
 
     &:focus,
     &.focus {
-        text-decoration: variables.$link-hover-decoration;
         border-color: transparent;
         box-shadow: variables.$box-shadow-none;
     }
@@ -208,54 +223,89 @@ fieldset:disabled a.btn {
     &.disabled,
     &:disabled {
         background-color: transparent;
+        border-color: transparent;
+        color: variables.$btn-link-disabled-color;
 
         @include hover.hover-focus {
             color: variables.$btn-link-disabled-color;
             text-decoration: none;
         }
     }
+}
 
-    &:disabled,
-    &.disabled {
-        color: variables.$btn-link-disabled-color;
-        border-color: transparent;
+// 主色链接（兼容旧 .btn-link）
+.btn-link,
+.btn-link-primary {
+    @include btn-link-base;
+    color: variables.$link-color;
+
+    @include hover.hover {
+        color: variables.$link-hover-color;
+        text-decoration: variables.$link-hover-decoration;
     }
 
-    // No need for an active state here
+    &:focus,
+    &.focus {
+        text-decoration: variables.$link-hover-decoration;
+    }
 }
 
-// 去除按钮图标和按钮链接的最小宽度
-.btn.btn-icon,
-.btn.btn-link {
-    min-width: 0px;
+// 中性链接：灰字 → 主色（原 link-secondary / btn-link-primary-weak）
+.btn-link-default {
+    @include btn-link-base;
+    @include mixin.btn-link-variant(variables.$gray-500, variables.$primary, none);
 }
 
+.btn-link-info {
+    @include btn-link-base;
+    @include mixin.btn-link-variant(variables.$info, variables.$primary, none);
+}
+
+.btn-link-warning {
+    @include btn-link-base;
+    @include mixin.btn-link-variant(variables.$warning, variables.$warning, none);
+}
+
+.btn-link-danger {
+    @include btn-link-base;
+    @include mixin.btn-link-variant(variables.$danger, variables.$danger, underline);
+}
+
+.btn-link-success {
+    @include btn-link-base;
+    @include mixin.btn-link-variant(variables.$success, variables.$success, underline);
+}
+
+// 兼容旧双 class 写法（CSS 直接使用时）
 .btn-link.btn-link-info {
     @include mixin.btn-link-variant(variables.$info, variables.$primary, none);
 }
 
-// 兼容之前的样式
 .btn-link.btn-link-default {
     @include mixin.btn-link-variant(variables.$btn-link-color-default, variables.$primary, none);
 }
 
-// 默认显示灰色，鼠标移上去显示主色
 .btn-link.btn-link-primary-weak {
     @include mixin.btn-link-variant(variables.$gray-500, variables.$primary, none);
 }
 
-// 默认显示灰色，鼠标移上去显示红色
 .btn-link.btn-link-danger-weak {
     @include mixin.btn-link-variant(variables.$gray-500, variables.$danger, none);
 }
 
-// 默认显示灰色，鼠标移上去显示红色
 .btn-link.btn-link-danger {
     @include mixin.btn-link-variant(variables.$danger, variables.$danger, underline);
 }
 
 .btn-link.btn-link-success {
     @include mixin.btn-link-variant(variables.$success, variables.$success, underline);
+}
+
+// 去除按钮图标和按钮链接的最小宽度
+.btn.btn-icon,
+.btn.btn-link,
+.btn[class^='btn-link-'] {
+    min-width: 0px;
 }
 
 //
@@ -284,11 +334,13 @@ input[type='button'] {
     .btn + .btn {
         margin-left: variables.$btn-pair-child-margin-left;
 
-        &.btn-link {
+        &.btn-link,
+        &[class^='btn-link-'] {
             margin-left: variables.$btn-pair-child-link-margin-left;
         }
     }
-    .btn-link + .btn {
+    .btn-link + .btn,
+    [class^='btn-link-'] + .btn {
         margin-left: variables.$btn-pair-child-link-margin-left;
     }
 }

--- a/src/button/styles/mixin.scss
+++ b/src/button/styles/mixin.scss
@@ -80,7 +80,8 @@
         }
     }
 
-    &.btn-link {
+    &.btn-link,
+    &[class^='btn-link-'] {
         padding: $padding-y 10px;
     }
 }

--- a/src/button/styles/theme.scss
+++ b/src/button/styles/theme.scss
@@ -3,6 +3,14 @@
     @include button-hover-box-shadow($primary);
 }
 
+.btn-default {
+    @include button-variant($gray-700, $gray-700, $gray-200, $gray-200, $gray-200, $gray-200, $gray-200, $gray-200);
+
+    &:hover {
+        box-shadow: 0px 2px 5px 1px #fafafa;
+    }
+}
+
 .btn-outline-primary {
     @include button-outline-variant($primary, $primary, $white, $primary, null, $primary, null);
 }
@@ -11,7 +19,8 @@
     @include button-outline-variant($gray-600, $gray-300, $primary, null, $primary, null, $primary);
 }
 
-.btn-link {
+.btn-link,
+.btn-link-primary {
     color: $link-color;
     @include hover {
         color: $link-hover-color;
@@ -25,26 +34,43 @@
     }
 }
 
+.btn-link-default {
+    @include btn-link-variant($gray-500, $primary, none);
+}
+
+.btn-link-info {
+    @include btn-link-variant($info, $primary, none);
+}
+
+.btn-link-warning {
+    @include btn-link-variant($warning, $warning, none);
+}
+
+.btn-link-danger {
+    @include btn-link-variant($danger, $danger, underline);
+}
+
+.btn-link-success {
+    @include btn-link-variant($success, $success, underline);
+}
+
+// 兼容旧双 class 写法
 .btn-link.btn-link-info {
     @include btn-link-variant($info, $primary, none);
 }
 
-// 兼容之前的样式
 .btn-link.btn-link-default {
     @include btn-link-variant($btn-link-color-default, $primary, none);
 }
 
-// 默认显示灰色，鼠标移上去显示主色
 .btn-link.btn-link-primary-weak {
     @include btn-link-variant($gray-500, $primary, none);
 }
 
-// 默认显示灰色，鼠标移上去显示红色
 .btn-link.btn-link-danger-weak {
     @include btn-link-variant($gray-500, $danger, none);
 }
 
-// 默认显示灰色，鼠标移上去显示红色
 .btn-link.btn-link-danger {
     @include btn-link-variant($danger, $danger, underline);
 }

--- a/src/button/test/button.spec.ts
+++ b/src/button/test/button.spec.ts
@@ -14,22 +14,23 @@ function assertButtonIcon(iconElement: Element, icon: string) {
 @Component({
     selector: 'thy-test-button-basic',
     template: `
-        <button [thyButton]="type" [thyLoading]="loading" [thyLoadingText]="loadingText" [thySize]="size">Basic Button</button>
-        <thy-button id="btn-with-icon" [thyIcon]="icon" [thyType]="type">Icon Button</thy-button>
-        <thy-button id="btn-only-icon" [thyIcon]="icon" [thyType]="type"></thy-button>
+        <button [thyButton]="type" [thyAppearance]="appearance" [thyLoading]="loading" [thyLoadingText]="loadingText" [thySize]="size">Basic Button</button>
+        <thy-button id="btn-with-icon" [thyIcon]="icon" [thyType]="type" [thyAppearance]="appearance">Icon Button</thy-button>
+        <thy-button id="btn-only-icon" [thyIcon]="icon" [thyType]="type" [thyAppearance]="appearance"></thy-button>
         <thy-button id="btn-default">Default Button</thy-button>
-        <thy-button id="btn-thy-disabled" [thyType]="type" [thyDisabled]="disabled" (click)="onClick()">Thy Disabled</thy-button>
-        <button id="btn-native-disabled" [thyButton]="type" [disabled]="disabled" (click)="onClick()">Native Disabled</button>
+        <thy-button id="btn-thy-disabled" [thyType]="type" [thyAppearance]="appearance" [thyDisabled]="disabled" (click)="onClick()">Thy Disabled</thy-button>
+        <button id="btn-native-disabled" [thyButton]="type" [thyAppearance]="appearance" [disabled]="disabled" (click)="onClick()">Native Disabled</button>
         <button id="btn-attr-disabled" thyButton="primary" disabled (click)="onClick()">Attr Disabled</button>
         <button id="btn-attr-disabled-true" thyButton="primary" disabled="true" (click)="onClick()">Attr Disabled True</button>
-        <thy-button id="btn-thy-loading" [thyType]="type" [thyLoading]="loading" (click)="onClick()">Loading Button</thy-button>
-        <button id="btn-native-loading" [thyButton]="type" [thyLoading]="loading" (click)="onClick()">Native Loading</button>
+        <thy-button id="btn-thy-loading" [thyType]="type" [thyAppearance]="appearance" [thyLoading]="loading" (click)="onClick()">Loading Button</thy-button>
+        <button id="btn-native-loading" [thyButton]="type" [thyAppearance]="appearance" [thyLoading]="loading" (click)="onClick()">Native Loading</button>
         <a id="btn-anchor" thyButton="primary" [thyDisabled]="disabled" (click)="onClick()">Anchor Button</a>
     `,
     imports: [ThyButtonModule]
 })
 class ThyTestButtonBasicComponent {
     type = `primary`;
+    appearance: 'fill' | 'outline' | 'link' = 'fill';
     size = '';
     loading = false;
     loadingText = 'Loading...';
@@ -89,41 +90,56 @@ describe('ThyButton', () => {
         });
 
         it('should set type success', () => {
-            [
-                'primary',
-                'info',
-                'warning',
-                'danger',
-                'warning',
-                'outline-warning',
-                'success',
-                'outline-primary',
-                'outline-default',
-                'outline-info',
-                'outline-success',
-                'outline-danger',
-                'link',
-                'link-info',
-                'link-warning',
-                'link-danger',
-                'link-success',
-                'link-danger-weak'
-            ].forEach(type => {
+            ['primary', 'default', 'info', 'warning', 'danger', 'success'].forEach(type => {
                 basicTestComponent.type = type;
+                basicTestComponent.appearance = 'fill';
                 fixture.detectChanges();
                 const btnElement: HTMLElement = buttonComponent.nativeElement;
                 expect(btnElement.classList.contains(`btn-${type}`)).toBeTruthy();
             });
         });
 
-        it('should set type with square success', () => {
-            ['primary-square', 'info-square', 'warning-square', 'danger-square', 'success-square'].forEach(type => {
+        it('should set appearance and type class success', () => {
+            const cases: Array<{ appearance: 'fill' | 'outline' | 'link'; type: string; className: string }> = [
+                { appearance: 'fill', type: 'primary', className: 'btn-primary' },
+                { appearance: 'fill', type: 'default', className: 'btn-default' },
+                { appearance: 'outline', type: 'primary', className: 'btn-outline-primary' },
+                { appearance: 'outline', type: 'default', className: 'btn-outline-default' },
+                { appearance: 'outline', type: 'danger', className: 'btn-outline-danger' },
+                { appearance: 'link', type: 'primary', className: 'btn-link-primary' },
+                { appearance: 'link', type: 'default', className: 'btn-link-default' },
+                { appearance: 'link', type: 'danger', className: 'btn-link-danger' },
+                { appearance: 'link', type: 'success', className: 'btn-link-success' },
+                { appearance: 'link', type: 'info', className: 'btn-link-info' },
+                { appearance: 'link', type: 'warning', className: 'btn-link-warning' }
+            ];
+            cases.forEach(({ appearance, type, className }) => {
+                basicTestComponent.appearance = appearance;
                 basicTestComponent.type = type;
+                fixture.detectChanges();
+                const btnElement: HTMLElement = buttonComponent.nativeElement;
+                expect(btnElement.classList.contains(className)).toBeTruthy();
+            });
+        });
+
+        it('should set type with square success', () => {
+            ['primary-square', 'info-square', 'warning-square', 'danger-square', 'success-square', 'default-square'].forEach(type => {
+                basicTestComponent.type = type;
+                basicTestComponent.appearance = 'fill';
                 fixture.detectChanges();
                 const btnElement: HTMLElement = buttonComponent.nativeElement;
                 expect(btnElement.classList.contains(`btn-${type.replace('-square', '')}`)).toBeTruthy();
                 expect(btnElement.classList.contains(`btn-square`)).toBeTruthy();
             });
+        });
+
+        it('should set outline square success', () => {
+            basicTestComponent.type = 'primary-square';
+            basicTestComponent.appearance = 'outline';
+            fixture.detectChanges();
+            const btnElement: HTMLElement = buttonComponent.nativeElement;
+            expect(btnElement.classList.contains('btn-outline-primary')).toBeTruthy();
+            expect(btnElement.classList.contains('btn-square')).toBeTruthy();
         });
 
         it('should set loading success', () => {

--- a/src/calendar/calendar-header.component.html
+++ b/src/calendar/calendar-header.component.html
@@ -7,7 +7,7 @@
     [thyPickerFormat]="pickerFormat"
     (ngModelChange)="onChangeRange($event)"></thy-date-range>
   @if (isCurrent) {
-    <button thyButton="outline-default-square" thySize="md" (click)="backToday()">{{ locale().today }}</button>
+    <button thyButton="default-square" thyAppearance="outline" thySize="md" (click)="backToday()">{{ locale().today }}</button>
   }
 </div>
 <div class="thy-calendar-full-header-right">

--- a/src/date-picker/lib/calendar/calendar-footer.component.html
+++ b/src/date-picker/lib/calendar/calendar-footer.component.html
@@ -22,7 +22,7 @@
           {{ locale().ok }}
         </button>
       }
-      <button class="time-picker-clear-btn" thyButton="link-secondary" thySize="sm" (click)="onClear()">{{ locale().clear }}</button>
+      <button class="time-picker-clear-btn" thyButton="default" thyAppearance="link" thySize="sm" (click)="onClear()">{{ locale().clear }}</button>
     </div>
   </div>
 }

--- a/src/date-picker/lib/date-carousel/date-carousel.component.html
+++ b/src/date-picker/lib/date-carousel/date-carousel.component.html
@@ -17,7 +17,7 @@
   <div class="carousel-item carousel-item-{{ type }}">
     <p class="carousel-item-title">{{ title }}</p>
     <div class="carousel-item-content">
-      <button thyButton="outline-default" thySize="sm" class="right-space" (click)="prevClick(type)">
+      <button thyButton="default" thyAppearance="outline" thySize="sm" class="right-space" (click)="prevClick(type)">
         <thy-icon thyIconName="angle-left"></thy-icon>
       </button>
       @for (item of selectableData; track $index) {
@@ -41,7 +41,7 @@
           }
         </div>
       }
-      <button thyButton="outline-default" thySize="sm" (click)="nextClick(type)">
+      <button thyButton="default" thyAppearance="outline" thySize="sm" (click)="nextClick(type)">
         <thy-icon thyIconName="angle-right"></thy-icon>
       </button>
     </div>

--- a/src/dialog/confirm/confirm.component.html
+++ b/src/dialog/confirm/confirm.component.html
@@ -7,7 +7,7 @@
     <thy-form-group-footer [thyAlign]="footerAlign">
       <div class="thy-confirm-footer" [ngClass]="'thy-confirm-footer-' + footerAlign">
         <button [thyButton]="okType" (click)="confirm()" [thyLoading]="loading" [thyLoadingText]="okLoadingText">{{ okText }}</button>
-        <button thyButton="link-secondary" (click)="close()" class="thy-confirm-cancel">{{ cancelText }}</button>
+        <button thyButton="default" thyAppearance="link" (click)="close()" class="thy-confirm-cancel">{{ cancelText }}</button>
       </div>
     </thy-form-group-footer>
   </form>

--- a/src/dialog/doc/zh-cn.md
+++ b/src/dialog/doc/zh-cn.md
@@ -153,7 +153,7 @@ class YourDialogComponent {
 </thy-dialog-body>
 <thy-dialog-footer>
     <button thyButton="primary" (click)="thyDialog.close()">确定</button>
-    <button thyButton="link-secondary" (click)="thyDialog.close()">关闭</button>
+    <button thyButton="default" thyAppearance="link" (click)="thyDialog.close()">关闭</button>
     <ng-template #description>
       <span class="text-desc">当前打开的是一个对话框</span>
     </ng-template>

--- a/src/dialog/examples/basic/basic.component.html
+++ b/src/dialog/examples/basic/basic.component.html
@@ -27,7 +27,7 @@
   </thy-dialog-body>
   <thy-dialog-footer [thyDivided]="layoutConfig.divider" [thyAlign]="layoutConfig.align">
     <button thyButton="primary" (click)="thyDialog.close()">确定</button>
-    <button thyButton="link-secondary" (click)="thyDialog.close()">关闭</button>
+    <button thyButton="default" thyAppearance="link" (click)="thyDialog.close()">关闭</button>
     <ng-template #description>
       <span class="text-desc">描述</span>
     </ng-template>

--- a/src/dialog/examples/basic/dialog-content.component.html
+++ b/src/dialog/examples/basic/dialog-content.component.html
@@ -27,5 +27,5 @@
 </thy-dialog-body>
 <thy-dialog-footer>
   <button thyButton="primary" (click)="thyDialog.close()">确定</button>
-  <button thyButton="link-secondary" (click)="thyDialog.close()">关闭</button>
+  <button thyButton="default" thyAppearance="link" (click)="thyDialog.close()">关闭</button>
 </thy-dialog-footer>

--- a/src/dialog/examples/basic/plain-dialog-content.component.html
+++ b/src/dialog/examples/basic/plain-dialog-content.component.html
@@ -2,5 +2,5 @@
 <p>在 <code>thyDialog.open</code> 的配置里传入 <code>title</code>、<code>icon</code> 后，由对话框容器渲染默认头部。</p>
 <div class="btn-pair">
   <button thyButton="primary" (click)="dialogRef.close(true)">确定</button>
-  <button thyButton="link-secondary" (click)="dialogRef.close()">关闭</button>
+  <button thyButton="default" thyAppearance="link" (click)="dialogRef.close()">关闭</button>
 </div>

--- a/src/dialog/examples/layout/dialog-layout.component.html
+++ b/src/dialog/examples/layout/dialog-layout.component.html
@@ -20,5 +20,5 @@
 </thy-dialog-body>
 <thy-dialog-footer [thyAlign]="layoutConfig().footerAlign" [thyDivided]="layoutConfig().footerDivided">
   <button thyButton="primary" (click)="ok()">确定</button>
-  <button thyButton="link-secondary" (click)="close()">取消</button>
+  <button thyButton="default" thyAppearance="link" (click)="close()">取消</button>
 </thy-dialog-footer>

--- a/src/dialog/examples/projectable-nodes/dialog-content.component.html
+++ b/src/dialog/examples/projectable-nodes/dialog-content.component.html
@@ -4,5 +4,5 @@
 </thy-dialog-body>
 <thy-dialog-footer>
   <button thyButton="primary" (click)="thyDialog.close()">确定</button>
-  <button thyButton="link-secondary" (click)="thyDialog.close()">关闭</button>
+  <button thyButton="default" thyAppearance="link" (click)="thyDialog.close()">关闭</button>
 </thy-dialog-footer>

--- a/src/dialog/examples/sidebar/dialog-sidebar.component.html
+++ b/src/dialog/examples/sidebar/dialog-sidebar.component.html
@@ -21,7 +21,7 @@
       <div [hidden]="currentConfig.type !== 'meet'">补充蛋白质！</div>
     </thy-dialog-body>
     <thy-dialog-footer thyAlign="right">
-      <button thyButton="link-secondary" (click)="close()">取消</button>
+      <button thyButton="default" thyAppearance="link" (click)="close()">取消</button>
       <button thyButton="primary" (click)="ok()">确定</button>
     </thy-dialog-footer>
   </thy-layout>

--- a/src/dialog/test/dialog-test-components.ts
+++ b/src/dialog/test/dialog-test-components.ts
@@ -36,7 +36,7 @@ export class DialogSimpleContentTestComponent {
         </thy-dialog-body>
         <thy-dialog-footer thyDivided="true">
             <button thyButton="primary" (click)="ok()">确定</button>
-            <button thyButton="link-secondary" (click)="close()">取消</button>
+            <button thyButton="default" thyAppearance="link" (click)="close()">取消</button>
         </thy-dialog-footer>
     `,
     imports: [ThyDialogModule, ThyButtonModule]

--- a/src/form/doc/zh-cn.md
+++ b/src/form/doc/zh-cn.md
@@ -50,7 +50,7 @@ import { ThyFormModule } from "ngx-tethys/form";
     <button [thyButton]="'primary'" [thyLoading]="saving" thyLoadingText="登录中" (thyFormSubmit)="login(demoForm)">
       登录
     </button>
-    <button [thyButton]="'link-secondary'" (click)="cancel()">取消</button>
+    <button [thyButton]="'default'" thyAppearance="link" (click)="cancel()">取消</button>
   </thy-form-group-footer>
 </form>
 ```

--- a/src/form/examples/basic/basic.component.html
+++ b/src/form/examples/basic/basic.component.html
@@ -7,6 +7,6 @@
   </thy-form-group>
   <thy-form-group-footer>
     <button [thyButton]="'primary'" [thyLoading]="saving()" thyLoadingText="Logining" (thyFormSubmit)="login()">Login</button>
-    <button [thyButton]="'link-secondary'" (click)="cancel()">Cancel</button>
+    <button [thyButton]="'default'" thyAppearance="link" (click)="cancel()">Cancel</button>
   </thy-form-group-footer>
 </form>

--- a/src/form/examples/dialog/dialog.component.html
+++ b/src/form/examples/dialog/dialog.component.html
@@ -16,7 +16,7 @@
         </thy-form-group>
         <thy-form-group-footer>
           <button thyButton="primary" [thyLoading]="saving" (thyFormSubmit)="submit()">Submit</button>
-          <button thyButton="link-secondary" (click)="close()">Cancel</button>
+          <button thyButton="default" thyAppearance="link" (click)="close()">Cancel</button>
         </thy-form-group-footer>
       </form>
     </thy-dialog-body>

--- a/src/form/examples/full/full.component.html
+++ b/src/form/examples/full/full.component.html
@@ -109,6 +109,6 @@
   }
   <thy-form-group-footer>
     <button [thyButton]="'primary'" (thyFormSubmit)="save(demoForm)">Save</button>
-    <button [thyButton]="'link-secondary'">Cancel</button>
+    <button [thyButton]="'default'" thyAppearance="link">Cancel</button>
   </thy-form-group-footer>
 </form>

--- a/src/form/examples/layout/layout.component.html
+++ b/src/form/examples/layout/layout.component.html
@@ -19,7 +19,7 @@
     </thy-form-group>
     <thy-form-group-footer>
       <button [thyButton]="'primary'" [thyLoading]="saving()" thyLoadingText="Logining" (thyFormSubmit)="login()">Login</button>
-      <button [thyButton]="'link-secondary'">Cancel</button>
+      <button [thyButton]="'default'" thyAppearance="link">Cancel</button>
     </thy-form-group-footer>
   </form>
 }

--- a/src/form/examples/reactive/reactive.component.html
+++ b/src/form/examples/reactive/reactive.component.html
@@ -137,7 +137,7 @@
     }
     <thy-form-group-footer>
       <button [thyButton]="'primary'" (thyFormSubmit)="save()">Save</button>
-      <button [thyButton]="'link-secondary'">Cancel</button>
+      <button [thyButton]="'default'" thyAppearance="link">Cancel</button>
     </thy-form-group-footer>
   </form>
 }

--- a/src/form/examples/validate/validate.component.html
+++ b/src/form/examples/validate/validate.component.html
@@ -15,6 +15,6 @@
       Add custom error
     </button>
     <button [thyButton]="'primary'" (click)="demoForm.validator.addError('This is form error')">Add form error</button>
-    <button [thyButton]="'link-secondary'" (click)="reset(demoForm)">Reset</button>
+    <button [thyButton]="'default'" thyAppearance="link" (click)="reset(demoForm)">Reset</button>
   </thy-form-group-footer>
 </form>

--- a/src/form/test/form-directive.spec.ts
+++ b/src/form/test/form-directive.spec.ts
@@ -135,7 +135,7 @@ export class TestFormFullComponent {
                 </thy-form-group>
                 <thy-form-group-footer>
                     <button [thyButton]="'primary'" (thyFormSubmit)="submit()"></button>
-                    <button [thyButton]="'link-secondary'">Cancel</button>
+                    <button [thyButton]="'default'" thyAppearance="link">Cancel</button>
                 </thy-form-group-footer>
             </form>
         }

--- a/src/input/examples/input-count/input-count.component.html
+++ b/src/input/examples/input-count/input-count.component.html
@@ -48,6 +48,6 @@
   </thy-form-group>
   <thy-form-group-footer>
     <button [thyButton]="'primary'" [thyLoading]="saving()" thyLoadingText="Logining" (thyFormSubmit)="login()">Login</button>
-    <button [thyButton]="'link-secondary'" (click)="cancel()">Cancel</button>
+    <button [thyButton]="'default'" thyAppearance="link" (click)="cancel()">Cancel</button>
   </thy-form-group-footer>
 </form>

--- a/src/result/examples/custom/custom.component.html
+++ b/src/result/examples/custom/custom.component.html
@@ -5,7 +5,7 @@
   <ng-template #thyTitle> Submission Failed </ng-template>
   <ng-template #thySubtitle> Please check your information before resubmitting. </ng-template>
   <ng-template #thyExtra>
-    <button thyButton="outline-primary-square">close</button>
+    <button thyButton="primary-square" thyAppearance="outline">close</button>
     <button thyButton="primary-square">view more</button>
   </ng-template>
 </thy-result>

--- a/src/result/test/result.spec.ts
+++ b/src/result/test/result.spec.ts
@@ -60,7 +60,7 @@ describe('ThyResult', () => {
             </ng-template>
             <ng-template #thyExtra>
                 <button thyButton="primary-square">关闭</button>
-                <button thyButton="outline-primary-square">查看详情</button>
+                <button thyButton="primary-square" thyAppearance="outline">查看详情</button>
             </ng-template>
             <ng-template #thyIcon>
                 <div class="custom-icon"></div>

--- a/src/space/examples/basic/basic.component.html
+++ b/src/space/examples/basic/basic.component.html
@@ -2,7 +2,7 @@
   <button *thySpaceItem thyButton="primary">Button</button>
   <button *thySpaceItem thyButton="info">Button</button>
   <button *thySpaceItem thyButton="success">Button</button>
-  <button *thySpaceItem thyButton="outline-default">Button</button>
-  <button *thySpaceItem thyButton="outline-primary">Button</button>
-  <a href="javascript:;" *thySpaceItem thyButton="link">Link</a>
+  <button *thySpaceItem thyButton="default" thyAppearance="outline">Button</button>
+  <button *thySpaceItem thyButton="primary" thyAppearance="outline">Button</button>
+  <a href="javascript:;" *thySpaceItem thyButton="primary" thyAppearance="link">Link</a>
 </thy-space>

--- a/src/space/examples/size/size.component.html
+++ b/src/space/examples/size/size.component.html
@@ -10,7 +10,7 @@
   <button *thySpaceItem thyButton="primary">Button</button>
   <button *thySpaceItem thyButton="info">Button</button>
   <button *thySpaceItem thyButton="success">Button</button>
-  <button *thySpaceItem thyButton="outline-default">Button</button>
-  <button *thySpaceItem thyButton="outline-primary">Button</button>
-  <a href="javascript:;" *thySpaceItem thyButton="link">Link</a>
+  <button *thySpaceItem thyButton="default" thyAppearance="outline">Button</button>
+  <button *thySpaceItem thyButton="primary" thyAppearance="outline">Button</button>
+  <a href="javascript:;" *thySpaceItem thyButton="primary" thyAppearance="link">Link</a>
 </thy-space>

--- a/src/stepper/examples/basic/basic.component.html
+++ b/src/stepper/examples/basic/basic.component.html
@@ -12,13 +12,13 @@
           <div class="demo-stepper-body">
             <p class="mb-3">This is a description for second step.</p>
             <button thyButton="primary" thyStepperNext>下一步</button>
-            <a thyButton="link-secondary" thyStepperPrevious>上一步</a>
+            <a thyButton="default" thyAppearance="link" thyStepperPrevious>上一步</a>
           </div>
         </thy-step>
         <thy-step label="第三步">
           <div class="demo-stepper-body">
             <p class="mb-3">This is a description for third step.</p>
-            <a thyButton="link-secondary" thyStepperPrevious>上一步</a>
+            <a thyButton="default" thyAppearance="link" thyStepperPrevious>上一步</a>
           </div>
         </thy-step>
       </thy-stepper>

--- a/src/stepper/examples/icon/icon.component.html
+++ b/src/stepper/examples/icon/icon.component.html
@@ -10,12 +10,12 @@
         <thy-step label="验证" thyIcon="tickets">
           <div class="demo-stepper-body">
             <button thyButton="primary" thyStepperNext>下一步</button>
-            <a thyButton="link-secondary" thyStepperPrevious>上一步</a>
+            <a thyButton="default" thyAppearance="link" thyStepperPrevious>上一步</a>
           </div>
         </thy-step>
         <thy-step label="完成">
           <div class="demo-stepper-body">
-            <a thyButton="link-secondary" thyStepperPrevious>上一步</a>
+            <a thyButton="default" thyAppearance="link" thyStepperPrevious>上一步</a>
           </div>
         </thy-step>
       </thy-stepper>

--- a/src/stepper/test/stepper.spec.ts
+++ b/src/stepper/test/stepper.spec.ts
@@ -18,13 +18,13 @@ import { provideAnimations } from '@angular/platform-browser/animations';
             <thy-step label="第二步" #step2>
                 <div class="demo-stepper-body second-step">
                     <button thyButton="primary">下一步</button>
-                    <a thyButton="link-secondary">上一步</a>
+                    <a thyButton="default" thyAppearance="link">上一步</a>
                     <p>This is second description.</p>
                 </div>
             </thy-step>
             <thy-step label="第三步">
                 <div class="demo-stepper-body third-step">
-                    <a thyButton="link-secondary">上一步</a>
+                    <a thyButton="default" thyAppearance="link">上一步</a>
                     <p>This is third description.</p>
                 </div>
             </thy-step>

--- a/src/tabs/examples/dynamic/dynamic.component.html
+++ b/src/tabs/examples/dynamic/dynamic.component.html
@@ -1,4 +1,4 @@
-<button class="mb-2" thyButton="outline-default" (click)="add()">添加</button>
+<button class="mb-2" thyButton="default" thyAppearance="outline" (click)="add()">添加</button>
 
 <thy-tabs [thyActiveTab]="activeTab">
   @for (tab of tabs; track trackByFn($index, tab.id); let i = $index) {

--- a/src/tabs/examples/extra/extra.component.html
+++ b/src/tabs/examples/extra/extra.component.html
@@ -6,12 +6,12 @@
 
 <ng-template #extraTemplate>
   @if (activeTab === 'tab1') {
-    <button thyButton="outline-default" thySize="md">Tab1 Extra Action</button>
+    <button thyButton="default" thyAppearance="outline" thySize="md">Tab1 Extra Action</button>
   }
   @if (activeTab === 'tab2') {
-    <button thyButton="outline-default" thySize="md">Tab2 Extra Action</button>
+    <button thyButton="default" thyAppearance="outline" thySize="md">Tab2 Extra Action</button>
   }
   @if (activeTab === 'tab3') {
-    <button thyButton="outline-default" thySize="md">Tab3 Extra Action</button>
+    <button thyButton="default" thyAppearance="outline" thySize="md">Tab3 Extra Action</button>
   }
 </ng-template>

--- a/src/tabs/test/tabs.spec.ts
+++ b/src/tabs/test/tabs.spec.ts
@@ -76,7 +76,7 @@ class TestTabsCustomTitleComponent {}
         </thy-tabs>
 
         <ng-template #extraTemplate>
-            <button thyButton="outline-default" thySize="md">Extra Action</button>
+            <button thyButton="default" thyAppearance="outline" thySize="md">Extra Action</button>
         </ng-template>
     `,
     imports: [ThyTabsModule]
@@ -117,7 +117,7 @@ class TestTabsActiveComponent {
 @Component({
     selector: 'test-tabs-dynamic-add',
     template: `
-        <button class="mb-2" thyButton="outline-default" (click)="addTab()">添加</button>
+        <button class="mb-2" thyButton="default" thyAppearance="outline" (click)="addTab()">添加</button>
 
         <thy-tabs [thyActiveTab]="activeTab" [thyAnimated]="thyAnimated">
             @for (tab of tabs; track trackByFn(i, tab); let i = $index) {

--- a/src/tooltip/examples/position/position.component.html
+++ b/src/tooltip/examples/position/position.component.html
@@ -1,35 +1,35 @@
 <div style="margin-left: 60px">
   <thy-space class="mt-4">
-    <button thyButton="outline-primary" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="topLeft">TopL</button>
-    <button thyButton="outline-primary" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="top">Top</button>
-    <button thyButton="outline-primary" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="topRight">TopR</button>
+    <button thyButton="primary" thyAppearance="outline" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="topLeft">TopL</button>
+    <button thyButton="primary" thyAppearance="outline" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="top">Top</button>
+    <button thyButton="primary" thyAppearance="outline" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="topRight">TopR</button>
   </thy-space>
 </div>
 <div style="float: left; width: 60px">
   <thy-space class="mt-4">
-    <button thyButton="outline-primary" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="leftTop">LeftT</button>
-    <button thyButton="outline-primary" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="left">Left</button>
-    <button thyButton="outline-primary" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="leftBottom">
+    <button thyButton="primary" thyAppearance="outline" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="leftTop">LeftT</button>
+    <button thyButton="primary" thyAppearance="outline" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="left">Left</button>
+    <button thyButton="primary" thyAppearance="outline" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="leftBottom">
       LeftB
     </button>
   </thy-space>
 </div>
 <div style="margin-left: 360px; width: 60px">
   <thy-space class="mt-4">
-    <button thyButton="outline-primary" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="rightTop">RightT</button>
-    <button thyButton="outline-primary" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="right">Right</button>
-    <button thyButton="outline-primary" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="rightBottom">
+    <button thyButton="primary" thyAppearance="outline" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="rightTop">RightT</button>
+    <button thyButton="primary" thyAppearance="outline" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="right">Right</button>
+    <button thyButton="primary" thyAppearance="outline" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="rightBottom">
       RightB
     </button>
   </thy-space>
 </div>
 <div style="margin-left: 60px; clear: both">
   <thy-space class="mt-4">
-    <button thyButton="outline-primary" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="bottomLeft">
+    <button thyButton="primary" thyAppearance="outline" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="bottomLeft">
       BottomL
     </button>
-    <button thyButton="outline-primary" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="bottom">Bottom</button>
-    <button thyButton="outline-primary" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="bottomRight">
+    <button thyButton="primary" thyAppearance="outline" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="bottom">Bottom</button>
+    <button thyButton="primary" thyAppearance="outline" *thySpaceItem thyTooltip="Hello, welcome to Pingcode" thyTooltipPlacement="bottomRight">
       BottomR
     </button>
   </thy-space>


### PR DESCRIPTION
## Summary
- Add `thyAppearance` (`fill` / `outline` / `link`); `thyButton` is color-only: `primary` | `default` | `info` | `warning` | `danger` | `success`
- Delete `btnTypeClassesMap`; class formula: fill → `btn-{type}`, outline/link → `btn-{appearance}-{type}`
- Add fill `default` styles (text gray-700, bg gray-200, hover shadow); migrate library examples/usages; Schematics deferred to a follow-up

## Test plan
- [x] `ng test ngx-tethys --include='**/button/test/button.spec.ts'` — 37 passed
- [x] Related dialog/form/stepper/result/tabs/calendar tests — 201 passed
- [ ] Visual check: fill/outline/link × types, especially fill default and link default (ex-link-secondary)

Closes AGENLU-29