### PR TITLE
fix(input): omit native type when thyType is null or undefined #TINFR-3994

### DIFF
--- a/src/input/input.component.html
+++ b/src/input/input.component.html
@@ -8,7 +8,7 @@
   thyInput
   [thySize]="thySize()"
   [thyAutofocus]="thyAutofocus()"
-  [type]="type()"
+  [attr.type]="type()"
   [placeholder]="thyPlaceholder()"
   [disabled]="disabled()"
   [(ngModel)]="value"

--- a/src/input/input.component.ts
+++ b/src/input/input.component.ts
@@ -71,10 +71,10 @@ export class ThyInput implements ControlValueAccessor {
     readonly thyAutofocus = input(false, { transform: coerceBooleanProperty });
 
     /**
-     * 输入框类型，对应原生 input 的 type 属性
-     * @type 'text' | 'password' | 'number' | string
+     * 输入框类型，对应原生 input 的 type 属性。未设置、null 或 undefined 时不输出 type，浏览器默认为 text
+     * @type 'text' | 'password' | 'number'
      */
-    readonly thyType = input<string>();
+    readonly thyType = input<string | null | undefined>();
 
     /**
      * 输入 Label 文本
@@ -114,7 +114,7 @@ export class ThyInput implements ControlValueAccessor {
         if (this.isPasswordType()) {
             return this.passwordVisible() ? 'text' : password;
         }
-        return this.thyType();
+        return this.thyType() ?? null;
     });
 
     public value = signal('');

--- a/src/input/test/input-component.spec.ts
+++ b/src/input/test/input-component.spec.ts
@@ -34,7 +34,7 @@ import { ThyFormControlSize } from 'ngx-tethys/core';
 })
 class TestBedComponent {
     thySize: ThyFormControlSize | undefined = 'md';
-    thyType = 'text';
+    thyType: string | null | undefined = 'text';
     readonly = false;
     passwordValue = '12345';
     checkFocus = false;
@@ -123,12 +123,31 @@ describe('input component', () => {
         expect(fixture.debugElement.query(By.css('.input2')).nativeElement.innerText.includes('后置模板')).toBe(true);
     });
 
+    it('should not set type by default', () => {
+        fixture.detectChanges();
+        const defaultInput = fixture.debugElement.query(By.css('.input2 input'));
+        expect(defaultInput.nativeElement.getAttribute('type')).toBeNull();
+    });
+
+    it('should not set type when thyType is undefined', () => {
+        basicTestComponent.thyType = undefined;
+        fixture.detectChanges();
+        expect(debugElement.nativeElement.getAttribute('type')).toBeNull();
+    });
+
+    it('should not set type when thyType is null', () => {
+        basicTestComponent.thyType = null;
+        fixture.detectChanges();
+        expect(debugElement.nativeElement.getAttribute('type')).toBeNull();
+    });
+
     it('thyType', () => {
         basicTestComponent.thyType = 'number';
         fixture.detectChanges();
         expect(debugElement.nativeElement.type).toBe('number');
         basicTestComponent.thyType = 'text';
         fixture.detectChanges();
+        expect(debugElement.nativeElement.type).toBe('text');
     });
 
     it('thyLabelText', () => {


### PR DESCRIPTION
## Summary
- `thy-input` 改为通过 `[attr.type]` 绑定原生 `type`，未传、`null`、`undefined` 时不再输出 `type` 属性，避免出现 `type="undefined"`。
- 浏览器在没有 `type` 时仍按原生默认使用 `text`；显式传入 `text` / `number` / `password` 时行为不变。

## Test plan
- [x] 不传 `thyType` 时，原生 input 没有 `type` 属性，输入表现为 text
- [x] `[thyType]="undefined"` / `[thyType]="null"` 时同样不设置 `type`
- [x] `thyType="number"`、`thyType="password"` 仍按传入值生效，密码可见性切换正常


Made with [Cursor](https://cursor.com)