### PR TITLE
feat(nav): add thyVariant instead of thyType #TINFR-3839

### DIFF
--- a/docs/guide/migration-v22.md
+++ b/docs/guide/migration-v22.md
@@ -313,12 +313,14 @@ ng generate ngx-tethys:migrate-22
 - `thyNavLink` 重命名为 `thyNavItem`
 - `thyNavLinkActive` 重命名为 `thyNavItemActive`
 - 移除 `thyInsideClosable`，改用 `thyPopoverOptions.insideClosable`
+- `thyType` 重命名为 `thyVariant`，推荐值 `pulled | tabs | pills | lite`；`primary | secondary | thirdly | secondary-divider` 已废弃
 
 **自动迁移**
 
 - `thyNavLink` → `thyNavItem`；`thyNavLinkActive` → `thyNavItemActive`
 - `thyInsideClosable` 默认 `true` 时移除属性，`false` 时写入 `[thyPopoverOptions]="{ insideClosable: false }"`
 - 若元素上**已存在** `[thyPopoverOptions]`，**不会**自动迁移，需完全手动合并（详见 **手动检查**）
+- `thyType` → `thyVariant`（仅 `thy-nav`）
 
 ---
 

--- a/schematics/ng-update/update-22/index.spec.ts
+++ b/schematics/ng-update/update-22/index.spec.ts
@@ -467,6 +467,46 @@ export class NavDemoComponent {}
         expect(content).not.toContain('thyNavLink');
     });
 
+    it('should migrate thyType to thyVariant for thy-nav', async () => {
+        const factory = createTestWorkspaceFactory(schematicRunner);
+        await factory.create();
+        await factory.addApplication({ name: 'update-22-test' });
+        const testTree = factory.addNewFile(
+            '/projects/update-22-test/src/app/nav-demo.component.ts',
+            `
+import { Component } from '@angular/core';
+import { ThyNavModule } from 'ngx-tethys/nav';
+
+@Component({
+    selector: 'app-nav-demo',
+    template: \`
+        <thy-nav thyType="pulled">
+            <a thyNavItem>Link</a>
+        </thy-nav>
+        <thy-nav [thyType]="type">
+            <a thyNavItem>Link</a>
+        </thy-nav>
+        <thy-tabs thyType="pills"></thy-tabs>
+        <thy-button thyType="primary">Ok</thy-button>
+    \`,
+    imports: [ThyNavModule]
+})
+export class NavDemoComponent {
+    type = 'tabs';
+}
+`
+        );
+
+        workspaceTree = await schematicRunner.runSchematic('migration-v22', undefined, testTree);
+        const content = workspaceTree.readContent('/projects/update-22-test/src/app/nav-demo.component.ts');
+        expect(content).toContain('thyVariant="pulled"');
+        expect(content).toContain('[thyVariant]="type"');
+        expect(content).toContain('thyType="pills"');
+        expect(content).toContain('thyType="primary"');
+        expect(content).not.toMatch(/<thy-nav[^>]*thyType/);
+        expect(content).not.toMatch(/<thy-nav[^>]*\[thyType\]/);
+    });
+
     it('should migrate thy-link to thy-anchor-link', async () => {
         const factory = createTestWorkspaceFactory(schematicRunner);
         await factory.create();

--- a/schematics/ng-update/update-22/update-data.ts
+++ b/schematics/ng-update/update-22/update-data.ts
@@ -90,6 +90,13 @@ export const upgradeData: UpgradeData = {
                         }
                     },
                     {
+                        replace: 'thyType',
+                        replaceWith: 'thyVariant',
+                        limitedTo: {
+                            elements: ['thy-nav']
+                        }
+                    },
+                    {
                         replace: 'thyShowRemove',
                         replaceWith: 'thyRemovable',
                         limitedTo: {

--- a/scripts/name-package-relation.json
+++ b/scripts/name-package-relation.json
@@ -409,6 +409,7 @@
   "ThyNavLink": "nav",
   "ThyNavLinkDirective": "nav",
   "ThyNavType": "nav",
+  "ThyNavVariant": "nav",
   "ThyNavSize": "nav",
   "ThyNavHorizontal": "nav",
   "ThyNav": "nav",

--- a/src/date-picker/lib/popups/date-popup.component.html
+++ b/src/date-picker/lib/popups/date-popup.component.html
@@ -16,7 +16,7 @@
         @if (flexible()) {
           <div class="{{ prefixCls }}-date-panel-flexible">
             <div class="{{ prefixCls }}-date-panel-flexible-tab">
-              <thy-nav thyType="pulled" thySize="sm">
+              <thy-nav thyVariant="pulled" thySize="sm">
                 <a href="javascript:;" thyNavItem [thyNavItemActive]="flexibleActiveTab === 'advanced'" (click)="selectTab('advanced')">{{
                   locale().advance
                 }}</a>

--- a/src/layout/examples/content/content.component.html
+++ b/src/layout/examples/content/content.component.html
@@ -5,7 +5,7 @@
       <div>Title</div>
     </thy-content-section>
     <thy-content-main>
-      <thy-nav thyType="secondary" class="pl-2">
+      <thy-nav thyVariant="tabs" thySize="sm" class="pl-2">
         <a href="javascript:;" thyNavItem thyNavItemActive="true">Link1</a>
         <a href="javascript:;" thyNavItem>Link2</a>
         <a href="javascript:;" thyNavItem>Link3</a>

--- a/src/layout/examples/header/header.component.html
+++ b/src/layout/examples/header/header.component.html
@@ -43,13 +43,13 @@
       <a href="javascript:;" class="title-name">Custom header<thy-icon thyIconName="angle-down"></thy-icon></a>
     </ng-template>
     <ng-template #headerContent>
-      <thy-nav thyType="pulled" thyHorizontal="center">
+      <thy-nav thyVariant="pulled" thyHorizontal="center">
         <a href="javascript:;" thyNavItem [thyNavItemActive]="'true'">Link1</a>
         <a href="javascript:;" thyNavItem>Link2</a>
       </thy-nav>
     </ng-template>
     <ng-template #headerOperation>
-      <thy-nav thyType="pulled" thyHorizontal="right">
+      <thy-nav thyVariant="pulled" thyHorizontal="right">
         <a thyNavItem href="javascript:;">
           <thy-icon [thyIconName]="'settings'"></thy-icon>
           Settings
@@ -76,7 +76,7 @@
       <thy-divider class="ml-2" thyColor="light" thyVertical="true"></thy-divider>
     </ng-template>
     <ng-template #headerContent>
-      <thy-nav thyType="pulled">
+      <thy-nav thyVariant="pulled">
         <a href="javascript:;" thyNavItem [thyNavItemActive]="'true'">Link1</a>
         <a href="javascript:;" thyNavItem>Link2</a>
       </thy-nav>

--- a/src/layout/examples/sidebar/sidebar.component.html
+++ b/src/layout/examples/sidebar/sidebar.component.html
@@ -28,7 +28,7 @@
   <thy-sidebar>
     <thy-sidebar-header thyDivided="true">
       <ng-template #headerTitle>
-        <thy-nav thyType="pulled">
+        <thy-nav thyVariant="pulled">
           <a href="javascript:;" thyNavItem [thyNavItemActive]="'true'">Link1</a>
           <a href="javascript:;" thyNavItem>Link2</a>
         </thy-nav>

--- a/src/layout/examples/subheader/subheader.component.html
+++ b/src/layout/examples/subheader/subheader.component.html
@@ -4,7 +4,7 @@
     <thy-header thyDivided="true" thySize="sm">
       <ng-template #headerTitle> </ng-template>
       <ng-template #headerContent>
-        <thy-nav thyType="pulled" thyHorizontal="left" thySize="sm">
+        <thy-nav thyVariant="pulled" thyHorizontal="left" thySize="sm">
           <a href="javascript:;" thyNavItem thyNavItemActive="true">Link1</a>
           <a href="javascript:;" thyNavItem>Link2</a>
           <a href="javascript:;" thyNavItem>Link3</a>
@@ -29,14 +29,14 @@
 <thy-layout>
   <thy-header thySize="lg" thyTitle="Header" thyDivided="true" thyIcon="house-square-fill">
     <ng-template #headerContent>
-      <thy-nav thyType="pulled" thySize="lg" thyHorizontal="center">
+      <thy-nav thyVariant="pulled" thySize="lg" thyHorizontal="center">
         <a href="javascript:;" thyNavItem thyNavItemActive="true">Link1</a>
         <a href="javascript:;" thyNavItem>Link2</a>
         <a href="javascript:;" thyNavItem>Link3</a>
       </thy-nav>
     </ng-template>
     <ng-template #headerOperation>
-      <thy-nav thyType="pulled" thySize="lg" thyHorizontal="right">
+      <thy-nav thyVariant="pulled" thySize="lg" thyHorizontal="right">
         <a thyNavItem href="javascript:;">
           <thy-icon thyIconName="settings"></thy-icon>
         </a>
@@ -60,7 +60,7 @@
         </thy-breadcrumb>
       </ng-template>
       <ng-template #headerOperation>
-        <thy-nav thyType="thirdly" thyHorizontal="right">
+        <thy-nav thyVariant="thirdly" thyHorizontal="right">
           <a thyNavItem href="javascript:;">
             <thy-icon [thyIconName]="'edit'"></thy-icon>
             Edit

--- a/src/nav/examples/basic/basic.component.html
+++ b/src/nav/examples/basic/basic.component.html
@@ -1,12 +1,7 @@
-<thy-nav thyType="pulled">
-  @for (item of navList; track $index) {
-    <a
-      href="javascript:;"
-      thyNavItem
-      [thyNavItemActive]="item.index === activeIndex"
-      [thyNavItemDisabled]="item.disabled"
-      (click)="activeIndex = item.index"
-      >{{ item.name }}</a
-    >
-  }
+<thy-nav>
+  <a href="javascript:;" thyNavItem thyNavItemActive="true">Item 1</a>
+  <a href="javascript:;" thyNavItem>Item 2</a>
+  <a href="javascript:;" thyNavItem>Item 3</a>
+  <a href="javascript:;" thyNavItem>Item 4</a>
+  <a href="javascript:;" thyNavItem>Item 5</a>
 </thy-nav>

--- a/src/nav/examples/basic/basic.component.ts
+++ b/src/nav/examples/basic/basic.component.ts
@@ -9,16 +9,6 @@ import { ThyNav, ThyNavItemDirective } from 'ngx-tethys/nav';
     imports: [ThyNav, ThyNavItemDirective]
 })
 export class ThyNavBasicExampleComponent implements OnInit {
-    public activeIndex = 0;
-
-    public navList = [
-        { index: 0, name: 'Item 1', disabled: false },
-        { index: 1, name: 'Item 2', disabled: false },
-        { index: 2, name: 'Item 3', disabled: false },
-        { index: 3, name: 'Item 4', disabled: true },
-        { index: 4, name: 'Item 5', disabled: false }
-    ];
-
     constructor() {}
 
     ngOnInit(): void {}

--- a/src/nav/examples/extra/extra.component.ts
+++ b/src/nav/examples/extra/extra.component.ts
@@ -1,12 +1,13 @@
 import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
 import { ThyNav, ThyNavItemDirective } from 'ngx-tethys/nav';
+import { ThyAction } from 'ngx-tethys/action';
 
 @Component({
     selector: 'thy-nav-extra-example',
     templateUrl: './extra.component.html',
     styleUrls: ['./extra.component.scss'],
     changeDetection: ChangeDetectionStrategy.Eager,
-    imports: [ThyNav, ThyNavItemDirective]
+    imports: [ThyNav, ThyNavItemDirective, ThyAction]
 })
 export class ThyNavExtraExampleComponent implements OnInit {
     activeIndex = 1;

--- a/src/nav/examples/fill/fill.component.html
+++ b/src/nav/examples/fill/fill.component.html
@@ -1,4 +1,4 @@
-<thy-nav thyType="pulled" thyFill="true">
+<thy-nav thyVariant="pulled" thyFill="true">
   <a href="javascript:;" thyNavItem thyNavItemActive="true">Item 1</a>
   <a href="javascript:;" thyNavItem>Item 2</a>
   <a href="javascript:;" thyNavItem>Item 3</a>

--- a/src/nav/examples/horizontal/horizontal.component.html
+++ b/src/nav/examples/horizontal/horizontal.component.html
@@ -1,18 +1,18 @@
 <thy-card>
   <thy-card-content>
-    <thy-nav thyType="pulled">
+    <thy-nav thyVariant="pulled">
       <a href="javascript:;" thyNavItem thyNavItemActive="true">导航一</a>
       <a href="javascript:;" thyNavItem>导航二</a>
       <a href="javascript:;" thyNavItem>导航三</a>
     </thy-nav>
 
-    <thy-nav thyType="pulled" thyHorizontal="center">
+    <thy-nav thyVariant="pulled" thyHorizontal="center">
       <a href="javascript:;" thyNavItem thyNavItemActive="true">导航一</a>
       <a href="javascript:;" thyNavItem>导航二</a>
       <a href="javascript:;" thyNavItem>导航三</a>
     </thy-nav>
 
-    <thy-nav thyType="pulled" thyHorizontal="end">
+    <thy-nav thyVariant="pulled" thyHorizontal="end">
       <a href="javascript:;" thyNavItem thyNavItemActive="true">导航一</a>
       <a href="javascript:;" thyNavItem>导航二</a>
       <a href="javascript:;" thyNavItem>导航三</a>

--- a/src/nav/examples/lite/index.md
+++ b/src/nav/examples/lite/index.md
@@ -1,5 +1,5 @@
 ---
 order: 21
-title: 精简模式
+title: Lite
 className: bg-example
 ---

--- a/src/nav/examples/lite/lite.component.html
+++ b/src/nav/examples/lite/lite.component.html
@@ -1,4 +1,4 @@
-<thy-nav thyType="lite">
+<thy-nav thyVariant="lite">
   <a href="javascript:;" thyNavItem thyNavItemActive="true">Item 1</a>
   <a href="javascript:;" thyNavItem>Item 2</a>
   <a href="javascript:;" thyNavItem>Item 3</a>

--- a/src/nav/examples/pills/index.md
+++ b/src/nav/examples/pills/index.md
@@ -1,5 +1,5 @@
 ---
 order: 22
-title: Pills 模式
+title: Pills
 className: bg-example
 ---

--- a/src/nav/examples/pills/pills.component.html
+++ b/src/nav/examples/pills/pills.component.html
@@ -1,4 +1,4 @@
-<thy-nav thyType="pills">
+<thy-nav thyVariant="pills">
   <a href="javascript:;" thyNavItem thyNavItemActive="true">Item 1</a>
   <a href="javascript:;" thyNavItem>Item 2</a>
   <a href="javascript:;" thyNavItem>Item 3</a>

--- a/src/nav/examples/pulled/index.md
+++ b/src/nav/examples/pulled/index.md
@@ -1,5 +1,5 @@
 ---
-order: 23
-title: Card
+order: 15
+title: Pulled
 className: bg-example
 ---

--- a/src/nav/examples/pulled/pulled.component.html
+++ b/src/nav/examples/pulled/pulled.component.html
@@ -1,5 +1,5 @@
-<thy-nav thyVariant="card">
-  @for (item of items; track $index) {
+<thy-nav thyVariant="pulled">
+  @for (item of navList; track $index) {
     <a
       href="javascript:;"
       thyNavItem

--- a/src/nav/examples/pulled/pulled.component.scss
+++ b/src/nav/examples/pulled/pulled.component.scss
@@ -1,0 +1,6 @@
+@use 'variables.scss' as variables2;
+
+:host {
+    display: block;
+    background: variables2.$bg-default;
+}

--- a/src/nav/examples/pulled/pulled.component.ts
+++ b/src/nav/examples/pulled/pulled.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { ThyNav, ThyNavItemDirective } from 'ngx-tethys/nav';
+
+@Component({
+    selector: 'thy-nav-pulled-example',
+    templateUrl: './pulled.component.html',
+    styleUrls: ['./pulled.component.scss'],
+    changeDetection: ChangeDetectionStrategy.Eager,
+    imports: [ThyNav, ThyNavItemDirective]
+})
+export class ThyNavPulledExampleComponent implements OnInit {
+    public activeIndex = 0;
+
+    public navList = [
+        { index: 0, name: 'Item 1', disabled: false },
+        { index: 1, name: 'Item 2', disabled: false },
+        { index: 2, name: 'Item 3', disabled: false },
+        { index: 3, name: 'Item 4', disabled: true },
+        { index: 4, name: 'Item 5', disabled: false }
+    ];
+
+    constructor() {}
+
+    ngOnInit(): void {}
+}

--- a/src/nav/examples/responsive/responsive.component.html
+++ b/src/nav/examples/responsive/responsive.component.html
@@ -1,5 +1,5 @@
 <div class="p-3">
-  <thy-nav thyType="pulled" [thyResponsive]="true" class="responsive-nav">
+  <thy-nav thyVariant="pulled" [thyResponsive]="true" class="responsive-nav">
     @for (item of navList; track $index) {
       <a
         class="nav-tab"
@@ -15,7 +15,7 @@
   </thy-nav>
   <br />
 
-  <thy-nav thyType="tabs" [thyResponsive]="true" class="responsive-nav">
+  <thy-nav thyVariant="tabs" [thyResponsive]="true" class="responsive-nav">
     @for (item of navList; track $index) {
       <a
         class="nav-tab"
@@ -43,7 +43,7 @@
   <br />
 
   <div class="py-2 bg-default">
-    <thy-nav thyType="pills" [thyResponsive]="true" class="responsive-nav">
+    <thy-nav thyVariant="pills" [thyResponsive]="true" class="responsive-nav">
       @for (item of navList; track $index) {
         <a
           class="nav-tab"

--- a/src/nav/examples/size/size.component.html
+++ b/src/nav/examples/size/size.component.html
@@ -7,35 +7,35 @@
 </thy-button-group>
 
 <div class="bg-example">
-  <thy-nav [thySize]="size.value" thyType="pulled">
+  <thy-nav [thySize]="size.value" thyVariant="pulled">
     <a href="javascript:;" thyNavItem thyNavItemActive="true">Item 1</a>
     <a href="javascript:;" thyNavItem>Item 2</a>
     <a href="javascript:;" thyNavItem>Item 3</a>
     <a href="javascript:;" thyNavItem>Item 4</a>
   </thy-nav>
 
-  <thy-nav [thySize]="size.value" thyType="tabs">
+  <thy-nav [thySize]="size.value" thyVariant="tabs">
     <a href="javascript:;" thyNavItem thyNavItemActive="true">Item 1</a>
     <a href="javascript:;" thyNavItem>Item 2</a>
     <a href="javascript:;" thyNavItem>Item 3</a>
     <a href="javascript:;" thyNavItem>Item 4</a>
   </thy-nav>
 
-  <thy-nav [thySize]="size.value" thyType="lite">
+  <thy-nav [thySize]="size.value" thyVariant="lite">
     <a href="javascript:;" thyNavItem thyNavItemActive="true">Item 1</a>
     <a href="javascript:;" thyNavItem>Item 2</a>
     <a href="javascript:;" thyNavItem>Item 3</a>
     <a href="javascript:;" thyNavItem>Item 4</a>
   </thy-nav>
 
-  <thy-nav [thySize]="size.value" thyType="pills">
+  <thy-nav [thySize]="size.value" thyVariant="pills">
     <a href="javascript:;" thyNavItem thyNavItemActive="true">Item 1</a>
     <a href="javascript:;" thyNavItem>Item 2</a>
     <a href="javascript:;" thyNavItem>Item 3</a>
     <a href="javascript:;" thyNavItem>Item 4</a>
   </thy-nav>
 
-  <thy-nav [thySize]="size.value" thyType="card">
+  <thy-nav [thySize]="size.value" thyVariant="card">
     <a href="javascript:;" thyNavItem thyNavItemActive="true">Item 1</a>
     <a href="javascript:;" thyNavItem>Item 2</a>
     <a href="javascript:;" thyNavItem>Item 3</a>

--- a/src/nav/examples/tabs/tabs.component.html
+++ b/src/nav/examples/tabs/tabs.component.html
@@ -1,4 +1,4 @@
-<thy-nav thyType="tabs">
+<thy-nav thyVariant="tabs">
   @for (item of navList; track $index) {
     <a
       href="javascript:;"

--- a/src/nav/examples/vertical/vertical.component.html
+++ b/src/nav/examples/vertical/vertical.component.html
@@ -1,4 +1,4 @@
-<thy-nav thyType="pulled" thyVertical="true">
+<thy-nav thyVariant="pulled" thyVertical="true">
   @for (item of navList; track $index) {
     <a href="javascript:;" thyNavItem [thyNavItemActive]="item.index === activeIndex" (click)="activeIndex = item.index">{{ item.name }}</a>
   }

--- a/src/nav/nav.component.ts
+++ b/src/nav/nav.component.ts
@@ -35,17 +35,18 @@ import { ThyNavInkBarDirective } from './nav-ink-bar.directive';
 import { ThyNavItemDirective } from './nav-item.directive';
 import { BypassSecurityTrustHtmlPipe } from './nav.pipe';
 
-export type ThyNavType = 'pulled' | 'tabs' | 'pills' | 'lite' | 'card' | 'primary' | 'secondary' | 'thirdly' | 'secondary-divider';
+export type ThyNavVariant = 'pulled' | 'tabs' | 'pills' | 'lite' | 'card' | 'primary' | 'secondary' | 'thirdly' | 'secondary-divider';
+export type ThyNavType = ThyNavVariant;
 export type ThyNavSize = 'lg' | 'md' | 'sm';
 export type ThyNavHorizontal = '' | 'start' | 'center' | 'end';
 
-const navTypeClassesMap = {
+const navVariantClassesMap: Record<ThyNavVariant, string[]> = {
     pulled: ['thy-nav-pulled'],
     tabs: ['thy-nav-tabs'],
     pills: ['thy-nav-pills'],
     lite: ['thy-nav-lite'],
     card: ['thy-nav-card'],
-    //如下类型已经废弃
+    // 如下类型已经废弃
     primary: ['thy-nav-primary'],
     secondary: ['thy-nav-secondary'],
     thirdly: ['thy-nav-thirdly'],
@@ -118,8 +119,16 @@ export class ThyNav implements OnDestroy {
     private readonly moreBtnOffset: WritableSignal<{ height: number; width: number }> = signal({ height: 0, width: 0 });
 
     /**
-     * 导航类型
-     * @type pulled | tabs | pills | lite | primary | secondary | thirdly | secondary-divider
+     * 导航形态
+     * @type pulled | tabs | pills | lite | card
+     * @default pulled
+     */
+    readonly thyVariant = input<ThyNavVariant>();
+
+    /**
+     * 导航类型（已废弃），请使用 thyVariant
+     * @deprecated please use thyVariant
+     * @type ThyNavVariant
      * @default pulled
      */
     readonly thyType = input<ThyNavType>();
@@ -210,17 +219,17 @@ export class ThyNav implements OnDestroy {
         return horizontalValue === 'right' ? 'end' : horizontalValue;
     });
 
-    readonly type = computed(() => this.thyType() || 'pulled');
+    readonly variant = computed(() => this.thyVariant() || this.thyType() || 'pulled');
 
     readonly showInkBar = computed(() => {
-        const showTypes: ThyNavType[] = ['pulled', 'tabs'];
-        return showTypes.includes(this.type());
+        const showVariants: ThyNavVariant[] = ['pulled', 'tabs'];
+        return showVariants.includes(this.variant());
     });
 
     private updateClasses() {
         let classNames: string[] = [];
-        if (navTypeClassesMap[this.type()]) {
-            classNames = [...navTypeClassesMap[this.type()]];
+        if (navVariantClassesMap[this.variant()]) {
+            classNames = [...navVariantClassesMap[this.variant()]];
         }
         if (navSizeClassesMap[this.thySize()]) {
             classNames.push(navSizeClassesMap[this.thySize()]);
@@ -246,8 +255,8 @@ export class ThyNav implements OnDestroy {
         });
 
         effect(() => {
-            const thyVertical = this.thyVertical();
-            const thyType = this.thyType();
+            this.thyVertical();
+            this.variant();
 
             untracked(() => {
                 this.alignInkBarToSelectedTab();
@@ -288,7 +297,7 @@ export class ThyNav implements OnDestroy {
                                 this.setHiddenItems();
                             }
 
-                            if (this.type() === 'card') {
+                            if (this.variant() === 'card') {
                                 this.setNavItemDivider();
                             }
                         })

--- a/src/nav/test/nav-ink-bar.directive.spec.ts
+++ b/src/nav/test/nav-ink-bar.directive.spec.ts
@@ -14,7 +14,7 @@ import { ThyNavInkBarDirective } from '../nav-ink-bar.directive';
 @Component({
     selector: 'app-nav-ink-bar',
     template: `
-        <thy-nav [thyType]="type" [thyVertical]="isVertical" [thyResponsive]="responsive">
+        <thy-nav [thyVariant]="type" [thyVertical]="isVertical" [thyResponsive]="responsive">
             @for (item of navLinks; track $index; let i = $index) {
                 <a thyNavItem [thyNavItemActive]="activeName === item.name" (click)="activeName = item.name">{{ item.name }}</a>
             }
@@ -93,7 +93,7 @@ const routes: Routes = [
     selector: 'app-nav-router-link-active-mode',
     template: `
         <div style="width: 400px;height: 50px;">
-            <thy-nav [thyType]="type" [thySize]="size">
+            <thy-nav [thyVariant]="type" [thySize]="size">
                 @for (item of navLinks; track $index) {
                     <a thyNavItem [routerLink]="[item.name]" routerLinkActive="active"
                         >{{ item.name }}
@@ -128,7 +128,7 @@ export class NavInkBarRouterLinkActiveModeComponent implements OnInit {
     selector: 'app-nav-have-badge-mode',
     template: `
         <div style="width: 400px;">
-            <thy-nav [thyType]="type" [thySize]="size">
+            <thy-nav [thyVariant]="type" [thySize]="size">
                 @for (item of navLinks; track item) {
                     <a thyNavItem [thyNavItemActive]="item.name === activeName"
                         >{{ item.name }}

--- a/src/nav/test/nav.component.spec.ts
+++ b/src/nav/test/nav.component.spec.ts
@@ -18,7 +18,7 @@ const NAV_LINK_CLASS = `thy-nav-item`;
     selector: 'app-nav-basic',
     template: `
         <thy-nav
-            [thyType]="type"
+            [thyVariant]="type"
             [thySize]="size"
             [thyFill]="isFill"
             [thyVertical]="isVertical"
@@ -53,10 +53,20 @@ export class NavBasicComponent implements OnInit {
 }
 
 @Component({
+    selector: 'app-nav-legacy-type',
+    template: ` <thy-nav [thyType]="type"></thy-nav> `,
+    changeDetection: ChangeDetectionStrategy.Eager,
+    imports: [ThyNavModule]
+})
+export class NavLegacyTypeComponent {
+    type: ThyNavType = 'tabs';
+}
+
+@Component({
     selector: 'app-nav-basic',
     template: `
         <thy-nav
-            [thyType]="type"
+            [thyVariant]="type"
             [thySize]="size"
             [thyFill]="isFill"
             [thyVertical]="isVertical"
@@ -188,12 +198,25 @@ describe(`thy-nav`, () => {
             expect(disabledLink.classList.contains('disabled')).toEqual(true);
         });
 
-        it(`should get correct class when input type`, () => {
+        it(`should get correct class when input thyVariant`, () => {
             ['pulled', 'pills', 'tabs', 'card', 'lite', 'primary', 'secondary', 'thirdly', 'secondary-divider'].forEach(type => {
                 fixture.debugElement.componentInstance.type = type;
                 fixture.detectChanges();
                 expect(navElement.classList.contains(NAV_CLASS)).toEqual(true);
                 expect(navElement.classList.contains(`thy-nav-${type}`)).toEqual(true);
+            });
+        });
+
+        it(`should get correct class when input deprecated thyType`, () => {
+            const legacyFixture = TestBed.createComponent(NavLegacyTypeComponent);
+            legacyFixture.detectChanges();
+            const element: HTMLElement = legacyFixture.debugElement.query(By.directive(ThyNav)).nativeElement;
+            expect(element.classList.contains('thy-nav-tabs')).toEqual(true);
+
+            ['pulled', 'pills', 'lite', 'primary', 'secondary', 'thirdly', 'secondary-divider'].forEach(type => {
+                legacyFixture.componentInstance.type = type as ThyNavType;
+                legacyFixture.detectChanges();
+                expect(element.classList.contains(`thy-nav-${type}`)).toEqual(true);
             });
         });
 

--- a/src/tabs/examples/card/index.md
+++ b/src/tabs/examples/card/index.md
@@ -1,4 +1,4 @@
 ---
-title: 卡片模式
+title: Card
 order: 13
 ---

--- a/src/tabs/examples/lite/index.md
+++ b/src/tabs/examples/lite/index.md
@@ -1,4 +1,4 @@
 ---
-title: 精简模式
+title: Lite
 order: 11
 ---

--- a/src/tabs/examples/pills/index.md
+++ b/src/tabs/examples/pills/index.md
@@ -1,4 +1,4 @@
 ---
-title: Pills 模式
+title: Pills
 order: 12
 ---

--- a/src/tabs/tabs.component.html
+++ b/src/tabs/tabs.component.html
@@ -1,7 +1,7 @@
 <!-- tabs nav -->
 <thy-nav
   class="thy-tabs-nav"
-  [thyType]="thyType()"
+  [thyVariant]="thyType()"
   [thySize]="thySize()"
   [thyExtra]="thyExtra()"
   [thyVertical]="thyPosition() === 'left'"


### PR DESCRIPTION
## Summary
- `thy-nav` 新增 `thyVariant`，`thyType` 标记为废弃并保持兼容
- 文档推荐值改为 `pulled | tabs | pills | lite | card`，废弃 `primary | secondary | thirdly | secondary-divider`
- 补充 v22 schematic 自动迁移 `thy-nav` 的 `thyType` → `thyVariant`，并新增 Pulled 示例、简化 Basic 示例

## Test plan
- [ ] 使用 `thyVariant="pulled|tabs|pills|lite|card"` 验证样式与 ink-bar
- [ ] 确认旧 `thyType` 仍可生效
- [ ] 确认 `ng update ngx-tethys` / `ng generate ngx-tethys:migrate-22` 会把 `thy-nav` 的 `thyType` 改为 `thyVariant`，且不影响 `thy-tabs` / `thy-button`
- [ ] 检查 Nav 文档示例：Basic 为写死 5 项，Pulled 为循环列表


Made with [Cursor](https://cursor.com)